### PR TITLE
Update QASM version string to `x.0`

### DIFF
--- a/pyqasm/elements.py
+++ b/pyqasm/elements.py
@@ -214,7 +214,7 @@ class Qasm2Module(QasmModule):
         statements: list,
     ):
         super().__init__(name, program, statements)
-        self._unrolled_ast = Program(statements=[Include("stdgates.inc")], version="2")
+        self._unrolled_ast = Program(statements=[Include("stdgates.inc")], version="2.0")
         self._whitelist_statements = {
             qasm3_ast.BranchingStatement,
             qasm3_ast.QubitDeclaration,
@@ -288,7 +288,7 @@ class Qasm3Module(QasmModule):
         statements: list,
     ):
         super().__init__(name, program, statements)
-        self._unrolled_ast = Program(statements=[Include("stdgates.inc")], version="3")
+        self._unrolled_ast = Program(statements=[Include("stdgates.inc")], version="3.0")
 
     @property
     def unrolled_qasm(self) -> str:

--- a/tests/qasm2/test_declarations.py
+++ b/tests/qasm2/test_declarations.py
@@ -21,13 +21,13 @@ from tests.utils import check_unrolled_qasm
 def test_qubit_declarations():
     """Test qubit declarations in different ways"""
     qasm2_string = """
-    OPENQASM 2;
+    OPENQASM 2.0;
     qreg q3[3];
     qreg q;
     
     """
 
-    expected_qasm = """OPENQASM 2;
+    expected_qasm = """OPENQASM 2.0;
     include "stdgates.inc";
     qreg q3[3];
     qreg q[1];
@@ -41,14 +41,14 @@ def test_qubit_declarations():
 def test_clbit_declarations():
     """Test clbit declarations in different ways"""
     qasm2_string = """
-    OPENQASM 2;
+    OPENQASM 2.0;
     include "stdgates.inc";
     
     creg c3[3];
     creg c;
     """
 
-    expected_qasm = """OPENQASM 2;
+    expected_qasm = """OPENQASM 2.0;
     include "stdgates.inc";
     creg c3[3];
     creg c[1];
@@ -62,7 +62,7 @@ def test_clbit_declarations():
 def test_qubit_clbit_declarations():
     """Test qubit and clbit declarations in different ways"""
     qasm2_string = """
-    OPENQASM 2;
+    OPENQASM 2.0;
     include "stdgates.inc";
 
     // qubit declarations
@@ -74,7 +74,7 @@ def test_qubit_clbit_declarations():
     creg c2[2];
     """
 
-    expected_qasm = """OPENQASM 2;
+    expected_qasm = """OPENQASM 2.0;
     include "stdgates.inc";
     qreg q1[1];
     qreg q2[2];

--- a/tests/qasm2/test_operations.py
+++ b/tests/qasm2/test_operations.py
@@ -24,7 +24,7 @@ from tests.utils import check_unrolled_qasm
 def test_whitelisted_ops():
     """Test qubit declarations in different ways"""
     qasm2_string = """
-    OPENQASM 2;
+    OPENQASM 2.0;
     include "stdgates.inc";
     gate custom_gate a, b {
         cx a, b;
@@ -42,7 +42,7 @@ def test_whitelisted_ops():
     """
 
     expected_qasm = """
-    OPENQASM 2;
+    OPENQASM 2.0;
     include "stdgates.inc";
     qreg q[2];
     creg c[2];
@@ -68,7 +68,7 @@ def test_subroutine_blacklist():
     with pytest.raises(ValidationError):
         validate(
             """
-            OPENQASM 2;
+            OPENQASM 2.0;
             include "stdgates.inc";
             qreg q[2];
             creg c[2];
