### PR TITLE
Fix expressions involving classical registers 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,52 +15,29 @@ Types of changes:
 ## [Unreleased]
 
 ### Added
-- Sphinx docs and examples added for pyqasm ([#20](https://github.com/qBraid/pyqasm/pull/20))
-- qBraid header check enabled in format action([#29](https://github.com/qBraid/pyqasm/pull/29))
-- Integrated code coverage with codecov ([#30](https://github.com/qBraid/pyqasm/pull/30))
+
+- Dependabot configuration file [#37](https://github.com/qBraid/pyqasm/pull/37)
 
 ### Improved / Modified
-- Housekeeping updates involving codeowners, workflows, pyproject, and readme ([#16](https://github.com/qBraid/pyqasm/pull/16))
-- Fixed parsing of compile-time constants for register sizes. Statements like `const int[32] N = 3; qubit[N] q;` are now supported ([#21](https://github.com/qBraid/pyqasm/pull/21)).
-- Update project `README.md` ([#22](https://github.com/qBraid/pyqasm/pull/22))
-- Updated sphinx docs page ([#26](https://github.com/qBraid/pyqasm/pull/26))
-- **Major Change**: The default type for `pyqasm.unroller.unroll` has been changed from `pyqasm.elements.Qasm3Module` to `str`. This change is backward-incompatible and will require users to update their code. The following code snippet demonstrates the change - 
 
-```python
-from pyqasm.unroller import unroll
-qasm_str = """
-OPENQASM 3;
-qubit[3] q;
-h q;
-"""
-
-# Old way : The default type for unroll was pyqasm.elements.Qasm3Module
-program = unroll(qasm_str, as_module=True)
-unrolled_qasm_old = program.unrolled_qasm
-
-# New way : The default type for unroll is now str
-unrolled_qasm_new = unroll(qasm_str)
-```
-To force the return type to be `pyqasm.elements.Qasm3Module`, users can set the `as_module` parameter to `True` as shown above to update their code.
+- Improved qubit declaration semantics by adding check for quantum registers being declared as predefined constants [#44](https://github.com/qBraid/pyqasm/pull/44)
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
-- Issue with aliasing of qubits was fixed where aliased qubits were referenced with non-aliased qubits in a quantum gate ([#14](https://github.com/qBraid/pyqasm/pull/14)). The following program is now supported - 
 
-```python
-OPENQASM 3;
-include "stdgates.inc";
-qubit[4] q;
-let alias = q[0:2];
-cx alias[1], q[2];
-```
+- Bug in initial sizes of classical registers. `bit c;` was being initialized with size `32` instead of `1` [#43](https://github.com/qBraid/pyqasm/pull/43)
+- Fixed bug in the handling of classical register type. Whenever a `bit` was referenced in an expression, it was treated as a scalar when it should be treated as an element of a 1D array with type `bit` [#44](https://github.com/qBraid/pyqasm/pull/44)
 
-- Issue with subroutines, when `return` keyword was absent, was fixed in ([#21](https://github.com/qBraid/pyqasm/pull/21))
 
 ### Dependencies
+
+- Update sphinx-autodoc-typehints requirement from <2.5,>=1.24 to >=1.24,<2.6 [#38](https://github.com/qBraid/pyqasm/pull/38)
+- Update sphinx requirement from <8.1.0,>=7.3.7 to >=7.3.7,<8.2.0 [#39](https://github.com/qBraid/pyqasm/pull/39)
+- Update sphinx-rtd-theme requirement from <3.0.0,>=2.0.0 to >=2.0.0,<4.0.0 [#40](https://github.com/qBraid/pyqasm/pull/40)
+
 
 ## References
 [Changelog for release v0.0.1](https://github.com/qBraid/pyqasm/releases/tag/v0.0.1)

--- a/pyqasm/elements.py
+++ b/pyqasm/elements.py
@@ -8,7 +8,7 @@
 #
 # THERE IS NO WARRANTY for pyqasm, as per Section 15 of the GPL v3.
 
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments, too-many-instance-attributes
 
 """
 Module defining Qasm3 Converter elements.
@@ -53,6 +53,7 @@ class Variable:
         dims (list[int]): Dimensions of the variable.
         value (Optional[Union[int, float, list]]): Value of the variable.
         is_constant (bool): Flag indicating if the variable is constant.
+        is_register (bool): Flag indicating if the variable is a register.
         readonly(bool): Flag indicating if the variable is readonly.
 
     """
@@ -65,6 +66,7 @@ class Variable:
         dims: Optional[list[int]] = None,
         value: Optional[Union[int, float, np.ndarray]] = None,
         is_constant: bool = False,
+        is_register: bool = False,
         readonly: bool = False,
     ):
         self.name = name
@@ -73,7 +75,16 @@ class Variable:
         self.dims = dims
         self.value = value
         self.is_constant = is_constant
+        self.is_register = is_register
         self.readonly = readonly
+
+    def __repr__(self) -> str:
+        return (
+            f"Variable(name = {self.name}, base_type = {self.base_type}, "
+            f"base_size = {self.base_size}, dimensions = {self.dims}, "
+            f"value = {self.value}, is_constant = {self.is_constant}, "
+            f"readonly = {self.readonly}, is_register = {self.is_register})"
+        )
 
 
 class Qasm3Module:

--- a/pyqasm/maps.py
+++ b/pyqasm/maps.py
@@ -721,7 +721,7 @@ def qasm_variable_type_cast(openqasm_type, var_name, base_size, rhs_value):
     # not sure if we wanna hande array bit assignments too.
     # For now, we only cater to single bit assignment.
     if openqasm_type == BitType:
-        return bool(rhs_value)
+        return rhs_value != 0
     if openqasm_type == AngleType:
         return rhs_value  # not sure
 

--- a/pyqasm/validator.py
+++ b/pyqasm/validator.py
@@ -15,7 +15,7 @@ Module with utility functions for QASM3 visitor
 from typing import Any, Optional, Union
 
 import numpy as np
-from openqasm3.ast import ArrayType, ClassicalDeclaration
+from openqasm3.ast import ArrayType, ClassicalDeclaration, FloatType
 from openqasm3.ast import IntType as Qasm3IntType
 from openqasm3.ast import QuantumGate, QuantumGateDefinition, ReturnStatement, SubroutineDefinition
 
@@ -157,6 +157,27 @@ class Qasm3Validator:
             )
 
         return type_casted_value
+
+    @staticmethod
+    def validate_classical_type(base_type, base_size, var_name, span) -> None:
+        """Validate the type and size of a classical variable.
+
+        Args:
+            base_type (Any): The base type of the variable.
+            base_size (int): The size of the variable.
+            var_name (str): The name of the variable.
+            span (Span): The span of the variable.
+
+        Raises:
+            ValidationError: If the type or size is invalid.
+        """
+        if not isinstance(base_size, int) or base_size <= 0:
+            raise_qasm3_error(f"Invalid base size {base_size} for variable {var_name}", span=span)
+
+        if isinstance(base_type, FloatType) and base_size not in [32, 64]:
+            raise_qasm3_error(
+                f"Invalid base size {base_size} for float variable {var_name}", span=span
+            )
 
     @staticmethod
     def validate_array_assignment_values(

--- a/pyqasm/visitor.py
+++ b/pyqasm/visitor.py
@@ -243,13 +243,13 @@ class BasicQasmVisitor:
     def _in_block_scope(self) -> bool:  # block scope is for if/else/for/while constructs
         return len(self._scope) > 1 and self._get_curr_context() == Context.BLOCK
 
-    def _visit_qubit_register(
+    def _visit_quantum_register(
         self, register: qasm3_ast.QubitDeclaration
     ) -> list[qasm3_ast.QubitDeclaration]:
-        """Visit a Qubit / Classical declaration statement.
+        """Visit a Qubit declaration statement.
 
         Args:
-            register (QubitDeclaration|ClassicalDeclaration): The register name and size.
+            register (QubitDeclaration): The register name and size.
 
         Returns:
             None
@@ -272,12 +272,14 @@ class BasicQasmVisitor:
 
         if self._check_in_scope(register_name):
             raise_qasm3_error(
-                f"Invalid declaration of register with name '{register_name}'", span=register.span
+                f"Re-declaration of quantum register with name '{register_name}'",
+                span=register.span,
             )
 
         if register_name in CONSTANTS_MAP:
             raise_qasm3_error(
-                f"Can not declare variable with keyword name {register_name}", span=register.span
+                f"Can not declare quantum register with keyword name '{register_name}'",
+                span=register.span,
             )
 
         self._add_var_in_scope(
@@ -1523,7 +1525,7 @@ class BasicQasmVisitor:
             qasm3_ast.QuantumMeasurementStatement: self._visit_measurement,
             qasm3_ast.QuantumReset: self._visit_reset,
             qasm3_ast.QuantumBarrier: self._visit_barrier,
-            qasm3_ast.QubitDeclaration: self._visit_qubit_register,
+            qasm3_ast.QubitDeclaration: self._visit_quantum_register,
             qasm3_ast.QuantumGateDefinition: self._visit_gate_definition,
             qasm3_ast.QuantumGate: self._visit_generic_gate_operation,
             qasm3_ast.ClassicalDeclaration: self._visit_classical_declaration,

--- a/tests/declarations/test_quantum.py
+++ b/tests/declarations/test_quantum.py
@@ -115,12 +115,25 @@ def test_qubit_clbit_declarations():
 
 def test_qubit_redeclaration_error():
     """Test redeclaration of qubit"""
-    with pytest.raises(ValidationError, match="Invalid declaration of register with name 'q1'"):
+    with pytest.raises(ValidationError, match="Re-declaration of quantum register with name 'q1'"):
         qasm3_string = """
         OPENQASM 3;
         include "stdgates.inc";
         qubit q1;
         qubit q1;
+        """
+        validate(qasm3_string)
+
+
+def test_invalid_qubit_name():
+    """Test that qubit name can not be one of constants"""
+    with pytest.raises(
+        ValidationError, match="Can not declare quantum register with keyword name 'pi'"
+    ):
+        qasm3_string = """
+        OPENQASM 3;
+        include "stdgates.inc";
+        qubit pi;
         """
         validate(qasm3_string)
 

--- a/tests/resources/variables.py
+++ b/tests/resources/variables.py
@@ -164,6 +164,24 @@ DECLARATION_TESTS = {
         """,
         "Invalid dimensions for array assignment to variable x. Expected 3 but got 1",
     ),
+    "invalid_bit_type_array_1": (
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+
+        array[bit, 3] x;
+        """,
+        "Can not declare array x with type 'bit'",
+    ),
+    "invalid_bit_type_array_2": (
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+
+        array[bit[32], 3] x;
+        """,
+        "Can not declare array x with type 'bit'",
+    ),
 }
 
 ASSIGNMENT_TESTS = {

--- a/tests/resources/variables.py
+++ b/tests/resources/variables.py
@@ -47,7 +47,7 @@ DECLARATION_TESTS = {
         int x;
         qubit x;
         """,
-        "Invalid declaration of register with name 'x'",
+        "Re-declaration of quantum register with name 'x'",
     ),
     "variable_redeclaration_with_qubits_2": (
         """

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -17,7 +17,7 @@ import pytest
 from pyqasm.exceptions import ValidationError
 from pyqasm.unroller import unroll
 from pyqasm.validate import validate
-from tests.utils import check_single_qubit_rotation_op
+from tests.utils import check_measure_op, check_single_qubit_gate_op, check_single_qubit_rotation_op
 
 
 def test_correct_expressions():
@@ -46,6 +46,25 @@ def test_correct_expressions():
     check_single_qubit_rotation_op(result.unrolled_ast, 3, [0] * 3, rx_expression_values, "rx")
     check_single_qubit_rotation_op(result.unrolled_ast, 2, [0] * 2, rz_expression_values, "rz")
 
+def test_bit_in_expression():
+    qasm_str = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+
+    bit[1] c3;
+    qubit[1] q3;
+    int dummy_int;
+    h q3[0];
+    c3[0] = measure q3[0];
+    dummy_int = c3[0];
+    """
+
+    result = unroll(qasm_str, as_module=True)
+    assert result.num_qubits == 1
+    assert result.num_clbits == 1
+    check_single_qubit_gate_op(result.unrolled_ast, 1, [0], "h")
+    meas_pairs = [(('q3',0),('c3',0))]
+    check_measure_op(result.unrolled_ast, 1, meas_pairs)
 
 def test_incorrect_expressions():
     with pytest.raises(ValidationError, match=r"Unsupported expression type .*"):

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -46,6 +46,7 @@ def test_correct_expressions():
     check_single_qubit_rotation_op(result.unrolled_ast, 3, [0] * 3, rx_expression_values, "rx")
     check_single_qubit_rotation_op(result.unrolled_ast, 2, [0] * 2, rz_expression_values, "rz")
 
+
 def test_bit_in_expression():
     qasm_str = """
     OPENQASM 3.0;
@@ -63,8 +64,9 @@ def test_bit_in_expression():
     assert result.num_qubits == 1
     assert result.num_clbits == 1
     check_single_qubit_gate_op(result.unrolled_ast, 1, [0], "h")
-    meas_pairs = [(('q3',0),('c3',0))]
+    meas_pairs = [(("q3", 0), ("c3", 0))]
     check_measure_op(result.unrolled_ast, 1, meas_pairs)
+
 
 def test_incorrect_expressions():
     with pytest.raises(ValidationError, match=r"Unsupported expression type .*"):

--- a/tests/test_sizeof.py
+++ b/tests/test_sizeof.py
@@ -55,25 +55,21 @@ def test_sizeof_multiple_types():
     OPENQASM 3;
     include "stdgates.inc";
 
-    array[bit, 3, 2] my_bits;
     array[int[32], 3, 2] my_ints;
     array[float[64], 3, 2] my_floats;
 
-    int[32] size1 = sizeof(my_bits); // this is 3
+    int[32] size1 = sizeof(my_ints, 1); // this is 2
 
-    int[32] size2 = sizeof(my_ints, 1); // this is 2
-
-    int[32] size3 = sizeof(my_floats, 0); // this is 3 too
+    int[32] size2 = sizeof(my_floats, 0); // this is 3 
     qubit[2] q;
 
-    rx(size1) q[0];
+    rx(size1) q[1];
     rx(size2) q[1];
-    rx(size3) q[1];
     """
 
     result = unroll(qasm3_string, as_module=True)
     assert result.num_qubits == 2
-    check_single_qubit_rotation_op(result.unrolled_ast, 3, [0, 1, 1], [3, 2, 3], "rx")
+    check_single_qubit_rotation_op(result.unrolled_ast, 2, [ 1, 1], [ 2, 3], "rx")
 
 
 def test_unsupported_target():

--- a/tests/test_sizeof.py
+++ b/tests/test_sizeof.py
@@ -69,7 +69,7 @@ def test_sizeof_multiple_types():
 
     result = unroll(qasm3_string, as_module=True)
     assert result.num_qubits == 2
-    check_single_qubit_rotation_op(result.unrolled_ast, 2, [ 1, 1], [ 2, 3], "rx")
+    check_single_qubit_rotation_op(result.unrolled_ast, 2, [1, 1], [2, 3], "rx")
 
 
 def test_unsupported_target():

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -291,7 +291,7 @@ def test_invalid_scalar_switch_target(invalid_type):
         validate(qasm3_switch_program)
 
 
-@pytest.mark.parametrize("invalid_type", ["float", "bool", "bit"])
+@pytest.mark.parametrize("invalid_type", ["float", "bool"])
 def test_invalid_array_switch_target(invalid_type):
     """Test that switch raises error if target is array element and not an integer."""
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -101,13 +101,15 @@ def check_u3_gate_op(unrolled_ast, num_gates, qubit_list, param_list):
 
     assert op_count == num_gates
 
+
 def check_measure_op(unrolled_ast, num_ops, meas_pairs):
     """Check that the unrolled ast contains the correct number of measurements.
 
     Args:
         unrolled_ast (qasm3_ast.Program): The unrolled ast to check.
         num_ops (int): The number of measurements to check for.
-        meas_pairs (list[tuple[(str, int), (str, int)]]): The list of measurement pairs to check for.
+        meas_pairs (list[tuple[(str, int), (str, int)]]): The list of measurement
+                                                          pairs to check for.
     """
 
     meas_count = 0
@@ -118,12 +120,13 @@ def check_measure_op(unrolled_ast, num_ops, meas_pairs):
             target_name = stmt.target.name.name
             target_index = stmt.target.indices[0][0].value
 
-            # preserve order of measurement pairs 
+            # preserve order of measurement pairs
             assert (source_name, source_index) == meas_pairs[meas_count][0]
             assert (target_name, target_index) == meas_pairs[meas_count][1]
             meas_count += 1
-            
+
     assert meas_count == num_ops
+
 
 def check_single_qubit_rotation_op(unrolled_ast, num_gates, qubit_list, param_list, gate_name):
     if gate_name == "u3":

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -101,6 +101,29 @@ def check_u3_gate_op(unrolled_ast, num_gates, qubit_list, param_list):
 
     assert op_count == num_gates
 
+def check_measure_op(unrolled_ast, num_ops, meas_pairs):
+    """Check that the unrolled ast contains the correct number of measurements.
+
+    Args:
+        unrolled_ast (qasm3_ast.Program): The unrolled ast to check.
+        num_ops (int): The number of measurements to check for.
+        meas_pairs (list[tuple[(str, int), (str, int)]]): The list of measurement pairs to check for.
+    """
+
+    meas_count = 0
+    for stmt in unrolled_ast.statements:
+        if isinstance(stmt, qasm3_ast.QuantumMeasurementStatement):
+            source_name = stmt.measure.qubit.name.name
+            source_index = stmt.measure.qubit.indices[0][0].value
+            target_name = stmt.target.name.name
+            target_index = stmt.target.indices[0][0].value
+
+            # preserve order of measurement pairs 
+            assert (source_name, source_index) == meas_pairs[meas_count][0]
+            assert (target_name, target_index) == meas_pairs[meas_count][1]
+            meas_count += 1
+            
+    assert meas_count == num_ops
 
 def check_single_qubit_rotation_op(unrolled_ast, num_gates, qubit_list, param_list, gate_name):
     if gate_name == "u3":


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the qBraid-QIR CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->
Fixes #44 
## Summary of changes
The most important changes include adding the `is_register` attribute to the `Variable` class, refining type validation, and updating the visitor logic to handle classical declarations more robustly.

Enhancements to variable handling:

* [`pyqasm/elements.py`](diffhunk://#diff-05ef42acb10d44bb317b4b6b62820bf8ec356f6a6ab0a0f35284edad447a35b8R56): Added the `is_register` attribute to the `Variable` class and updated its `__init__` and `__repr__` methods to include this attribute. [[1]](diffhunk://#diff-05ef42acb10d44bb317b4b6b62820bf8ec356f6a6ab0a0f35284edad447a35b8R56) [[2]](diffhunk://#diff-05ef42acb10d44bb317b4b6b62820bf8ec356f6a6ab0a0f35284edad447a35b8R69) [[3]](diffhunk://#diff-05ef42acb10d44bb317b4b6b62820bf8ec356f6a6ab0a0f35284edad447a35b8R78-R88)

Improvements in validation:

* [`pyqasm/validator.py`](diffhunk://#diff-b1928acdd4eeaf4229d08d59e77f625df04d9b3a628454dcec0892218bef9118R161-R181): Added the `validate_classical_type` method to ensure the type and size of classical variables are valid.
* [`pyqasm/maps.py`](diffhunk://#diff-8d578f59e7a96eb1bc542fd42dec5ee0d9efbffbe9c0d0b0a00d098723ddf666L724-R724): Modified `qasm_variable_type_cast` to handle bit type assignments more accurately.

Updates to visitor logic:

* [`pyqasm/visitor.py`](diffhunk://#diff-5b26d2cb7dbbf506dbaa06405eeb8e9b44a0786e2ac64ede3787b3e96a964207R860-L873): Enhanced the `_visit_classical_declaration` method to initialize bit registers and validate classical types properly. Also added a check to prevent declaring variables with keyword names. [[1]](diffhunk://#diff-5b26d2cb7dbbf506dbaa06405eeb8e9b44a0786e2ac64ede3787b3e96a964207R860-L873) [[2]](diffhunk://#diff-5b26d2cb7dbbf506dbaa06405eeb8e9b44a0786e2ac64ede3787b3e96a964207L882-R906) [[3]](diffhunk://#diff-5b26d2cb7dbbf506dbaa06405eeb8e9b44a0786e2ac64ede3787b3e96a964207L896-R927) [[4]](diffhunk://#diff-5b26d2cb7dbbf506dbaa06405eeb8e9b44a0786e2ac64ede3787b3e96a964207L928)
* Added a check to verify is qubit names are not overlapping with predefined constants

Test updates:

* [`tests/resources/variables.py`](diffhunk://#diff-b3a1c03a00066a0c2b058dad185033e7cccf377047929517e33353efa05fbf4aR167-R184): Added new test cases for invalid bit type array declarations.
* [`tests/test_expressions.py`](diffhunk://#diff-056f94703aba5a58c9f01fc582ddfad127cf6c11a861b78ea26ecf93f2fcb6b9R49-R67): Added a test for using bit types in expressions.
* [`tests/test_sizeof.py`](diffhunk://#diff-68b9a492ccbf4da4cc5a7813ffd7e685d8478f6430ff4132991dd52b9846770bL58-R72): Updated the test for `sizeof` to remove bit type arrays and correct the test logic.
* [`tests/test_switch.py`](diffhunk://#diff-76626654c1bd499421e4d9ef3c15f7a650cbf2ea5adfb74f35f5db687bea115bL294-R294): Removed `bit` from invalid scalar switch target test cases.
* [`tests/utils.py`](diffhunk://#diff-9e08e8c7769db7b58089fd7659d75ca96df40bb7b5d50299d3a30abd54da9ad6R104-R126): Added a utility function `check_measure_op` to verify measurement operations in the unrolled AST.