### PR TITLE
Fix alias bug

### DIFF
--- a/pyqasm/visitor.py
+++ b/pyqasm/visitor.py
@@ -325,7 +325,7 @@ class BasicQasmVisitor:
         openqasm_bits = []
         visited_bits = set()
         bit_list = []
-        replace_alias = False
+        original_size_map = reg_size_map
 
         if isinstance(operation, qasm3_ast.QuantumMeasurementStatement):
             assert operation.target is not None
@@ -336,6 +336,9 @@ class BasicQasmVisitor:
             )
 
         for bit in bit_list:
+            # required for each bit
+            replace_alias = False
+            reg_size_map = original_size_map
             if isinstance(bit, qasm3_ast.IndexedIdentifier):
                 reg_name = bit.name.name
             else:


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the qBraid-QIR CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

## Summary of changes
- Aliased bits can be used in combination with global qubits. Eg - 

```C
    OPENQASM 3;
    include "stdgates.inc";
    qubit[4] q;
    bit[4] c;

    let alias = q[0:2];

    h q;
    measure q -> c;

    if(c[1] == 1){
        cx alias[1], q[2];
    }
```
- The semantic check currently raises the error -
```bash
pyqasm.exceptions.ValidationError: Missing register declaration for q in operation QuantumGate ...
```
- Reason is that while getting the bits of `cx alias[1], q[2];` we force alias replacement for all bits. This is an incorrect assumption as `q[2]` is a not an aliased bit.