### PR TITLE
Add `reverse_qubit_order` to `QasmModule`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,49 @@ Out[7]:
  'z q3[2];']
 ```
 
+- Implemented the `reverse_qubit_order` method to the `QasmModule` class which can be used to reverse the order of qubits in a quantum program ([#60](https://github.com/qBraid/pyqasm/pull/60)). Usage is as follows - 
+
+```python
+In [3]: import pyqasm
+
+In [4]: qasm3_str = """
+   ...:     OPENQASM 3.0;
+   ...:     include "stdgates.inc";
+   ...:     qubit[2] q;
+   ...:     qubit[4] q2;
+   ...:     qubit q3;
+   ...:     bit[1] c;
+   ...:
+   ...:     cnot q[0], q[1];
+   ...:     cnot q2[0], q2[1];
+   ...:     x q2[3];
+   ...:     cnot q2[0], q2[2];
+   ...:     x q3;
+   ...:     c[0] = measure q2[0];
+   ...:     """
+
+In [5]: module = pyqasm.load(qasm3_str)
+
+In [6]: module.reverse_qubit_order()
+Out[6]: <pyqasm.modules.Qasm3Module at 0x105bc9ac0>
+
+In [7]: module.unrolled_qasm.splitlines()
+Out[7]:
+['OPENQASM 3.0;',
+ 'include "stdgates.inc";',
+ 'qubit[2] q;',
+ 'qubit[4] q2;',
+ 'qubit[1] q3;',
+ 'bit[1] c;',
+ 'cx q[1], q[0];',
+ 'cx q2[3], q2[2];',
+ 'x q2[0];',
+ 'cx q2[3], q2[1];',
+ 'x q3[0];',
+ 'c[0] = measure q2[3];']
+ ```
+
+
 ### Improved / Modified
 - Improved qubit declaration semantics by adding check for quantum registers being declared as predefined constants ([#44](https://github.com/qBraid/pyqasm/pull/44))
 - Updated pre-release scripts + workflow ([#47](https://github.com/qBraid/pyqasm/pull/47))

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -118,9 +118,12 @@ Example
    result = measure q;
    """
 
-   unrolled = pyqasm.unroll(qasm)
+   module = pyqasm.load(qasm)
+   module.unroll()
 
-   print(unrolled)
+   unrolled_qasm = module.unrolled_qasm
+
+   print(unrolled_qasm)
 
 .. code-block:: bash
 

--- a/examples/unroll_example.py
+++ b/examples/unroll_example.py
@@ -11,7 +11,7 @@
 # pylint: disable=invalid-name
 
 """
-Script demonstrating how to unroll a QASM 3 program using the `pyqasm.unrolll` function.
+Script demonstrating how to unroll a QASM 3 program using pyqasm.
 
 """
 

--- a/examples/validate_example.py
+++ b/examples/validate_example.py
@@ -11,7 +11,7 @@
 # pylint: disable=invalid-name
 
 """
-Script demonstrating how to validate a QASM 3 program using the `pyqasm.validate` function.
+Script demonstrating how to validate a QASM 3 program using pyqasm.
 
 """
 

--- a/pyqasm/analyzer.py
+++ b/pyqasm/analyzer.py
@@ -25,6 +25,7 @@ from openqasm3.ast import (
     IndexExpression,
     IntegerLiteral,
     IntType,
+    QuantumMeasurementStatement,
     RangeDefinition,
 )
 from openqasm3.parser import QASM3ParsingError
@@ -184,6 +185,29 @@ class Qasm3Analyzer:
             slice(start, end + 1, step) if start != end else start for start, end, step in indices
         )
         return multi_dim_arr[slicing]  # type: ignore[index]
+
+    @staticmethod
+    def get_op_bit_list(operation):
+        """
+        Get the list of qubits associated with an operation.
+
+        Args:
+            operation (QuantumOperation): The quantum operation.
+
+        Returns:
+            list: The list of qubits associated with the operation.
+        """
+        bit_list = []
+        if isinstance(operation, QuantumMeasurementStatement):
+            assert operation.target is not None
+            bit_list = [operation.measure.qubit]
+        else:
+            bit_list = (
+                operation.qubits
+                if isinstance(operation.qubits, list)
+                else [operation.qubits]  # type: ignore[assignment]
+            )
+        return bit_list
 
     @staticmethod
     def extract_qasm_version(qasm: str) -> int:  # type: ignore # pylint: disable=R1710

--- a/tests/qasm3/test_transformations.py
+++ b/tests/qasm3/test_transformations.py
@@ -89,3 +89,38 @@ def test_remove_idle_qubits_qasm3():
     assert module.num_qubits == 7
 
     check_unrolled_qasm(module.unrolled_qasm, expected_qasm3_str)
+
+
+def test_reverse_qubit_order_qasm3():
+    """Test the reverse qubit ordering function for qasm3 string"""
+    qasm3_str = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    qubit[4] q2;
+    qubit q3;
+
+    cnot q[0], q[1];
+    cnot q2[0], q2[1];
+    x q2[3];
+    cnot q2[0], q2[2];
+    x q3;
+    """
+
+    expected_qasm3_str = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    qubit[4] q2;
+    qubit[1] q3;
+
+    cx q[1], q[0];
+    cx q2[3], q2[2];
+    x q2[0];
+    cx q2[3], q2[1];
+    x q3[0];
+    """
+
+    module = load(qasm3_str)
+    module.reverse_qubit_order()
+    check_unrolled_qasm(module.unrolled_qasm, expected_qasm3_str)

--- a/tests/qasm3/test_transformations.py
+++ b/tests/qasm3/test_transformations.py
@@ -99,12 +99,14 @@ def test_reverse_qubit_order_qasm3():
     qubit[2] q;
     qubit[4] q2;
     qubit q3;
+    bit[1] c; 
 
     cnot q[0], q[1];
     cnot q2[0], q2[1];
     x q2[3];
     cnot q2[0], q2[2];
     x q3;
+    c[0] = measure q2[0];
     """
 
     expected_qasm3_str = """
@@ -113,12 +115,15 @@ def test_reverse_qubit_order_qasm3():
     qubit[2] q;
     qubit[4] q2;
     qubit[1] q3;
+    bit[1] c;
 
     cx q[1], q[0];
     cx q2[3], q2[2];
     x q2[0];
     cx q2[3], q2[1];
     x q3[0];
+
+    c[0] = measure q2[3];
     """
 
     module = load(qasm3_str)


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

## Summary of changes

### Documentation updates:
* [`docs/index.rst`](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534L121-R126): Updated the example to use the `pyqasm.load` method instead of `pyqasm.unroll` and adjusted the variable names accordingly.
* [`examples/unroll_example.py`](diffhunk://#diff-643463ca132721b1f7223229b13c5228c48631fb8b7e0924acf3da7286165fddL14-R14): Updated the script description to reflect the use of `pyqasm` instead of `pyqasm.unroll`.
* [`examples/validate_example.py`](diffhunk://#diff-e94a0794e03de73822f8272042334375e3dfa9c1db1f20cd332175f7867c20bfL14-R14): Updated the script description to reflect the use of `pyqasm` instead of `pyqasm.validate`.

### Code enhancements:
* [`pyqasm/analyzer.py`](diffhunk://#diff-8e5d9175c923fd56ad629984ae100f4853c368e09c8988925ea1f5f0e9c18fc2R28): Added the `get_op_bit_list` method to retrieve the list of qubits associated with an operation. [[1]](diffhunk://#diff-8e5d9175c923fd56ad629984ae100f4853c368e09c8988925ea1f5f0e9c18fc2R28) [[2]](diffhunk://#diff-8e5d9175c923fd56ad629984ae100f4853c368e09c8988925ea1f5f0e9c18fc2R189-R211)
* [`pyqasm/modules.py`](diffhunk://#diff-bf90adbe7344704cc0abdd5a37bd542dc9a8cf0b173f322b1cb472729dc0f0c9R24): Refactored the `_remap_qubits` method to use the new `Qasm3Analyzer.get_op_bit_list` method and implemented the `reverse_qubit_order` method to support in-place reversal and return a new module if requested. [[1]](diffhunk://#diff-bf90adbe7344704cc0abdd5a37bd542dc9a8cf0b173f322b1cb472729dc0f0c9R24) [[2]](diffhunk://#diff-bf90adbe7344704cc0abdd5a37bd542dc9a8cf0b173f322b1cb472729dc0f0c9L299-R300) [[3]](diffhunk://#diff-bf90adbe7344704cc0abdd5a37bd542dc9a8cf0b173f322b1cb472729dc0f0c9L372-R417)

### Testing:
* [`tests/qasm3/test_transformations.py`](diffhunk://#diff-354b13fcbf2bfc7c297ac3676001e4573d5f884a24a7bb9f839599f25adc5480R92-R126): Added a new test function `test_reverse_qubit_order_qasm3` to verify the functionality of the `reverse_qubit_order` method.