### PR TITLE
Initial size bug in `bit` declarations

### DIFF
--- a/pyqasm/visitor.py
+++ b/pyqasm/visitor.py
@@ -895,8 +895,9 @@ class BasicQasmVisitor:
                 statements.extend(stmts)
         base_size = 1
         if not isinstance(base_type, qasm3_ast.BoolType):
+            initial_size = 1 if isinstance(base_type, qasm3_ast.BitType) else 32
             base_size = (
-                32
+                initial_size
                 if not hasattr(base_type, "size") or base_type.size is None
                 else Qasm3ExprEvaluator.evaluate_expression(base_type.size, const_expr=True)[0]
             )

--- a/tests/declarations/test_classical.py
+++ b/tests/declarations/test_classical.py
@@ -121,6 +121,7 @@ def test_scalar_type_casts():
     uint[4] b = -4; // -4 % 16 = 12
     bool f = 0;
     bool g = 1;
+    bit h = 1;
 
     qubit q;
     rx(a) q;
@@ -137,7 +138,7 @@ def test_scalar_type_casts():
     g = 1
 
     result = unroll(qasm3_string, as_module=True)
-    assert result.num_clbits == 0
+    assert result.num_clbits == 1
     assert result.num_qubits == 1
 
     check_single_qubit_rotation_op(result.unrolled_ast, 5, [0, 0, 0, 0, 0], [a, r, b, f, g], "rx")


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the qBraid-QIR CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

## Summary of changes
When a classical bit is declared as `bit c1;`, the `base_size` is read as 32 when it should be 1. 
Reference - [base size calculation](https://github.com/qBraid/pyqasm/blob/main/pyqasm/visitor.py#L898). 