### PR TITLE
Add `rebase` functionality to `QasmModule`

### DIFF
--- a/pyqasm/elements.py
+++ b/pyqasm/elements.py
@@ -162,3 +162,21 @@ class Variable:
             f"value = {self.value}, is_constant = {self.is_constant}, "
             f"readonly = {self.readonly}, is_register = {self.is_register})"
         )
+
+
+class BasisSet(Enum):
+    """
+    Enum for the different basis sets in Qasm.
+    """
+
+    DEFAULT = 0
+    TOFFOLI = 1
+    CLIFFORD = 2
+    PAULI = 3
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__}.{self.name}: {self.value}>"
+
+    @staticmethod
+    def get_supported_bases():
+        return list(BasisSet)

--- a/pyqasm/maps.py
+++ b/pyqasm/maps.py
@@ -36,7 +36,7 @@ from openqasm3.ast import (
     UintType,
 )
 
-from pyqasm.elements import InversionOp
+from pyqasm.elements import BasisSet, InversionOp
 from pyqasm.exceptions import ValidationError
 from pyqasm.linalg import kak_decomposition_angles
 
@@ -689,6 +689,31 @@ THREE_QUBIT_OP_MAP = {
     "ccx": ccx_gate_op,
     "ccnot": ccx_gate_op,
     "cswap": cswap_gate,
+}
+
+BASIS_GATE_MAP = {
+    # default basis set is the gate set of the stdgates.inc library file
+    BasisSet.DEFAULT: {
+        "id",
+        "rx",
+        "ry",
+        "rz",
+        "h",
+        "x",
+        "y",
+        "z",
+        "s",
+        "sx",
+        "t",
+        "sdg",
+        "tdg",
+        "cx",
+        "cz",
+        "swap",
+    },
+    BasisSet.CLIFFORD: {"h", "t", "s", "cx"},
+    BasisSet.PAULI: {"rx", "ry", "rz", "cx"},
+    BasisSet.TOFFOLI: {"h", "ccx"},
 }
 
 

--- a/pyqasm/modules/base.py
+++ b/pyqasm/modules/base.py
@@ -20,7 +20,7 @@ import openqasm3.ast as qasm3_ast
 from openqasm3.ast import Include, Program
 
 from pyqasm.analyzer import Qasm3Analyzer
-from pyqasm.elements import ClbitDepthNode, QubitDepthNode
+from pyqasm.elements import BasisSet, ClbitDepthNode, QubitDepthNode
 from pyqasm.exceptions import UnrollError, ValidationError
 from pyqasm.maps import QUANTUM_STATEMENTS
 from pyqasm.visitor import QasmVisitor
@@ -443,6 +443,41 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
         qasm_module._statements = qasm_module._unrolled_ast.statements
 
         # 4. return the module
+        return qasm_module
+
+    def _transform_to_basis(self, basis_set: BasisSet):
+        """Transform the unrolled module to a new basis set
+
+        Args:
+            basis_set (BasisSet): The basis set to transform the module to
+
+        Returns:
+            None
+        """
+        if basis_set == BasisSet.DEFAULT:
+            return
+        
+
+    def rebase(self, basis_set: BasisSet = BasisSet.DEFAULT, in_place=True):
+        """Rebases an openqasm program to a new gate set.
+        Will unroll the module if not already done.
+
+        Args:
+            basis_set (BasisSet): The new gate set to rebase the program to.
+
+        Returns:
+            QasmModule: The module rebased to the new gate set. If in_place is False, a new module
+                        with the rebased gate set is returned.
+
+        """
+
+        if not isinstance(basis_set, BasisSet):
+            raise TypeError(f"'gate_set' must be one of {BasisSet.get_supported_bases()}")
+
+        qasm_module = self if in_place else self.copy()
+        qasm_module.unroll()
+        qasm_module._transform_to_basis(basis_set)
+
         return qasm_module
 
     def validate(self):


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

Fixes #66 

## Summary of changes
This PR migrates the `rebase` functionality to the `QasmModule` 

- Note that the essence of `rebase` is to change the "basis set" of the program and the original implementation did not cater to the universality of the supplied gate set. Thus, it is proposed to use a [fixed number of basis gate sets](https://github.com/qBraid/pyqasm/compare/migrate-rebase?expand=1#diff-05ef42acb10d44bb317b4b6b62820bf8ec356f6a6ab0a0f35284edad447a35b8R167) out of which the user can choose to "rebase". 
- The user call to `rebase` would then change the basis set to one of the supported basis sets in pyqasm. 

