### PR TITLE
Make default return type of `pyqasm.unroll` as str

### DIFF
--- a/examples/unroll_example.py
+++ b/examples/unroll_example.py
@@ -53,4 +53,4 @@ bit[4] result;
 measure q -> result;
 """
 
-print(unroll(example_qasm_program).unrolled_qasm)
+print(unroll(example_qasm_program))

--- a/pyqasm/unroller.py
+++ b/pyqasm/unroller.py
@@ -23,6 +23,7 @@ from .visitor import BasicQasmVisitor
 
 def unroll(
     program: Union[openqasm3.ast.Program, str],
+    as_module: bool = False,
     **kwargs,
 ) -> Qasm3Module:
     """Converts an OpenQASM 3 program to an unrolled qasm program
@@ -52,4 +53,7 @@ def unroll(
     visitor = BasicQasmVisitor(module=module, **kwargs)
     module.accept(visitor)
 
-    return module
+    if as_module:
+        return module
+
+    return module.unrolled_qasm

--- a/tests/declarations/test_classical.py
+++ b/tests/declarations/test_classical.py
@@ -104,7 +104,7 @@ def test_scalar_value_assignment():
     b = 5.0
     r = 0.23
     f = 0.5
-    result = unroll(qasm3_string)
+    result = unroll(qasm3_string, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 1
 
@@ -136,7 +136,7 @@ def test_scalar_type_casts():
     f = 0
     g = 1
 
-    result = unroll(qasm3_string)
+    result = unroll(qasm3_string, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 1
 
@@ -165,7 +165,7 @@ def test_array_type_casts():
     arr_bool_val = 1
     arr_float32_val = 6.0
 
-    result = unroll(qasm3_string)
+    result = unroll(qasm3_string, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 1
 
@@ -241,7 +241,7 @@ def test_array_assignments():
     c = 4.5
     d = 6.7
     f = True
-    result = unroll(qasm3_string)
+    result = unroll(qasm3_string, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 1
     check_single_qubit_rotation_op(
@@ -284,7 +284,7 @@ def test_array_expressions():
     b = 3
     c = 4.5
     d = 6.7
-    result = unroll(qasm3_string)
+    result = unroll(qasm3_string, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 1
     check_single_qubit_rotation_op(
@@ -313,7 +313,7 @@ def test_array_initializations():
     rx(arr_bool[0][1]) q;
     """
 
-    result = unroll(qasm3_string)
+    result = unroll(qasm3_string, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 1
 
@@ -344,7 +344,7 @@ def test_array_range_assignment():
 
     """
 
-    result = unroll(qasm3_string)
+    result = unroll(qasm3_string, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 1
 

--- a/tests/declarations/test_quantum.py
+++ b/tests/declarations/test_quantum.py
@@ -45,7 +45,7 @@ def test_qubit_declarations():
     qubit[10] q5;
     """
 
-    unrolled_qasm = unroll(qasm3_string).unrolled_qasm
+    unrolled_qasm = unroll(qasm3_string)
     check_unrolled_qasm(unrolled_qasm, expected_qasm)
 
 
@@ -73,7 +73,7 @@ def test_clbit_declarations():
     bit[10] c5;
     """
 
-    unrolled_qasm = unroll(qasm3_string).unrolled_qasm
+    unrolled_qasm = unroll(qasm3_string)
     check_unrolled_qasm(unrolled_qasm, expected_qasm)
 
 
@@ -109,7 +109,7 @@ def test_qubit_clbit_declarations():
     bit[1] c4;
     """
 
-    unrolled_qasm = unroll(qasm3_string).unrolled_qasm
+    unrolled_qasm = unroll(qasm3_string)
     check_unrolled_qasm(unrolled_qasm, expected_qasm)
 
 

--- a/tests/subroutines/test_subroutines.py
+++ b/tests/subroutines/test_subroutines.py
@@ -34,7 +34,7 @@ def test_function_declaration():
     my_function(q);
     """
 
-    result = unroll(qasm_str)
+    result = unroll(qasm_str, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 1
 
@@ -57,7 +57,7 @@ def test_simple_function_call():
     my_function(q, r);
     """
 
-    result = unroll(qasm_str)
+    result = unroll(qasm_str, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 1
 
@@ -78,7 +78,7 @@ def test_const_visible_in_function_call():
     my_function(q);
     """
 
-    result = unroll(qasm_str)
+    result = unroll(qasm_str, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 1
 
@@ -100,7 +100,7 @@ def test_update_variable_in_function():
     my_function(q);
     """
 
-    result = unroll(qasm_str)
+    result = unroll(qasm_str, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 1
 
@@ -122,7 +122,7 @@ def test_function_call_in_expression():
     bool b = my_function(q);
     """
 
-    result = unroll(qasm_str)
+    result = unroll(qasm_str, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 4
 
@@ -153,7 +153,7 @@ def test_classical_quantum_function():
     if(new_var>2)
         h q[0];
     """
-    result = unroll(qasm_str)
+    result = unroll(qasm_str, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 4
 
@@ -177,7 +177,7 @@ def test_multiple_function_calls():
     my_function(0, q[0]);
     """
 
-    result = unroll(qasm_str)
+    result = unroll(qasm_str, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 3
 
@@ -198,7 +198,7 @@ def test_function_call_with_return():
     float[32] r = my_function(q);
     """
 
-    result = unroll(qasm_str)
+    result = unroll(qasm_str, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 1
 
@@ -227,7 +227,7 @@ def test_return_values_from_function():
 
     """
 
-    result = unroll(qasm_str)
+    result = unroll(qasm_str, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 2
 
@@ -255,7 +255,7 @@ def test_function_call_with_custom_gate():
     my_function(q, r);
     """
 
-    result = unroll(qasm_str)
+    result = unroll(qasm_str, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 1
 
@@ -281,7 +281,7 @@ def test_function_call_from_within_fn():
     my_function_2(q);
     """
 
-    result = unroll(qasm_str)
+    result = unroll(qasm_str, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 2
 

--- a/tests/subroutines/test_subroutines_arrays.py
+++ b/tests/subroutines/test_subroutines_arrays.py
@@ -37,7 +37,7 @@ def test_simple_function_call():
 
     """
 
-    result = unroll(qasm_str)
+    result = unroll(qasm_str, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 1
 
@@ -60,7 +60,7 @@ def test_passing_array_to_function():
     my_function(arr, my_q);
     """
 
-    result = unroll(qasm_str)
+    result = unroll(qasm_str, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 1
 
@@ -87,7 +87,7 @@ def test_passing_subarray_to_function():
 
     """
 
-    result = unroll(qasm_str)
+    result = unroll(qasm_str, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 1
 
@@ -111,7 +111,7 @@ def test_passing_array_with_dim_identifier():
     my_function(arr[0, :, :], my_q);
     """
 
-    result = unroll(qasm_str)
+    result = unroll(qasm_str, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 1
 
@@ -141,7 +141,7 @@ def test_pass_multiple_arrays_to_function():
     my_function(arr_1, arr_2, my_q);
     """
 
-    result = unroll(qasm_str)
+    result = unroll(qasm_str, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 1
 

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -55,7 +55,7 @@ def test_alias():
     swap myqreg5[0], myqreg5[1];
     cz myqreg6;
     """
-    result = unroll(qasm3_alias_program)
+    result = unroll(qasm3_alias_program, as_module=True)
     assert result.num_qubits == 5
     assert result.num_clbits == 0
     check_single_qubit_gate_op(result.unrolled_ast, 1, [0], "x")
@@ -80,36 +80,36 @@ def test_alias_update():
 
     x alias[1];
     """
-    result = unroll(qasm3_alias_program)
+    result = unroll(qasm3_alias_program, as_module=True)
     assert result.num_qubits == 4
     assert result.num_clbits == 0
     check_single_qubit_gate_op(result.unrolled_ast, 1, [3], "x")
 
 
-# def test_valid_alias_redefinition():
-#     """Test converting OpenQASM 3 program with redefined alias in scope."""
+def test_valid_alias_redefinition():
+    """Test converting OpenQASM 3 program with redefined alias in scope."""
 
-#     qasm3_alias_program = """
-#     OPENQASM 3.0;
-#     include "stdgates.inc";
+    qasm3_alias_program = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
 
-#     qubit[5] q;
-#     bit[5] c;
-#     h q;
-#     measure q -> c;
+    qubit[5] q;
+    bit[5] c;
+    h q;
+    measure q -> c;
 
-#     if (c[0] == 1) {
-#         float[32] alias = 4.3;
-#     }
-#     // valid alias
-#     let alias = q[2];
-#     x alias;
-#     """
-#     result = unroll(qasm3_alias_program)
-#     assert result.num_qubits == 5
-#     assert result.num_clbits == 5
+    if (c[0] == 1) {
+        float[32] alias = 4.3;
+    }
+    // valid alias
+    let alias = q[2];
+    x alias;
+    """
+    result = unroll(qasm3_alias_program, as_module=True)
+    assert result.num_qubits == 5
+    assert result.num_clbits == 5
 
-#     check_single_qubit_gate_op(result.unrolled_ast, 1, [2], "x")
+    check_single_qubit_gate_op(result.unrolled_ast, 1, [2], "x")
 
 
 def test_alias_wrong_indexing():

--- a/tests/test_barrier.py
+++ b/tests/test_barrier.py
@@ -22,7 +22,7 @@ from tests.utils import check_unrolled_qasm
 
 # 1. Test barrier operations in different ways
 def test_barrier():
-    qasm3_string = """
+    qasm_str = """
     OPENQASM 3;
     include "stdgates.inc";
 
@@ -61,7 +61,7 @@ def test_barrier():
     barrier q2[1];
     barrier q3[0];
     """
-    unrolled_qasm = unroll(qasm3_string).unrolled_qasm
+    unrolled_qasm = unroll(qasm_str)
     check_unrolled_qasm(unrolled_qasm, expected_qasm)
 
 
@@ -86,7 +86,7 @@ def test_barrier_in_function():
     barrier q[2];
     barrier q[3];
     """
-    unrolled_qasm = unroll(qasm_str).unrolled_qasm
+    unrolled_qasm = unroll(qasm_str)
     check_unrolled_qasm(unrolled_qasm, expected_qasm)
 
 

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -38,7 +38,7 @@ def test_correct_expressions():
     c[1] = c[0] + 2;
     """
 
-    result = unroll(qasm_str)
+    result = unroll(qasm_str, as_module=True)
     assert result.num_qubits == 1
     assert result.num_clbits == 0
     rx_expression_values = [1.57, -1.57, 0]

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -43,7 +43,7 @@ def test_single_qubit_qasm3_gates(circuit_name, request):
     gate_name = circuit_name.removeprefix("Fixture_")
 
     qasm3_string = request.getfixturevalue(circuit_name)
-    result = unroll(qasm3_string)
+    result = unroll(qasm3_string, as_module=True)
     assert result.num_qubits == 2
     assert result.num_clbits == 0
     check_single_qubit_gate_op(result.unrolled_ast, 5, qubit_list, gate_name)
@@ -55,7 +55,7 @@ def test_two_qubit_qasm3_gates(circuit_name, request):
     gate_name = circuit_name.removeprefix("Fixture_")
 
     qasm3_string = request.getfixturevalue(circuit_name)
-    result = unroll(qasm3_string)
+    result = unroll(qasm3_string, as_module=True)
     assert result.num_qubits == 2
     assert result.num_clbits == 0
     check_two_qubit_gate_op(result.unrolled_ast, 2, qubit_list, gate_name)
@@ -68,7 +68,7 @@ def test_rotation_qasm3_gates(circuit_name, request):
     gate_name = circuit_name.removeprefix("Fixture_")
 
     qasm3_string = request.getfixturevalue(circuit_name)
-    result = unroll(qasm3_string)
+    result = unroll(qasm3_string, as_module=True)
     assert result.num_qubits == 2
     assert result.num_clbits == 0
     check_single_qubit_rotation_op(result.unrolled_ast, 3, qubit_list, param_list, gate_name)
@@ -80,14 +80,14 @@ def test_three_qubit_qasm3_gates(circuit_name, request):
     gate_name = circuit_name.removeprefix("Fixture_")
 
     qasm3_string = request.getfixturevalue(circuit_name)
-    result = unroll(qasm3_string)
+    result = unroll(qasm3_string, as_module=True)
     assert result.num_qubits == 3
     assert result.num_clbits == 0
     check_three_qubit_gate_op(result.unrolled_ast, 2, qubit_list, gate_name)
 
 
 def test_gate_body_param_expression():
-    qasm3_str = """
+    qasm3_string = """
     OPENQASM 3;
     include "stdgates.inc";
 
@@ -109,7 +109,7 @@ def test_gate_body_param_expression():
     bool o = true;
     my_gate(m, n, o) q;
     """
-    result = unroll(qasm3_str)
+    result = unroll(qasm3_string, as_module=True)
     assert result.num_qubits == 1
     assert result.num_clbits == 0
 
@@ -126,7 +126,7 @@ def test_qasm_u3_gates():
     qubit[2] q1;
     u3(0.5, 0.5, 0.5) q1[0];
     """
-    result = unroll(qasm3_string)
+    result = unroll(qasm3_string, as_module=True)
     assert result.num_qubits == 2
     assert result.num_clbits == 0
     check_single_qubit_rotation_op(result.unrolled_ast, 1, [0], [0.5, 0.5, 0.5], "u3")
@@ -140,7 +140,7 @@ def test_qasm_u2_gates():
     qubit[2] q1;
     u2(0.5, 0.5) q1[0];
     """
-    result = unroll(qasm3_string)
+    result = unroll(qasm3_string, as_module=True)
     assert result.num_qubits == 2
     assert result.num_clbits == 0
     check_single_qubit_rotation_op(result.unrolled_ast, 1, [0], [0.5, 0.5], "u2")
@@ -157,7 +157,7 @@ def test_incorrect_single_qubit_gates(test_name):
 def test_custom_ops(test_name, request):
     qasm3_string = request.getfixturevalue(test_name)
     gate_type = test_name.removeprefix("Fixture_")
-    result = unroll(qasm3_string)
+    result = unroll(qasm3_string, as_module=True)
 
     assert result.num_qubits == 2
     assert result.num_clbits == 0
@@ -174,7 +174,7 @@ def test_pow_gate_modifier():
     inv @ pow(2) @ pow(4) @ h q;
     pow(-2) @ h q;
     """
-    result = unroll(qasm3_string)
+    result = unroll(qasm3_string, as_module=True)
     assert result.num_qubits == 1
     assert result.num_clbits == 0
     check_single_qubit_gate_op(result.unrolled_ast, 10, [0] * 10, "h")
@@ -194,7 +194,7 @@ def test_inv_gate_modifier():
     inv @ cx q2;
     inv @ ccx q[0], q2;
     """
-    result = unroll(qasm3_string)
+    result = unroll(qasm3_string, as_module=True)
     print(result.unrolled_qasm)
     assert result.num_qubits == 3
     assert result.num_clbits == 0
@@ -207,7 +207,7 @@ def test_inv_gate_modifier():
 
 
 def test_nested_gate_modifiers():
-    qasm_str = """
+    qasm3_string = """
     OPENQASM 3;
     include "stdgates.inc";
     qubit[2] q;
@@ -221,7 +221,7 @@ def test_nested_gate_modifiers():
     pow(1) @ inv @ pow(2) @ custom q;
     pow(-1) @ custom q;
     """
-    result = unroll(qasm_str)
+    result = unroll(qasm3_string, as_module=True)
     assert result.num_qubits == 2
     assert result.num_clbits == 0
     check_single_qubit_gate_op(result.unrolled_ast, 3, [1, 1, 1], "z")

--- a/tests/test_if.py
+++ b/tests/test_if.py
@@ -63,7 +63,7 @@ def test_simple_if():
     }
     """
 
-    result = unroll(qasm)
+    result = unroll(qasm, as_module=True)
     assert result.num_clbits == 4
     assert result.num_qubits == 4
 
@@ -129,7 +129,7 @@ def test_complex_if():
     h q[0];
     h q[1];
     """
-    result = unroll(qasm)
+    result = unroll(qasm, as_module=True)
     assert result.num_clbits == 8
     assert result.num_qubits == 4
     print(result.unrolled_qasm)

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -57,6 +57,7 @@ def test_convert_qasm3_for_loop():
         }
         measure q->c;
         """,
+        as_module=True,
     )
     assert result.num_qubits == 4
     assert result.num_clbits == 4
@@ -86,6 +87,7 @@ def test_convert_qasm3_for_loop_shadow():
         h q[i];
         measure q->c;
         """,
+        as_module=True,
     )
     assert result.num_clbits == 4
     assert result.num_qubits == 4
@@ -113,6 +115,7 @@ def test_convert_qasm3_for_loop_enclosing():
         }
         measure q->c;
         """,
+        as_module=True,
     )
 
     assert result.num_clbits == 4
@@ -143,6 +146,7 @@ def test_convert_qasm3_for_loop_enclosing_modifying():
         h q[j];
         measure q->c;
         """,
+        as_module=True,
     )
     print(result.unrolled_qasm)
 
@@ -169,6 +173,7 @@ def test_convert_qasm3_for_loop_discrete_set():
         }
         measure q->c;
         """,
+        as_module=True,
     )
     assert result.num_clbits == 4
     assert result.num_qubits == 4
@@ -196,7 +201,7 @@ def test_function_executed_in_loop():
     }
     """
 
-    result = unroll(qasm_str)
+    result = unroll(qasm_str, as_module=True)
     assert result.num_qubits == 5
     assert result.num_clbits == 0
 
@@ -220,7 +225,7 @@ def test_loop_inside_function():
     my_function(q1);
     """
 
-    result = unroll(qasm_str)
+    result = unroll(qasm_str, as_module=True)
 
     assert result.num_qubits == 3
     assert result.num_clbits == 0
@@ -251,7 +256,7 @@ def test_function_in_nested_loop():
     my_function(q[0], 2*b);
     """
 
-    result = unroll(qasm_str)
+    result = unroll(qasm_str, as_module=True)
     assert result.num_qubits == 5
     assert result.num_clbits == 0
 
@@ -282,7 +287,7 @@ def test_loop_in_nested_function_call():
     qubit q;
     my_function_2(q, 3);
     """
-    result = unroll(qasm3_string)
+    result = unroll(qasm3_string, as_module=True)
 
     assert result.num_clbits == 0
     assert result.num_qubits == 1

--- a/tests/test_measurement.py
+++ b/tests/test_measurement.py
@@ -58,7 +58,7 @@ def test_measure():
     c1[0] = measure q2[1]; 
     """
 
-    unrolled_qasm = unroll(qasm3_string).unrolled_qasm
+    unrolled_qasm = unroll(qasm3_string)
     check_unrolled_qasm(unrolled_qasm, expected_qasm)
 
 

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -51,7 +51,7 @@ def test_reset_operations():
     reset q3[1];
     """
 
-    unrolled_qasm = unroll(qasm3_string).unrolled_qasm
+    unrolled_qasm = unroll(qasm3_string)
     check_unrolled_qasm(unrolled_qasm, expected_qasm)
 
 
@@ -74,7 +74,7 @@ def test_reset_inside_function():
     reset q[1];
     """
 
-    unrolled_qasm = unroll(qasm_str).unrolled_qasm
+    unrolled_qasm = unroll(qasm_str)
     check_unrolled_qasm(unrolled_qasm, expected_qasm)
 
 

--- a/tests/test_sizeof.py
+++ b/tests/test_sizeof.py
@@ -43,7 +43,7 @@ def test_simple_sizeof():
     rx(size3) q[1];
     """
 
-    result = unroll(qasm3_string)
+    result = unroll(qasm3_string, as_module=True)
     assert result.num_qubits == 2
 
     check_single_qubit_rotation_op(result.unrolled_ast, 4, [0, 0, 1, 1], [3, 3, 2, 3], "rx")
@@ -71,7 +71,7 @@ def test_sizeof_multiple_types():
     rx(size3) q[1];
     """
 
-    result = unroll(qasm3_string)
+    result = unroll(qasm3_string, as_module=True)
     assert result.num_qubits == 2
     check_single_qubit_rotation_op(result.unrolled_ast, 3, [0, 1, 1], [3, 2, 3], "rx")
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -46,7 +46,7 @@ def test_switch():
     }
     """
 
-    result = unroll(qasm3_switch_program)
+    result = unroll(qasm3_switch_program, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 1
 
@@ -76,7 +76,7 @@ def test_switch_default():
     }
     """
 
-    result = unroll(qasm3_switch_program)
+    result = unroll(qasm3_switch_program, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 1
     check_single_qubit_gate_op(result.unrolled_ast, 1, [0], "z")
@@ -103,7 +103,7 @@ def test_switch_identifier_case():
     }
     """
 
-    result = unroll(qasm3_switch_program)
+    result = unroll(qasm3_switch_program, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 1
 
@@ -131,7 +131,7 @@ def test_switch_const_int():
     }
     """
 
-    result = unroll(qasm3_switch_program)
+    result = unroll(qasm3_switch_program, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 1
 
@@ -222,7 +222,7 @@ def test_nested_switch():
     }
     """
 
-    result = unroll(qasm3_switch_program)
+    result = unroll(qasm3_switch_program, as_module=True)
 
     assert result.num_clbits == 0
     assert result.num_qubits == 1
@@ -254,7 +254,7 @@ def test_subroutine_inside_switch():
     }
     """
 
-    result = unroll(qasm_str)
+    result = unroll(qasm_str, as_module=True)
     assert result.num_clbits == 0
     assert result.num_qubits == 2
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the qBraid-QIR CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

## Summary of changes
- Added a parameter `as_module` to make default return type of `pyqasm.unroll` as str