@@ -85,7 +85,7 @@ def test_switch_blacklist():
     with pytest.raises(ValidationError):
         validate(
             """
-            OPENQASM 2;
+            OPENQASM 2.0;
             include "stdgates.inc";
             qreg q[2];
             creg c[2];
@@ -105,7 +105,7 @@ def test_for_blacklist():
     with pytest.raises(ValidationError):
         validate(
             """
-            OPENQASM 2;
+            OPENQASM 2.0;
             include "stdgates.inc";
             qreg q[2];
             creg c[2];
@@ -122,7 +122,7 @@ def test_while_blacklist():
     with pytest.raises(ValidationError):
         validate(
             """
-            OPENQASM 2;
+            OPENQASM 2.0;
             include "stdgates.inc";
             qreg q[2];
             creg c[2];

--- a/tests/qasm3/declarations/test_classical.py
+++ b/tests/qasm3/declarations/test_classical.py
@@ -24,7 +24,7 @@ from tests.utils import check_single_qubit_rotation_op
 def test_scalar_declarations():
     """Test scalar declarations in different ways"""
     qasm3_string = """
-    OPENQASM 3;
+    OPENQASM 3.0;
     include "stdgates.inc";
     int a;
     uint b;
@@ -43,7 +43,7 @@ def test_scalar_declarations():
 def test_const_declarations():
     """Test const declarations in different ways"""
     qasm3_string = """
-    OPENQASM 3;
+    OPENQASM 3.0;
     include "stdgates.inc";
     const int a = 5;
     const uint b = 10;
@@ -68,7 +68,7 @@ def test_const_declarations():
 def test_scalar_assignments():
     """Test scalar assignments in different ways"""
     qasm3_string = """
-    OPENQASM 3;
+    OPENQASM 3.0;
     include "stdgates.inc";
     int a = 5;
     uint b;
@@ -88,7 +88,7 @@ def test_scalar_assignments():
 def test_scalar_value_assignment():
     """Test assigning variable values from other variables"""
     qasm3_string = """
-    OPENQASM 3;
+    OPENQASM 3.0;
     include "stdgates.inc";
     int a = 5;
     float[32] r;
@@ -113,7 +113,7 @@ def test_scalar_value_assignment():
 def test_scalar_type_casts():
     """Test type casts on scalar variables"""
     qasm3_string = """
-    OPENQASM 3;
+    OPENQASM 3.0;
     include "stdgates.inc";
     int[32] a = 5.1;
     float[32] r = 245;
@@ -146,7 +146,7 @@ def test_scalar_type_casts():
 def test_array_type_casts():
     """Test type casts on array variables"""
     qasm3_string = """
-    OPENQASM 3;
+    OPENQASM 3.0;
     include "stdgates.inc";
     array[int[32], 3, 2] arr_int = { {1, 2}, {3, 4}, {5, 6.2} };
     array[uint[32], 3, 2] arr_uint = { {1, 2}, {3, 4}, {5, 6.2} };
@@ -182,7 +182,7 @@ def test_array_type_casts():
 def test_array_declarations():
     """Test array declarations in different ways"""
     qasm3_string = """
-    OPENQASM 3;
+    OPENQASM 3.0;
     include "stdgates.inc";
     array[int[32], 3, 2] arr_int;
     array[uint[32-9], 3, 2] arr_uint;
@@ -198,7 +198,7 @@ def test_array_assignments():
     """Test array assignments"""
 
     qasm3_string = """
-    OPENQASM 3;
+    OPENQASM 3.0;
     include "stdgates.inc";
 
     array[int[32], 3, 2] arr_int;
@@ -253,7 +253,7 @@ def test_array_assignments():
 def test_array_expressions():
     """Test array expressions"""
     qasm3_string = """
-    OPENQASM 3;
+    OPENQASM 3.0;
     include "stdgates.inc";
 
     array[int[32], 3, 2] arr_int;
@@ -296,7 +296,7 @@ def test_array_initializations():
     """Test array initializations"""
 
     qasm3_string = """
-    OPENQASM 3;
+    OPENQASM 3.0;
     include "stdgates.inc";
 
     array[int[32], 3, 2] arr_int = { {1, 2}, {3, 4}, {5, 6} };
@@ -326,7 +326,7 @@ def test_array_range_assignment():
     """Test array range assignment"""
 
     qasm3_string = """
-    OPENQASM 3;
+    OPENQASM 3.0;
     include "stdgates.inc";
 
     array[int[32], 3, 2] arr_int = { {1, 2}, {3, 4}, {5, 6} };

--- a/tests/qasm3/declarations/test_quantum.py
+++ b/tests/qasm3/declarations/test_quantum.py
@@ -24,7 +24,7 @@ from tests.utils import check_unrolled_qasm
 def test_qubit_declarations():
     """Test qubit declarations in different ways"""
     qasm3_string = """
-    OPENQASM 3;
+    OPENQASM 3.0;
     include "stdgates.inc";
     qubit q1;
     qubit[2] q2;
@@ -35,7 +35,7 @@ def test_qubit_declarations():
     qubit[N] q5;
     """
 
-    expected_qasm = """OPENQASM 3;
+    expected_qasm = """OPENQASM 3.0;
     include "stdgates.inc";
     qubit[1] q1;
     qubit[2] q2;
@@ -52,7 +52,7 @@ def test_qubit_declarations():
 def test_clbit_declarations():
     """Test clbit declarations in different ways"""
     qasm3_string = """
-    OPENQASM 3;
+    OPENQASM 3.0;
     include "stdgates.inc";
     bit c1;
     bit[2] c2;
@@ -63,7 +63,7 @@ def test_clbit_declarations():
     bit[size] c5;
     """
 
-    expected_qasm = """OPENQASM 3;
+    expected_qasm = """OPENQASM 3.0;
     include "stdgates.inc";
     bit[1] c1;
     bit[2] c2;
@@ -80,7 +80,7 @@ def test_clbit_declarations():
 def test_qubit_clbit_declarations():
     """Test qubit and clbit declarations in different ways"""
     qasm3_string = """
-    OPENQASM 3;
+    OPENQASM 3.0;
     include "stdgates.inc";
 
     // qubit declarations
@@ -96,7 +96,7 @@ def test_qubit_clbit_declarations():
     bit[1] c4;
     """
 
-    expected_qasm = """OPENQASM 3;
+    expected_qasm = """OPENQASM 3.0;
     include "stdgates.inc";
     qubit[1] q1;
     qubit[2] q2;
@@ -116,7 +116,7 @@ def test_qubit_redeclaration_error():
     """Test redeclaration of qubit"""
     with pytest.raises(ValidationError, match="Re-declaration of quantum register with name 'q1'"):
         qasm3_string = """
-        OPENQASM 3;
+        OPENQASM 3.0;
         include "stdgates.inc";
         qubit q1;
         qubit q1;
@@ -130,7 +130,7 @@ def test_invalid_qubit_name():
         ValidationError, match="Can not declare quantum register with keyword name 'pi'"
     ):
         qasm3_string = """
-        OPENQASM 3;
+        OPENQASM 3.0;
         include "stdgates.inc";
         qubit pi;
         """
@@ -141,7 +141,7 @@ def test_clbit_redeclaration_error():
     """Test redeclaration of clbit"""
     with pytest.raises(ValidationError, match=r"Re-declaration of variable c1"):
         qasm3_string = """
-        OPENQASM 3;
+        OPENQASM 3.0;
         include "stdgates.inc";
         bit c1;
         bit[4] c1;
@@ -155,7 +155,7 @@ def test_non_constant_size():
         ValidationError, match=r"Variable 'N' is not a constant in given expression"
     ):
         qasm3_string = """
-        OPENQASM 3;
+        OPENQASM 3.0;
         include "stdgates.inc";
         int[32] N = 10;
         qubit[N] q;
@@ -166,7 +166,7 @@ def test_non_constant_size():
         ValidationError, match=r"Variable 'size' is not a constant in given expression"
     ):
         qasm3_string = """
-        OPENQASM 3;
+        OPENQASM 3.0;
         include "stdgates.inc";
         int[32] size = 10;
         bit[size] c;

--- a/tests/qasm3/subroutines/test_subroutines.py
+++ b/tests/qasm3/subroutines/test_subroutines.py
@@ -23,7 +23,7 @@ from tests.utils import check_single_qubit_gate_op, check_single_qubit_rotation_
 
 def test_function_declaration():
     """Test that a function declaration is correctly parsed."""
-    qasm_str = """OPENQASM 3;
+    qasm_str = """OPENQASM 3.0;
     include "stdgates.inc";
     def my_function(qubit q) {
         h q;
@@ -65,7 +65,7 @@ def test_simple_function_call():
 
 def test_const_visible_in_function_call():
     """Test that a constant is visible in a function call."""
-    qasm_str = """OPENQASM 3;
+    qasm_str = """OPENQASM 3.0;
     include "stdgates.inc";
     const float[32] pi2 = 3.14;
 
@@ -86,7 +86,7 @@ def test_const_visible_in_function_call():
 
 def test_update_variable_in_function():
     """Test that variable update works correctly in a function."""
-    qasm_str = """OPENQASM 3;
+    qasm_str = """OPENQASM 3.0;
     include "stdgates.inc";
 
     def my_function(qubit q) {
@@ -108,7 +108,7 @@ def test_update_variable_in_function():
 
 def test_function_call_in_expression():
     """Test that a function call in an expression is correctly parsed."""
-    qasm_str = """OPENQASM 3;
+    qasm_str = """OPENQASM 3.0;
     include "stdgates.inc";
 
     def my_function(qubit[4] q) -> bool{
@@ -132,7 +132,7 @@ def test_function_call_in_expression():
 def test_classical_quantum_function():
     """Test that a function with classical and quantum instructions is correctly unrolled"""
     qasm_str = """
-    OPENQASM 3;
+    OPENQASM 3.0;
     include "stdgates.inc";
     def my_function(qubit q, int[32] iter) -> int[32]{
         h q;
@@ -162,7 +162,7 @@ def test_classical_quantum_function():
 
 def test_multiple_function_calls():
     """Test that multiple function calls are correctly parsed."""
-    qasm_str = """OPENQASM 3;
+    qasm_str = """OPENQASM 3.0;
     include "stdgates.inc";
 
     def my_function(int[32] a, qubit q_arg) {
@@ -186,7 +186,7 @@ def test_multiple_function_calls():
 
 def test_function_call_with_return():
     """Test that a function call with a return value is correctly parsed."""
-    qasm_str = """OPENQASM 3;
+    qasm_str = """OPENQASM 3.0;
     include "stdgates.inc";
 
     def my_function(qubit q) -> float[32] {
@@ -206,7 +206,7 @@ def test_function_call_with_return():
 
 def test_return_values_from_function():
     """Test that the values returned from a function are used correctly in other function."""
-    qasm_str = """OPENQASM 3;
+    qasm_str = """OPENQASM 3.0;
     include "stdgates.inc";
 
     def my_function(qubit q) -> float[32] {
@@ -264,7 +264,7 @@ def test_function_call_with_custom_gate():
 @pytest.mark.skip(reason="Not implemented nested functions yet")
 def test_function_call_from_within_fn():
     """Test that a function call from within another function is correctly converted."""
-    qasm_str = """OPENQASM 3;
+    qasm_str = """OPENQASM 3.0;
     include "stdgates.inc";
 
     def my_function(qubit q1) {
@@ -291,7 +291,7 @@ def test_function_call_from_within_fn():
 def test_return_value_mismatch(data_type):
     """Test that returning a value of incorrect type raises error."""
     qasm_str = (
-        """OPENQASM 3;
+        """OPENQASM 3.0;
     include "stdgates.inc";
 
     def my_function(qubit q) {
@@ -315,7 +315,7 @@ def test_return_value_mismatch(data_type):
 @pytest.mark.parametrize("keyword", ["pi", "euler", "tau"])
 def test_subroutine_keyword_naming(keyword):
     """Test that using a keyword as a subroutine name raises error."""
-    qasm_str = f"""OPENQASM 3;
+    qasm_str = f"""OPENQASM 3.0;
     include "stdgates.inc";
 
     def {keyword}(qubit q) {{
@@ -334,7 +334,7 @@ def test_subroutine_keyword_naming(keyword):
 def test_qubit_size_arg_mismatch(qubit_params):
     """Test that passing a qubit of different size raises error."""
     qasm_str = (
-        """OPENQASM 3;
+        """OPENQASM 3.0;
     include "stdgates.inc";
 
     def my_function(qubit[3] q) {

--- a/tests/qasm3/test_barrier.py
+++ b/tests/qasm3/test_barrier.py
@@ -22,7 +22,7 @@ from tests.utils import check_unrolled_qasm
 # 1. Test barrier operations in different ways
 def test_barrier():
     qasm_str = """
-    OPENQASM 3;
+    OPENQASM 3.0;
     include "stdgates.inc";
 
     qubit[2] q1;
@@ -37,7 +37,7 @@ def test_barrier():
     barrier q1, q2[0:2], q3[:];
     """
 
-    expected_qasm = """OPENQASM 3;
+    expected_qasm = """OPENQASM 3.0;
     include "stdgates.inc";
     qubit[2] q1;
     qubit[3] q2;
@@ -66,7 +66,7 @@ def test_barrier():
 
 def test_barrier_in_function():
     """Test that a barrier in a function is correctly parsed."""
-    qasm_str = """OPENQASM 3;
+    qasm_str = """OPENQASM 3.0;
     include "stdgates.inc";
 
     def my_function(qubit[4] a) {
@@ -77,7 +77,7 @@ def test_barrier_in_function():
     my_function(q);
     """
 
-    expected_qasm = """OPENQASM 3;
+    expected_qasm = """OPENQASM 3.0;
     include "stdgates.inc";
     qubit[4] q;
     barrier q[0];
@@ -92,7 +92,7 @@ def test_barrier_in_function():
 def test_incorrect_barrier():
 
     undeclared = """
-    OPENQASM 3;
+    OPENQASM 3.0;
 
     qubit[3] q1;
 
@@ -103,7 +103,7 @@ def test_incorrect_barrier():
         validate(undeclared)
 
     out_of_bounds = """
-    OPENQASM 3;
+    OPENQASM 3.0;
 
     qubit[2] q1;
 
@@ -116,7 +116,7 @@ def test_incorrect_barrier():
         validate(out_of_bounds)
 
     duplicate = """
-    OPENQASM 3;
+    OPENQASM 3.0;
 
     qubit[2] q1;
 

--- a/tests/qasm3/test_if.py
+++ b/tests/qasm3/test_if.py
@@ -21,7 +21,7 @@ from tests.utils import check_unrolled_qasm
 
 
 def test_simple_if():
-    qasm = """OPENQASM 3;
+    qasm = """OPENQASM 3.0;
     include "stdgates.inc";
     qubit[4] q;
     bit[4] c;
@@ -38,7 +38,7 @@ def test_simple_if():
         x q[3];
     }
     """
-    expected_qasm = """OPENQASM 3;
+    expected_qasm = """OPENQASM 3.0;
     include "stdgates.inc";
     qubit[4] q;
     bit[4] c;
@@ -70,7 +70,7 @@ def test_simple_if():
 
 
 def test_complex_if():
-    qasm = """OPENQASM 3;
+    qasm = """OPENQASM 3.0;
     include "stdgates.inc";
     gate custom a, b{
         cx a, b;
@@ -101,7 +101,7 @@ def test_complex_if():
         h q[1];
     }
     """
-    expected_qasm = """OPENQASM 3;
+    expected_qasm = """OPENQASM 3.0;
     include "stdgates.inc";
     qubit[4] q;
     bit[4] c;
@@ -140,7 +140,7 @@ def test_incorrect_if():
     with pytest.raises(ValidationError, match=r"Missing if block"):
         validate(
             """
-            OPENQASM 3;
+            OPENQASM 3.0;
            include "stdgates.inc";
            qubit[2] q;
            bit[2] c;
@@ -156,7 +156,7 @@ def test_incorrect_if():
     with pytest.raises(ValidationError, match=r"Undefined identifier c2 in expression"):
         validate(
             """
-            OPENQASM 3;
+            OPENQASM 3.0;
            include "stdgates.inc";
            qubit[2] q;
            bit[2] c;
@@ -173,7 +173,7 @@ def test_incorrect_if():
     with pytest.raises(ValidationError, match=r"Only '!' supported .*"):
         validate(
             """
-            OPENQASM 3;
+            OPENQASM 3.0;
            include "stdgates.inc";
            qubit[2] q;
            bit[2] c;
@@ -189,7 +189,7 @@ def test_incorrect_if():
     with pytest.raises(ValidationError, match=r"Only '==' supported .*"):
         validate(
             """
-            OPENQASM 3;
+            OPENQASM 3.0;
            include "stdgates.inc";
            qubit[2] q;
            bit[2] c;
@@ -208,7 +208,7 @@ def test_incorrect_if():
     ):
         validate(
             """
-            OPENQASM 3;
+            OPENQASM 3.0;
            include "stdgates.inc";
            qubit[2] q;
            bit[2] c;
@@ -227,7 +227,7 @@ def test_incorrect_if():
     ):
         validate(
             """
-            OPENQASM 3;
+            OPENQASM 3.0;
            include "stdgates.inc";
            qubit[2] q;
            bit[2] c;
@@ -247,7 +247,7 @@ def test_incorrect_if():
     ):
         validate(
             """
-            OPENQASM 3;
+            OPENQASM 3.0;
            include "stdgates.inc";
            qubit[2] q;
            bit[2] c;

--- a/tests/qasm3/test_measurement.py
+++ b/tests/qasm3/test_measurement.py
@@ -22,7 +22,7 @@ from tests.utils import check_unrolled_qasm
 # Test measurement operations in different ways
 def test_measure():
     qasm3_string = """
-    OPENQASM 3;
+    OPENQASM 3.0;
 
     qubit[2] q1;
     qubit[5] q2;
@@ -40,7 +40,7 @@ def test_measure():
 
     """
 
-    expected_qasm = """OPENQASM 3;
+    expected_qasm = """OPENQASM 3.0;
     include "stdgates.inc";
     qubit[2] q1;
     qubit[5] q2;
@@ -69,7 +69,7 @@ def test_incorrect_measure():
     # Test for undeclared register q2
     run_test(
         """
-        OPENQASM 3;
+        OPENQASM 3.0;
         qubit[2] q1;
         bit[2] c1;
         c1[0] = measure q2[0];  // undeclared register
@@ -80,7 +80,7 @@ def test_incorrect_measure():
     # Test for undeclared register c2
     run_test(
         """
-        OPENQASM 3;
+        OPENQASM 3.0;
         qubit[2] q1;
         bit[2] c1;
         measure q1 -> c2;  // undeclared register
@@ -91,7 +91,7 @@ def test_incorrect_measure():
     # Test for size mismatch between q1 and c2
     run_test(
         """
-        OPENQASM 3;
+        OPENQASM 3.0;
         qubit[2] q1;
         bit[2] c1;
         bit[1] c2;
@@ -103,7 +103,7 @@ def test_incorrect_measure():
     # Test for size mismatch between q1 and c2 in ranges
     run_test(
         """
-        OPENQASM 3;
+        OPENQASM 3.0;
         qubit[5] q1;
         bit[4] c1;
         bit[1] c2;
@@ -115,7 +115,7 @@ def test_incorrect_measure():
     # Test for out of bounds index for q1
     run_test(
         """
-        OPENQASM 3;
+        OPENQASM 3.0;
         qubit[2] q1;
         bit[2] c1;
         measure q1[3] -> c1[0];  // out of bounds
@@ -126,7 +126,7 @@ def test_incorrect_measure():
     # Test for out of bounds index for c1
     run_test(
         """
-        OPENQASM 3;
+        OPENQASM 3.0;
         qubit[2] q1;
         bit[2] c1;
         measure q1 -> c1[3];  // out of bounds

--- a/tests/qasm3/test_reset.py
+++ b/tests/qasm3/test_reset.py
@@ -23,7 +23,7 @@ from tests.utils import check_unrolled_qasm
 def test_reset_operations():
     """Test reset operations in different ways"""
     qasm3_string = """
-    OPENQASM 3;
+    OPENQASM 3.0;
     include "stdgates.inc";
 
     // qubit declarations
@@ -38,7 +38,7 @@ def test_reset_operations():
     reset q3[:2];
     """
 
-    expected_qasm = """OPENQASM 3;
+    expected_qasm = """OPENQASM 3.0;
     include "stdgates.inc";
     qubit[1] q1;
     qubit[2] q2;
@@ -56,7 +56,7 @@ def test_reset_operations():
 
 def test_reset_inside_function():
     """Test that a qubit reset inside a function is correctly parsed."""
-    qasm_str = """OPENQASM 3;
+    qasm_str = """OPENQASM 3.0;
     include "stdgates.inc";
 
     def my_function(qubit a) {
@@ -67,7 +67,7 @@ def test_reset_inside_function():
     my_function(q[1]);
     """
 
-    expected_qasm = """OPENQASM 3;
+    expected_qasm = """OPENQASM 3.0;
     include "stdgates.inc";
     qubit[3] q;
     reset q[1];
@@ -79,7 +79,7 @@ def test_reset_inside_function():
 
 def test_incorrect_resets():
     undeclared = """
-    OPENQASM 3;
+    OPENQASM 3.0;
     include "stdgates.inc";
 
     qubit[3] q1;
@@ -91,7 +91,7 @@ def test_incorrect_resets():
         validate(undeclared)
 
     index_error = """
-    OPENQASM 3;
+    OPENQASM 3.0;
     include "stdgates.inc";
 
     qubit[2] q1;


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

## Summary of changes
This pull request updates the version numbers in various files to ensure consistency with the QASM 2.0 and 3.0 specifications. The changes span across multiple files and test cases.

### Version Updates:

* Updated the version number in the `_unrolled_ast` initialization from "2" to "2.0" and from "3" to "3.0". [[1]](diffhunk://#diff-05ef42acb10d44bb317b4b6b62820bf8ec356f6a6ab0a0f35284edad447a35b8L217-R217) [[2]](diffhunk://#diff-05ef42acb10d44bb317b4b6b62820bf8ec356f6a6ab0a0f35284edad447a35b8L291-R291)

* Updated the version number in several test cases from "2" to "2.0" and from "3" to "3.0". 