### PR TITLE
Add gate definitions to `maps.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Types of changes:
 
 ### Added
 - Added a `dumps` and `formatted_qasm` method to the `QasmModule` class to allow for the conversion of a `QasmModule` object to a string representation of the QASM code ([#71](https://github.com/qBraid/pyqasm/pull/71))
+- Added gate definitions for "c3sqrtx", "u1", "rxx", "cu3", "csx", "rccx" , "ch" , "cry", "cp", "cu", "cu1", "rzz" in `maps.py` ([#74](https://github.com/qBraid/pyqasm/pull/74))
 
 ### Improved / Modified
 - Changed the `__init__` method for the `QasmModule` class to only accept an `openqasm3.ast.Program` object as input ([#71](https://github.com/qBraid/pyqasm/pull/71))

--- a/pyqasm/maps.py
+++ b/pyqasm/maps.py
@@ -8,6 +8,8 @@
 #
 # THERE IS NO WARRANTY for pyqasm, as per Section 15 of the GPL v3.
 
+# pylint: disable=too-many-lines
+
 """
 Module mapping supported QASM gates/operations to lower level gate operations.
 
@@ -471,7 +473,7 @@ def crz_gate(
     return result
 
 
-def cu3_gate(
+def cu3_gate(  # pylint: disable=too-many-arguments
     theta: Union[int, float],
     phi: Union[int, float],
     lam: Union[int, float],
@@ -482,7 +484,6 @@ def cu3_gate(
     """
     Implements the CU3 gate as a decomposition of other gates.
     """
-
     result: list[QuantumGate] = []
     result.extend(phaseshift_gate(gamma, qubit0))
     result.extend(phaseshift_gate((lam + phi) / 2, qubit0))
@@ -508,9 +509,9 @@ def csx_gate(qubit0: IndexedIdentifier, qubit1: IndexedIdentifier) -> list[Quant
     Out[21]:
 
     q_0: ──■───
-        ┌─┴──┐
+         ┌─┴──┐
     q_1: ┤ Sx ├
-        └────┘
+         └────┘
 
     In [22]: q.decompose().decompose().draw()
     Out[22]:
@@ -519,9 +520,7 @@ def csx_gate(qubit0: IndexedIdentifier, qubit1: IndexedIdentifier) -> list[Quant
              ├─────────┤┌─┴─┐┌──────────┐┌─┴─┐┌─────────┐┌─────────┐
         q_1: ┤ U2(0,π) ├┤ X ├┤ U1(-π/4) ├┤ X ├┤ U1(π/4) ├┤ U2(0,π) ├
              └─────────┘└───┘└──────────┘└───┘└─────────┘└─────────┘
-
     """
-
     result: list[QuantumGate] = []
     result.extend(phaseshift_gate(CONSTANTS_MAP["pi"] / 4, qubit0))
     result.extend(u2_gate(0, CONSTANTS_MAP["pi"], qubit1))
@@ -603,7 +602,6 @@ def rzz_gate(
     # TODO: verify implementation of the global phase
     # result.extend(phaseshift_gate(-theta/2, qubit0))
     # result.extend(phaseshift_gate(-theta/2, qubit1))
-
     result.extend(two_qubit_gate_op("cx", qubit0, qubit1))
     result.extend(u3_gate(0, 0, theta, qubit1))
     result.extend(two_qubit_gate_op("cx", qubit0, qubit1))
@@ -892,7 +890,6 @@ TWO_QUBIT_OP_MAP = {
     "cu": cu3_gate,
     "cu3": cu3_gate,
     "csx": csx_gate,
-    "rccx": rccx_gate,
     "cphaseshift": cphaseshift_gate,
     "cu1": cphaseshift_gate,
     "cp00": cphaseshift00_gate,
@@ -909,6 +906,7 @@ THREE_QUBIT_OP_MAP = {
     "ccx": ccx_gate_op,
     "ccnot": ccx_gate_op,
     "cswap": cswap_gate,
+    "rccx": rccx_gate,
 }
 
 
@@ -1071,7 +1069,6 @@ ARRAY_TYPE_MAP = {
     BoolType: np.bool_,
     AngleType: np.float64,
 }
-
 
 # Reference : https://openqasm.com/language/types.html#arrays
 MAX_ARRAY_DIMENSIONS = 7

--- a/tests/qasm3/resources/gates.py
+++ b/tests/qasm3/resources/gates.py
@@ -185,7 +185,6 @@ double_op_tests = [_fixture_name(s) for s in TWO_QUBIT_OP_MAP]
 already_tested_double_op = [
     "cv",
     "cy",
-    "ch",
     "xx",
     "xy",
     "yy",

--- a/tests/qasm3/resources/gates.py
+++ b/tests/qasm3/resources/gates.py
@@ -177,7 +177,7 @@ for gate in already_tested_single_op:
     single_op_tests.remove(_fixture_name(gate))
 
 rotation_tests = [_fixture_name(s) for s in ONE_QUBIT_ROTATION_MAP if "u" not in s.lower()]
-already_tested_rotation = ["prx", "phaseshift", "p", "gpi", "gpi2"]
+already_tested_rotation = ["prx", "gpi", "gpi2"]
 for gate in already_tested_rotation:
     rotation_tests.remove(_fixture_name(gate))
 

--- a/tests/qasm3/resources/gates.py
+++ b/tests/qasm3/resources/gates.py
@@ -107,7 +107,7 @@ def _generate_two_qubit_fixture(gate_name: str):
             raise ValueError(f"Unknown qasm3 gate {gate_name}")
 
         theta = ""
-        if gate_name in ["crz", "crx"]:
+        if gate_name in ["crz", "crx", "cry", "rzz", "rxx"]:
             theta = f"({CONTROLLED_ROTATION_ANGLE_1})"
 
         qasm3_string = f"""
@@ -185,16 +185,21 @@ double_op_tests = [_fixture_name(s) for s in TWO_QUBIT_OP_MAP]
 already_tested_double_op = [
     "cv",
     "cy",
+    "ch",
     "xx",
     "xy",
     "yy",
     "zz",
+    "csx",
     "pswap",
     "cp",
     "cp00",
     "cp01",
     "cp10",
     "cphaseshift",
+    "cu1",
+    "cu",
+    "cu3",
     "cphaseshift00",
     "cphaseshift01",
     "cphaseshift10",
@@ -205,7 +210,7 @@ for gate in already_tested_double_op:
     double_op_tests.remove(_fixture_name(gate))
 
 triple_op_tests = [_fixture_name(s) for s in THREE_QUBIT_OP_MAP]
-already_tested_triple_op = ["ccnot", "cswap"]
+already_tested_triple_op = ["ccnot", "cswap", "rccx"]
 for gate in already_tested_triple_op:
     triple_op_tests.remove(_fixture_name(gate))
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -54,6 +54,15 @@ def check_single_qubit_gate_op(unrolled_ast, num_gates, qubit_list, gate_name):
     assert gate_count == num_gates
 
 
+def _check_ch_gate_op(unrolled_ast, num_gates, qubits):
+    check_single_qubit_gate_op(unrolled_ast, num_gates, [qubits[1]] * num_gates, "s")
+    check_single_qubit_gate_op(unrolled_ast, 2 * num_gates, [qubits[1]] * 2 * num_gates, "h")
+    check_single_qubit_gate_op(unrolled_ast, num_gates, [qubits[1]] * num_gates, "t")
+    check_two_qubit_gate_op(unrolled_ast, num_gates, [qubits] * num_gates, "cx")
+    check_single_qubit_gate_op(unrolled_ast, num_gates, [qubits[1]] * num_gates, "tdg")
+    check_single_qubit_gate_op(unrolled_ast, num_gates, [qubits[1]] * num_gates, "sdg")
+
+
 def _check_crx_gate_op(unrolled_ast, num_gates, qubits, theta):
     num_u3_gates = 3 * num_gates
     check_u3_gate_op(
@@ -138,6 +147,9 @@ def check_two_qubit_gate_op(unrolled_ast, num_gates, qubit_list, gate_name):
     if gate_name == "cnot":
         gate_name = "cx"
 
+    controlled_gate_tests = {
+        "ch": _check_ch_gate_op,
+    }
     controlled_rotation_gate_tests = {
         "crx": _check_crx_gate_op,
         "crz": _check_crz_gate_op,
@@ -145,8 +157,9 @@ def check_two_qubit_gate_op(unrolled_ast, num_gates, qubit_list, gate_name):
         "rxx": _check_rxx_gate_op,
         "rzz": _check_rzz_gate_op,
     }
-
-    if gate_name in controlled_rotation_gate_tests:
+    if gate_name in controlled_gate_tests:
+        controlled_gate_tests[gate_name](unrolled_ast, num_gates, qubit_list[0])
+    elif gate_name in controlled_rotation_gate_tests:
         controlled_rotation_gate_tests[gate_name](
             unrolled_ast, num_gates, qubit_list[0], CONTROLLED_ROTATION_ANGLE_1
         )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -219,6 +219,15 @@ def check_u3_gate_op(unrolled_ast, num_gates, qubit_list, param_list):
     assert op_count == num_gates
 
 
+def _check_phase_shift_gate_op(unrolled_ast, num_gates, qubit_list, param_list):
+    num_h_gates = 2 * num_gates
+    h_qubit_list = [qubit for qubit in qubit_list for _ in range(2)]
+    num_rx_gates = 1 * num_gates
+
+    check_single_qubit_gate_op(unrolled_ast, num_h_gates, h_qubit_list, "h")
+    check_single_qubit_rotation_op(unrolled_ast, num_rx_gates, qubit_list, param_list, "rx")
+
+
 def check_measure_op(unrolled_ast, num_ops, meas_pairs):
     """Check that the unrolled ast contains the correct number of measurements.
 
@@ -252,6 +261,9 @@ def check_single_qubit_rotation_op(unrolled_ast, num_gates, qubit_list, param_li
     if gate_name == "u2":
         param_list = [CONSTANTS_MAP["pi"] / 2, param_list[0], param_list[1]]
         check_u3_gate_op(unrolled_ast, num_gates, qubit_list, [param_list])
+        return
+    if gate_name in ["p", "phaseshift"]:
+        _check_phase_shift_gate_op(unrolled_ast, num_gates, qubit_list, param_list)
         return
     qubit_id, param_id, gate_count = 0, 0, 0
     for stmt in unrolled_ast.statements:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -88,17 +88,68 @@ def _check_crz_gate_op(unrolled_ast, num_gates, qubits, theta):
     check_two_qubit_gate_op(unrolled_ast, num_cx_gates, [qubits] * num_u3_gates, "cx")
 
 
+def _check_cry_gate_op(unrolled_ast, num_gates, qubits, theta):
+    num_u3_gates = 2 * num_gates
+    num_cx_gates = 2 * num_gates
+    check_u3_gate_op(
+        unrolled_ast,
+        num_u3_gates,
+        [qubits[1]] * num_u3_gates,
+        [
+            [theta / 2, 0, 0],
+            [-theta / 2, 0, 0],
+        ]
+        * num_gates,
+    )
+    check_two_qubit_gate_op(unrolled_ast, num_cx_gates, [qubits] * num_u3_gates, "cx")
+
+
+def _check_rxx_gate_op(unrolled_ast, num_gates, qubits, theta):
+    num_h_gates = 4 * num_gates
+    # because H is applied as H(q0) H(q1) H(q1) H(q0) in  1 rxx gate
+    h_qubit_list = (qubits + qubits[::-1]) * num_gates
+    num_cx_gates = 2 * num_gates
+    num_rz_gates = num_gates
+    check_single_qubit_gate_op(unrolled_ast, num_h_gates, h_qubit_list, "h")
+    check_two_qubit_gate_op(unrolled_ast, num_cx_gates, [qubits] * num_cx_gates, "cx")
+    check_single_qubit_rotation_op(
+        unrolled_ast, num_rz_gates, [qubits[1]] * num_gates, [theta] * num_gates, "rz"
+    )
+
+
+def _check_rzz_gate_op(unrolled_ast, num_gates, qubits, theta):
+    num_cx_gates = 2 * num_gates
+    num_u3_gates = num_gates
+
+    check_two_qubit_gate_op(unrolled_ast, num_cx_gates, [qubits] * num_cx_gates, "cx")
+    check_u3_gate_op(
+        unrolled_ast,
+        num_u3_gates,
+        [qubits[1]] * num_u3_gates,
+        [
+            [0, 0, theta],
+        ]
+        * num_gates,
+    )
+
+
 def check_two_qubit_gate_op(unrolled_ast, num_gates, qubit_list, gate_name):
     qubit_id, gate_count = 0, 0
     if gate_name == "cnot":
         gate_name = "cx"
 
-    if gate_name == "crx":
-        param = CONTROLLED_ROTATION_ANGLE_1
-        _check_crx_gate_op(unrolled_ast, num_gates, qubit_list[0], param)
-    elif gate_name == "crz":
-        param = CONTROLLED_ROTATION_ANGLE_1
-        _check_crz_gate_op(unrolled_ast, num_gates, qubit_list[0], param)
+    controlled_rotation_gate_tests = {
+        "crx": _check_crx_gate_op,
+        "crz": _check_crz_gate_op,
+        "cry": _check_cry_gate_op,
+        "rxx": _check_rxx_gate_op,
+        "rzz": _check_rzz_gate_op,
+    }
+
+    if gate_name in controlled_rotation_gate_tests:
+        controlled_rotation_gate_tests[gate_name](
+            unrolled_ast, num_gates, qubit_list[0], CONTROLLED_ROTATION_ANGLE_1
+        )
     else:
         for stmt in unrolled_ast.statements:
             if isinstance(stmt, qasm3_ast.QuantumGate) and stmt.name.name == gate_name.lower():
@@ -113,6 +164,7 @@ def check_two_qubit_gate_op(unrolled_ast, num_gates, qubit_list, gate_name):
 
 def check_three_qubit_gate_op(unrolled_ast, num_gates, qubit_list, gate_name):
     qubit_id, gate_count = 0, 0
+
     for stmt in unrolled_ast.statements:
         if isinstance(stmt, qasm3_ast.QuantumGate) and stmt.name.name == gate_name.lower():
             assert len(stmt.qubits) == 3


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->
Fixes #69 

## Summary of changes
This pull request adds several new quantum gate implementations to the `pyqasm` library, along with their respective decompositions into other gates. The changes include the addition of new gate functions and updates to the gate mapping dictionary.

New quantum gate implementations:

* Added `ch_gate` function to implement the CH gate decomposition.
* Added `cry_gate` function to implement the CRY gate decomposition.
* Added `cu3_gate` function to implement the CU3 gate decomposition.
* Added `csx_gate` function to implement the CSX gate decomposition.
* Added `rxx_gate`, `rccx_gate`, and `rzz_gate` functions to implement their respective gate decompositions.

Updates to gate mapping:

* Updated the gate mapping dictionary to include the new gates: `u1`, `U1`, `ch`, `rzz`, `cry`, `rxx`, `cu`, `cu3`, `csx`, `rccx`, and `cu1`. [[1]](diffhunk://#diff-8d578f59e7a96eb1bc542fd42dec5ee0d9efbffbe9c0d0b0a00d098723ddf666R857-R858) [[2]](diffhunk://#diff-8d578f59e7a96eb1bc542fd42dec5ee0d9efbffbe9c0d0b0a00d098723ddf666R880-R897)