### PR TITLE
Migrate `remove_idle_qubits` to pyqasm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,53 @@ Types of changes:
 
 ### Added
 - Dependabot configuration file ([#37](https://github.com/qBraid/pyqasm/pull/37))
+- Added support for QASM2 program validation and unrolling ([#46](https://github.com/qBraid/pyqasm/pull/46))
 - Added better typing to linalg module + some tests ([#47](https://github.com/qBraid/pyqasm/pull/47))
+- Added a `remove_idle_qubits` method to the `QasmModule` class which can be used to remove idle qubits from a quantum program ([#58](https://github.com/qBraid/pyqasm/pull/58)). Usage is as follows - 
+
+```python
+In [3]: import pyqasm
+   ...: qasm_str = """OPENQASM 3.0;
+   ...:      gate custom q1, q2, q3{
+   ...:          x q1;
+   ...:          y q2;
+   ...:          z q3;
+   ...:      }
+   ...:      qreg q1[2];
+   ...:      qubit[2] q2;
+   ...:      qubit[3] q3;
+   ...:      qubit q4;
+   ...:      qubit[5]   q5;
+   ...:
+   ...:      x q1[0];
+   ...:      y q2[1];
+   ...:      z q3;"""
+   ...: module = pyqasm.load(qasm_str)
+   ...: module.validate()
+   ...:
+
+In [4]: module.num_qubits
+Out[4]: 13
+
+In [5]: module.remove_idle_qubits()
+Out[5]: <pyqasm.modules.Qasm3Module at 0x1052364b0>
+
+In [6]: module.num_qubits
+Out[6]: 5
+
+In [7]: module.unrolled_qasm.splitlines()
+Out[7]:
+['OPENQASM 3.0;',
+ 'include "stdgates.inc";',
+ 'qubit[1] q1;',
+ 'qubit[1] q2;',
+ 'qubit[3] q3;',
+ 'x q1[0];',
+ 'y q2[0];',
+ 'z q3[0];',
+ 'z q3[1];',
+ 'z q3[2];']
+```
 
 ### Improved / Modified
 - Improved qubit declaration semantics by adding check for quantum registers being declared as predefined constants ([#44](https://github.com/qBraid/pyqasm/pull/44))
@@ -24,6 +70,103 @@ Types of changes:
 - Moved pylint config from pyproject to rcfile, reduced disabled list, and moved disable flags to specific areas where applicable instead of over entire files ([#47](https://github.com/qBraid/pyqasm/pull/47))
 - Consolidated duplicate code from `pyqasm.unroller.py` and `pyqasm.validate.py` into `pyqasm.entrypoint.py` with new `pyqasm.load()` function which returns a `Qasm3Module` ([#47](https://github.com/qBraid/pyqasm/pull/47))
 - Updated examples in `README.md` to show outputs and explain in more detail what's happening in each example ([#47](https://github.com/qBraid/pyqasm/pull/47))
+- Updated the handling of qasm version string by forcing it to be `x.0` ([#48](https://github.com/qBraid/pyqasm/pull/48))
+- **Major Update**: Changed the API for the `unroll` and `validate` functions. Introduced a new `load` function that returns a `QasmModule` object, which can be used to then call `unroll` and `validate`. Also added methods like `remove_measurements`, `remove_barriers`, `has_measurements` and `depth` to the `QasmModule` class ([#49](https://github.com/qBraid/pyqasm/pull/49)). Usage is as follows - 
+
+```python
+In [1]: import pyqasm
+
+In [2]: qasm_str = """OPENQASM 3.0;
+   ...:     gate custom q1, q2, q3{
+   ...:         x q1;
+   ...:         y q2;
+   ...:         z q3;
+   ...:     }
+   ...:     qreg q1[2];
+   ...:     qubit[2] q2;
+   ...:     qubit[3] q3;
+   ...:     qubit q4;
+   ...:     qubit[5]   q5;
+   ...:     qreg qr[3];
+   ...:
+   ...:     x q1[0];
+   ...:     y q2[1];
+   ...:     z q3;
+   ...:
+   ...:
+   ...:     qubit[3] q6;
+   ...:
+   ...:     cx q6[1], q6[2];"""
+
+In [3]: module = pyqasm.load(qasm_str)
+
+In [4]: module.num_qubits
+Out[4]: 19
+
+In [5]: module.num_clbits
+Out[5]: 0
+
+In [6]: module.validate()
+
+In [7]: module.unroll()
+
+In [8]: module.unrolled_qasm.splitlines()
+Out[8]:
+['OPENQASM 3.0;',
+ 'include "stdgates.inc";',
+ 'qubit[2] q1;',
+ 'qubit[2] q2;',
+ 'qubit[3] q3;',
+ 'qubit[1] q4;',
+ 'qubit[5] q5;',
+ 'qubit[3] qr;',
+ 'x q1[0];',
+ 'y q2[1];',
+ 'z q3[0];',
+ 'z q3[1];',
+ 'z q3[2];',
+ 'qubit[3] q6;',
+ 'cx q6[1], q6[2];']
+
+In [9]: module.has_measurements()
+Out[9]: False
+
+In [10]: module.remove_measurements()
+Out[10]: <pyqasm.modules.Qasm3Module at 0x107406540>
+
+In [11]: module.depth()
+Out[11]: 1
+
+```
+
+Users can also choose to pass an `in_place=False` argument to the methods above and get a new `QasmModule` object with the applied changes - 
+
+```python
+In [1]: import pyqasm
+
+In [2]: qasm_str = """OPENQASM 3.0;
+   ...:     gate custom q1, q2, q3{
+   ...:         x q1;
+   ...:         y q2;
+   ...:         z q3;
+   ...:     }
+   ...:     qreg q1[2];
+   ...:     qubit[2] q2;
+   ...:     qubit[3] q3;
+   ...:     qubit q4;
+   ...:     qubit[5]   q5;
+   ...:     qreg qr[3];
+   ...:
+   ...:     x q1[0];
+   ...:     y q2[1];
+   ...:     z q3;"""
+
+In [3]: module = pyqasm.load(qasm_str)
+
+In [4]: module.validate()
+
+In [5]: module_copy = module.remove_measurements(in_place=False)
+```
 
 ### Deprecated
 

--- a/pyqasm/elements.py
+++ b/pyqasm/elements.py
@@ -93,6 +93,12 @@ class QubitDepthNode(DepthNode):
             f"depth = {self.depth})"
         )
 
+    def _total_ops(self):
+        return self.num_resets + self.num_measurements + self.num_gates + self.num_barriers
+
+    def is_idle(self):
+        return self._total_ops() == 0
+
 
 class ClbitDepthNode(DepthNode):
     """Classical bit depth node."""
@@ -106,6 +112,9 @@ class ClbitDepthNode(DepthNode):
             f"ClbitDepthNode(reg_name = {self.reg_name}, reg_index = {self.reg_index},"
             f" depth = {self.depth})"
         )
+
+    def is_idle(self):
+        return self.num_measurements == 0
 
 
 # pylint: disable-next=too-many-instance-attributes

--- a/pyqasm/maps.py
+++ b/pyqasm/maps.py
@@ -26,8 +26,11 @@ from openqasm3.ast import (
     Identifier,
     IndexedIdentifier,
     IntType,
+    QuantumBarrier,
     QuantumGate,
     QuantumGateDefinition,
+    QuantumMeasurementStatement,
+    QuantumReset,
     QubitDeclaration,
     SubroutineDefinition,
     UintType,
@@ -863,3 +866,5 @@ SWITCH_BLACKLIST_STMTS = {
 }
 
 SUPPORTED_QASM_VERSIONS = {"3.0", "3", "2", "2.0"}
+
+QUANTUM_STATEMENTS = (QuantumGate, QuantumBarrier, QuantumReset, QuantumMeasurementStatement)

--- a/pyqasm/visitor.py
+++ b/pyqasm/visitor.py
@@ -297,7 +297,8 @@ class QasmVisitor:
 
         self._label_scope_level[self._curr_scope].add(register_name)
 
-        self._module._add_qubits(register_size)
+        self._module._add_qubit_register(register_name, register_size)
+
         logger.debug("Added labels for register '%s'", str(register))
 
         if self._check_only:
@@ -1006,7 +1007,7 @@ class QasmVisitor:
                     else qasm3_ast.IntegerLiteral(base_size)
                 )
             statements.append(statement)
-            self._module._add_classical_bits(base_size)
+            self._module._add_classical_register(var_name, base_size)
 
         return statements
 

--- a/tests/qasm3/test_transformations.py
+++ b/tests/qasm3/test_transformations.py
@@ -1,0 +1,91 @@
+# Copyright (C) 2024 qBraid
+#
+# This file is part of pyqasm
+#
+# Pyqasm is free software released under the GNU General Public License v3
+# or later. You can redistribute and/or modify it under the terms of the GPL v3.
+# See the LICENSE file in the project root or <https://www.gnu.org/licenses/gpl-3.0.html>.
+#
+# THERE IS NO WARRANTY for pyqasm, as per Section 15 of the GPL v3.
+
+"""
+Module containing unit tests for transformations on qasm3 programs 
+
+"""
+
+from pyqasm.entrypoint import load
+from tests.utils import check_unrolled_qasm
+
+
+def test_remove_idle_qubits_qasm3_small():
+    """Test that remove_idle_qubits for qasm3 string"""
+    qasm3_str = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[4] q;
+    h q[1];
+    cx q[1], q[3];
+    """
+
+    expected_qasm3_str = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    h q[0];
+    cx q[0], q[1];
+    """
+    module = load(qasm3_str)
+    assert module.num_qubits == 4
+    module.remove_idle_qubits()
+    assert module.num_qubits == 2
+    check_unrolled_qasm(module.unrolled_qasm, expected_qasm3_str)
+
+
+def test_remove_idle_qubits_qasm3():
+    """Test conversion of qasm3 to compressed contiguous qasm3"""
+    qasm3_str = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    gate custom q1, q2, q3{
+        x q1;
+        y q2;
+        z q3;
+    }
+    qreg q1[2];
+    qubit[2] q2;
+    qubit[3] q3;
+    qubit q4;
+    qubit[5]   q5;
+    qreg qr[3];
+    
+    x q1[0];
+    y q2[1];
+    z q3;
+    
+    
+    qubit[3] q6;
+    
+    cx q6[1], q6[2];
+    """
+
+    expected_qasm3_str = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[1] q1;
+    qubit[1] q2;
+    qubit[3] q3;
+    x q1[0];
+    y q2[0];
+    z q3[0];
+    z q3[1];
+    z q3[2];
+    qubit[2] q6;
+    cx q6[0], q6[1];
+    """
+
+    module = load(qasm3_str)
+    assert module.num_qubits == 19
+    module.remove_idle_qubits()
+    assert module.num_qubits == 7
+
+    check_unrolled_qasm(module.unrolled_qasm, expected_qasm3_str)


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->
Fixes #55

## Summary of changes

### Enhancements to `pyqasm/elements.py`:

* Added `_total_ops` and `is_idle` methods to calculate total operations and check if a node is idle. (`pyqasm/elements.py`, [pyqasm/elements.pyR96-R101](diffhunk://#diff-05ef42acb10d44bb317b4b6b62820bf8ec356f6a6ab0a0f35284edad447a35b8R96-R101))
* Added `is_idle` method for classical nodes to check they have no measurements. (`pyqasm/elements.py`, [pyqasm/elements.pyR116-R118](diffhunk://#diff-05ef42acb10d44bb317b4b6b62820bf8ec356f6a6ab0a0f35284edad447a35b8R116-R118))

### Changes to`pyqasm/modules.py`:

* Introduced `_qubit_registers` and `_classical_registers` dictionaries to manage registers. (`pyqasm/modules.py`, [pyqasm/modules.pyR43-R46](diffhunk://#diff-bf90adbe7344704cc0abdd5a37bd542dc9a8cf0b173f322b1cb472729dc0f0c9R43-R46))
* Renamed methods to `_add_qubit_register` and `_add_classical_register` for better clarity and added logic to update register sizes. (`pyqasm/modules.py`, [[1]](diffhunk://#diff-bf90adbe7344704cc0abdd5a37bd542dc9a8cf0b173f322b1cb472729dc0f0c9L69-R72) [[2]](diffhunk://#diff-bf90adbe7344704cc0abdd5a37bd542dc9a8cf0b173f322b1cb472729dc0f0c9L93-R97)
* Added `_remap_qubits` method to handle the remapping of qubits after removing idle ones and added `remove_idle_qubits` method to utilize this. (`pyqasm/modules.py`, [pyqasm/modules.pyL261-R365](diffhunk://#diff-bf90adbe7344704cc0abdd5a37bd542dc9a8cf0b173f322b1cb472729dc0f0c9L261-R365))

### Updates to visitor methods:

* Modified `_visit_quantum_register` and `_visit_classical_declaration` to use the new register methods. (`pyqasm/visitor.py`, [[1]](diffhunk://#diff-5b26d2cb7dbbf506dbaa06405eeb8e9b44a0786e2ac64ede3787b3e96a964207L300-R301) [[2]](diffhunk://#diff-5b26d2cb7dbbf506dbaa06405eeb8e9b44a0786e2ac64ede3787b3e96a964207L1009-R1010)