### PR TITLE
Add `populate_idle_qubits`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Types of changes:
 
 ### Added
 - Added a `dumps` and `formatted_qasm` method to the `QasmModule` class to allow for the conversion of a `QasmModule` object to a string representation of the QASM code ([#71](https://github.com/qBraid/pyqasm/pull/71))
+- Added the `populate_idle_qubits` method to the `QasmModule` class to populate idle qubits with an `id` gate ([#72](https://github.com/qBraid/pyqasm/pull/72))
 
 ### Improved / Modified
 - Changed the `__init__` method for the `QasmModule` class to only accept an `openqasm3.ast.Program` object as input ([#71](https://github.com/qBraid/pyqasm/pull/71))

--- a/pyqasm/visitor.py
+++ b/pyqasm/visitor.py
@@ -465,28 +465,31 @@ class QasmVisitor:
                 span=statement.span,
             )
         unrolled_measurements = []
-        if not self._check_only:
-            for src_id, tgt_id in zip(source_ids, target_ids):
-                unrolled_measure = qasm3_ast.QuantumMeasurementStatement(
-                    measure=qasm3_ast.QuantumMeasurement(qubit=src_id), target=tgt_id
-                )
-                src_name, src_id = src_id.name.name, src_id.indices[0][0].value  # type: ignore
-                tgt_name, tgt_id = tgt_id.name.name, tgt_id.indices[0][0].value  # type: ignore
+        for src_id, tgt_id in zip(source_ids, target_ids):
+            unrolled_measure = qasm3_ast.QuantumMeasurementStatement(
+                measure=qasm3_ast.QuantumMeasurement(qubit=src_id), target=tgt_id
+            )
+            src_name, src_id = src_id.name.name, src_id.indices[0][0].value  # type: ignore
+            tgt_name, tgt_id = tgt_id.name.name, tgt_id.indices[0][0].value  # type: ignore
 
-                qubit_node, clbit_node = (
-                    self._module._qubit_depths[(src_name, src_id)],
-                    self._module._clbit_depths[(tgt_name, tgt_id)],
-                )
-                qubit_node.depth += 1
-                qubit_node.num_measurements += 1
+            qubit_node, clbit_node = (
+                self._module._qubit_depths[(src_name, src_id)],
+                self._module._clbit_depths[(tgt_name, tgt_id)],
+            )
+            qubit_node.depth += 1
+            qubit_node.num_measurements += 1
 
-                clbit_node.depth += 1
-                clbit_node.num_measurements += 1
+            clbit_node.depth += 1
+            clbit_node.num_measurements += 1
 
-                qubit_node.depth = max(qubit_node.depth, clbit_node.depth)
-                clbit_node.depth = max(qubit_node.depth, clbit_node.depth)
+            qubit_node.depth = max(qubit_node.depth, clbit_node.depth)
+            clbit_node.depth = max(qubit_node.depth, clbit_node.depth)
 
-                unrolled_measurements.append(unrolled_measure)
+            unrolled_measurements.append(unrolled_measure)
+
+        if self._check_only:
+            return []
+
         return unrolled_measurements
 
     def _visit_reset(self, statement: qasm3_ast.QuantumReset) -> list[qasm3_ast.QuantumReset]:
@@ -511,17 +514,20 @@ class QasmVisitor:
         qubit_ids = self._get_op_bits(statement, self._global_qreg_size_map, True)
 
         unrolled_resets = []
-        if not self._check_only:
-            for qid in qubit_ids:
-                unrolled_reset = qasm3_ast.QuantumReset(qubits=qid)
+        for qid in qubit_ids:
+            unrolled_reset = qasm3_ast.QuantumReset(qubits=qid)
 
-                qubit_name, qubit_id = qid.name.name, qid.indices[0][0].value  # type: ignore
-                qubit_node = self._module._qubit_depths[(qubit_name, qubit_id)]
+            qubit_name, qubit_id = qid.name.name, qid.indices[0][0].value  # type: ignore
+            qubit_node = self._module._qubit_depths[(qubit_name, qubit_id)]
 
-                qubit_node.depth += 1
-                qubit_node.num_resets += 1
+            qubit_node.depth += 1
+            qubit_node.num_resets += 1
 
-                unrolled_resets.append(unrolled_reset)
+            unrolled_resets.append(unrolled_reset)
+
+        if self._check_only:
+            return []
+
         return unrolled_resets
 
     def _visit_barrier(self, barrier: qasm3_ast.QuantumBarrier) -> list[qasm3_ast.QuantumBarrier]:
@@ -548,25 +554,25 @@ class QasmVisitor:
             )
         barrier_qubits = self._get_op_bits(barrier, self._global_qreg_size_map)
         unrolled_barriers = []
-        if not self._check_only:
-            max_involved_depth = 0
-            for qubit in barrier_qubits:
-                unrolled_barrier = qasm3_ast.QuantumBarrier(
-                    qubits=[qubit]  # type: ignore[list-item]
-                )
-                qubit_name, qubit_id = qubit.name.name, qubit.indices[0][0].value  # type: ignore
-                qubit_node = self._module._qubit_depths[(qubit_name, qubit_id)]
+        max_involved_depth = 0
+        for qubit in barrier_qubits:
+            unrolled_barrier = qasm3_ast.QuantumBarrier(qubits=[qubit])  # type: ignore[list-item]
+            qubit_name, qubit_id = qubit.name.name, qubit.indices[0][0].value  # type: ignore
+            qubit_node = self._module._qubit_depths[(qubit_name, qubit_id)]
 
-                qubit_node.depth += 1
-                qubit_node.num_barriers += 1
+            qubit_node.depth += 1
+            qubit_node.num_barriers += 1
 
-                max_involved_depth = max(max_involved_depth, qubit_node.depth)
-                unrolled_barriers.append(unrolled_barrier)
+            max_involved_depth = max(max_involved_depth, qubit_node.depth)
+            unrolled_barriers.append(unrolled_barrier)
 
-            for qubit in barrier_qubits:
-                qubit_name, qubit_id = qubit.name.name, qubit.indices[0][0].value  # type: ignore
-                qubit_node = self._module._qubit_depths[(qubit_name, qubit_id)]
-                qubit_node.depth = max_involved_depth
+        for qubit in barrier_qubits:
+            qubit_name, qubit_id = qubit.name.name, qubit.indices[0][0].value  # type: ignore
+            qubit_node = self._module._qubit_depths[(qubit_name, qubit_id)]
+            qubit_node.depth = max_involved_depth
+
+        if self._check_only:
+            return []
 
         return unrolled_barriers
 
@@ -651,8 +657,7 @@ class QasmVisitor:
             op_parameters = self._get_op_parameters(operation)
             if inverse_action == InversionOp.INVERT_ROTATION:
                 op_parameters = [-1 * param for param in op_parameters]
-        if self._check_only:
-            return []
+
         result = []
         for i in range(0, len(op_qubits), op_qubit_count):
             # we apply the gate on the qubit subset linearly
@@ -754,6 +759,7 @@ class QasmVisitor:
                 )
 
         self._restore_context()
+
         if self._check_only:
             return []
 
@@ -826,6 +832,7 @@ class QasmVisitor:
                 result.extend(self._visit_custom_gate_operation(operation, inverse_value))
             else:
                 result.extend(self._visit_basic_gate_operation(operation, inverse_value))
+
         if self._check_only:
             return []
 
@@ -880,6 +887,9 @@ class QasmVisitor:
         variable.value = Qasm3Validator.validate_variable_assignment_value(variable, init_value)
 
         self._add_var_in_scope(variable)
+
+        if self._check_only:
+            return []
 
         return statements
 
@@ -1009,6 +1019,9 @@ class QasmVisitor:
             statements.append(statement)
             self._module._add_classical_register(var_name, base_size)
 
+        if self._check_only:
+            return []
+
         return statements
 
     def _visit_classical_assignment(
@@ -1096,6 +1109,9 @@ class QasmVisitor:
         else:
             lvar.value = rvalue_eval  # type: ignore[union-attr]
         self._update_var_in_scope(lvar)  # type: ignore[arg-type]
+
+        if self._check_only:
+            return []
 
         return statements
 
@@ -1386,6 +1402,9 @@ class QasmVisitor:
         del self._label_scope_level[self._curr_scope]
         self._curr_scope -= 1
         self._pop_scope()
+
+        if self._check_only:
+            return return_value, []
 
         return return_value, result
 

--- a/tests/qasm3/test_transformations.py
+++ b/tests/qasm3/test_transformations.py
@@ -129,3 +129,88 @@ def test_reverse_qubit_order_qasm3():
     module = load(qasm3_str)
     module.reverse_qubit_order()
     check_unrolled_qasm(module.dumps(), expected_qasm3_str)
+
+
+def test_populate_idle_qubits_qasm3():
+    """Test the populate idle qubits function for qasm3 string"""
+
+    qasm3_str = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    qubit[4] q2;
+    qubit q3;
+    bit[1] c;
+
+    cnot q;
+    """
+
+    expected_qasm3_str = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    qubit[4] q2;
+    qubit[1] q3;
+    bit[1] c;
+
+    cnot q;
+    id q2[0];
+    id q2[1];
+    id q2[2];
+    id q2[3];
+    id q3[0];
+    """
+
+    module = load(qasm3_str)
+    module.populate_idle_qubits()
+    check_unrolled_qasm(module.dumps(), expected_qasm3_str)
+
+
+def test_populate_idle_qubits_for_no_idle_qubits():
+    """Test the populate idle qubits function for qasm3 string"""
+
+    qasm3_str = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    qubit[4] q2;
+    qubit q3;
+    bit[1] c;
+
+    h q;
+    h q2;
+    h q3;
+    """
+    # no change in the qasm
+    expected_qasm3_str = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    qubit[4] q2;
+    qubit[1] q3;
+    bit[1] c;
+    
+    h q;
+    h q2;
+    h q3;
+    """
+
+    module = load(qasm3_str)
+    module.populate_idle_qubits()
+    check_unrolled_qasm(module.dumps(), expected_qasm3_str)
+
+
+def test_populate_idle_qubits_increases_depth_by_one():
+    """Test that the depth of the program increases by one when populating idle qubits"""
+    qasm3_str = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    qubit[4] q2;
+    qubit q3;
+    
+    """
+    module = load(qasm3_str)
+    original_depth = module.depth()
+    module.populate_idle_qubits()
+    assert module.depth() == original_depth + 1


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

## Summary of changes

### New functionalities for idle qubits:
* Added `_get_idle_qubit_indices` method to retrieve indices of idle qubits (`pyqasm/modules/base.py`).
* Introduced `populate_idle_qubits` method to populate idle qubits with identity gates (`pyqasm/modules/base.py`).

### Modifications to existing methods:
* Updated `remove_idle_qubits` to use the new `_get_idle_qubit_indices` method (`pyqasm/modules/base.py`).

### Visitor pattern enhancements:
* Refactored checks for `_check_only` mode in various visitor methods to return early if the check-only mode is enabled. This ensures that depth calculations are executed even if we are in the check-only mode. 

### Testing:
* Added new tests for the `populate_idle_qubits` method to ensure correct functionality and depth handling (`tests/qasm3/test_transformations.py`).