### PR TITLE
Update entrypoint methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,15 +18,76 @@ Types of changes:
 - Added a `dumps` and `formatted_qasm` method to the `QasmModule` class to allow for the conversion of a `QasmModule` object to a string representation of the QASM code ([#71](https://github.com/qBraid/pyqasm/pull/71))
 - Added the `populate_idle_qubits` method to the `QasmModule` class to populate idle qubits with an `id` gate ([#72](https://github.com/qBraid/pyqasm/pull/72))
 - Added gate definitions for "c3sqrtx", "u1", "rxx", "cu3", "csx", "rccx" , "ch" , "cry", "cp", "cu", "cu1", "rzz" in `maps.py` ([#74](https://github.com/qBraid/pyqasm/pull/74))
+- Added support for skipping the unrolling for externally linked gates. The `QasmModule.unroll()` method now accepts an `external_gates` parameter which is a list of gate names that should not be unrolled ([#59](https://github.com/qBraid/pyqasm/pull/59)). Usage - 
+
+```python
+In [30]: import pyqasm
+
+In [31]: qasm_str = """OPENQASM 3.0;
+    ...:     include "stdgates.inc";
+    ...:     gate custom q1, q2, q3{
+    ...:         x q1;
+    ...:         y q2;
+    ...:         z q3;
+    ...:     }
+    ...:
+    ...:     qubit[4] q;
+    ...:     custom q[0], q[1], q[2];
+    ...:     cx q[1], q[2];"""
+
+In [32]: module = pyqasm.loads(qasm_str)
+
+In [33]: module.unroll(external_gates= ["custom"])
+
+In [34]: pyqasm.dumps(module).splitlines()
+Out[34]:
+['OPENQASM 3.0;',
+ 'include "stdgates.inc";',
+ 'qubit[4] q;',
+ 'custom q[0], q[1], q[2];',
+ 'cx q[1], q[2];']
+```
+- **Major Change**: Added the `load`, `loads`, `dump`, and `dumps` functions to the `pyqasm` module to allow for the loading and dumping of QASM code ([#76](https://github.com/qBraid/pyqasm/pull/76)). Usage - 
+
+```python
+In [18]: import pyqasm
+
+In [19]: qasm_str = """OPENQASM 3.0;
+    ...:     include "stdgates.inc";
+    ...:     qreg q1[2];
+    ...:     qubit[2] q2;"""
+
+In [20]: module = pyqasm.loads(qasm_str)
+
+In [21]: print(pyqasm.dumps(module))
+OPENQASM 3.0;
+include "stdgates.inc";
+qubit[2] q1;
+qubit[2] q2;
+
+
+In [22]: file_path = "test.qasm"
+
+In [23]: pyqasm.dump(module, file_path)
+
+In [24]: module = pyqasm.load(file_path)
+
+In [25]: print(pyqasm.dumps(module))
+OPENQASM 3.0;
+include "stdgates.inc";
+qubit[2] q1;
+qubit[2] q2;
+```
 
 ### Improved / Modified
 - Changed the `__init__` method for the `QasmModule` class to only accept an `openqasm3.ast.Program` object as input ([#71](https://github.com/qBraid/pyqasm/pull/71))
+- The `load` function has been renamed to `loads` and `load` is now used to load a QASM file. `QasmModule.dumps()` has been renamed to `qasm_str()` ([#76](https://github.com/qBraid/pyqasm/pull/76))
 
 ### Deprecated
 
 ### Removed
 - Removed the `from_program` method from the `QasmModule` class ([#71](https://github.com/qBraid/pyqasm/pull/71))
-
+- `QasmModule.formatted_qasm()` method has been removed ([#76](https://github.com/qBraid/pyqasm/pull/76))
 ### Fixed
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,13 +81,14 @@ qubit[2] q2;
 
 ### Improved / Modified
 - Changed the `__init__` method for the `QasmModule` class to only accept an `openqasm3.ast.Program` object as input ([#71](https://github.com/qBraid/pyqasm/pull/71))
-- The `load` function has been renamed to `loads` and `load` is now used to load a QASM file. `QasmModule.dumps()` has been renamed to `qasm_str()` ([#76](https://github.com/qBraid/pyqasm/pull/76))
+- The `load` function has been renamed to `loads` and `load` is now used to load a QASM file. `QasmModule.dumps()` has been replaced with `__str__` method ([#76](https://github.com/qBraid/pyqasm/pull/76))
 
 ### Deprecated
 
 ### Removed
 - Removed the `from_program` method from the `QasmModule` class ([#71](https://github.com/qBraid/pyqasm/pull/71))
 - `QasmModule.formatted_qasm()` method has been removed ([#76](https://github.com/qBraid/pyqasm/pull/76))
+
 ### Fixed
 
 ### Dependencies

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -118,10 +118,10 @@ Example
    result = measure q;
    """
 
-   module = pyqasm.load(qasm)
+   module = pyqasm.loads(qasm)
    module.unroll()
 
-   unrolled_qasm = module.dumps()
+   unrolled_qasm = pyqasm.dumps(module)
 
    print(unrolled_qasm)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,9 +30,9 @@ bit[4] result;
 result = measure q;
 """
 
-qasm_module = pyqasm.load(program)
+qasm_module = pyqasm.loads(program)
 qasm_module.unroll()
-print(qasm_module.dumps())
+print(pyqasm.dumps(qasm_module))
 ```
 
 ```text
@@ -81,7 +81,7 @@ h q[2];
 c = measure q;
 """
 
-pyqasm.load(program).validate()
+pyqasm.loads(program).validate()
 ```
 
 ```text

--- a/examples/unroll_example.py
+++ b/examples/unroll_example.py
@@ -70,7 +70,7 @@ bit[4] result;
 result = measure q;
 """
 
-qasm_module = pyqasm.load(qasm_program)
+qasm_module = pyqasm.loads(qasm_program)
 qasm_module.unroll()
 
-print(qasm_module.dumps())
+print(pyqasm.dumps(qasm_module))

--- a/examples/validate_example.py
+++ b/examples/validate_example.py
@@ -84,4 +84,4 @@ for int i in [0:N-1] {
 c = measure q;
 """
 
-pyqasm.load(qasm_program).validate()
+pyqasm.loads(qasm_program).validate()

--- a/pyqasm/__init__.py
+++ b/pyqasm/__init__.py
@@ -20,6 +20,9 @@ Functions
    :toctree: ../stubs/
 
    load
+   loads
+   dump
+   dumps
 
 Classes
 ---------
@@ -51,7 +54,7 @@ except ImportError:  # pragma: no cover
     warnings.warn("Importing 'pyqasm' outside a proper installation.")
     __version__ = "dev"
 
-from .entrypoint import load
+from .entrypoint import dump, dumps, load, loads
 from .exceptions import PyQasmError, QasmParsingError, ValidationError
 from .modules import Qasm2Module, Qasm3Module, QasmModule
 
@@ -60,6 +63,9 @@ __all__ = [
     "ValidationError",
     "QasmParsingError",
     "load",
+    "loads",
+    "dump",
+    "dumps",
     "QasmModule",
     "Qasm2Module",
     "Qasm3Module",

--- a/pyqasm/entrypoint.py
+++ b/pyqasm/entrypoint.py
@@ -26,18 +26,35 @@ if TYPE_CHECKING:
     import openqasm3.ast
 
 
-def load(program: openqasm3.ast.Program | str) -> QasmModule:
-    """Loads an OpenQASM 3 program into a `Qasm3Module` object.
+def load(filename: str) -> QasmModule:
+    """Loads an OpenQASM program into a `QasmModule` object.
 
     Args:
-        program (openqasm3.ast.Program or str): The OpenQASM 3 program to validate.
+        filename (str): The filename of the OpenQASM program to validate.
+
+    Returns:
+        QasmModule: An object containing the parsed qasm representation along with
+            some useful metadata and methods
+    """
+    if not isinstance(filename, str):
+        raise TypeError("Input 'filename' must be of type 'str'.")
+    with open(filename, "r", encoding="utf-8") as file:
+        program = file.read()
+    return loads(program)
+
+
+def loads(program: openqasm3.ast.Program | str) -> QasmModule:
+    """Loads an OpenQASM program into a `QasmModule` object.
+
+    Args:
+        program (openqasm3.ast.Program or str): The OpenQASM program to validate.
 
     Raises:
         TypeError: If the input is not a string or an `openqasm3.ast.Program` instance.
         ValidationError: If the program fails parsing or semantic validation.
 
     Returns:
-        Qasm3Module: An object containing the parsed qasm representation along with
+        QasmModule: An object containing the parsed qasm representation along with
             some useful metadata and methods
     """
     if isinstance(program, str):
@@ -48,7 +65,10 @@ def load(program: openqasm3.ast.Program | str) -> QasmModule:
     elif not isinstance(program, openqasm3.ast.Program):
         raise TypeError("Input quantum program must be of type 'str' or 'openqasm3.ast.Program'.")
     if program.version not in SUPPORTED_QASM_VERSIONS:
-        raise ValidationError(f"Unsupported OpenQASM version: {program.version}")
+        raise ValidationError(
+            f"Unsupported OpenQASM version: {program.version}. "
+            f"Supported versions are: {SUPPORTED_QASM_VERSIONS}"
+        )
 
     # change version string to x.0 format
     program.version = str(float(program.version))
@@ -57,3 +77,36 @@ def load(program: openqasm3.ast.Program | str) -> QasmModule:
     module = qasm_module("main", program)
 
     return module
+
+
+def dump(module: QasmModule, filename: str = "main.qasm") -> None:
+    """Dumps the `QasmModule` object to a file.
+
+    Args:
+        module (QasmModule): The module to dump.
+        filename (str): The filename to dump to.
+
+    Returns:
+        None
+    """
+    qasm_string = dumps(module)
+    with open(filename, "w", encoding="utf-8") as file:
+        file.write(qasm_string)
+
+
+def dumps(module: QasmModule) -> str:
+    """Dumps the `QasmModule` object to a string.
+
+    Args:
+        module (QasmModule): The module to dump.
+
+    Raises:
+        TypeError: If the input is not a `QasmModule` instance
+
+    Returns:
+        str: The dumped module as string.
+    """
+    if not isinstance(module, QasmModule):
+        raise TypeError("Input 'module' must be of type pyqasm.modules.base.QasmModule")
+
+    return module.qasm_str()

--- a/pyqasm/entrypoint.py
+++ b/pyqasm/entrypoint.py
@@ -109,4 +109,4 @@ def dumps(module: QasmModule) -> str:
     if not isinstance(module, QasmModule):
         raise TypeError("Input 'module' must be of type pyqasm.modules.base.QasmModule")
 
-    return module.qasm_str()
+    return str(module)

--- a/pyqasm/modules/base.py
+++ b/pyqasm/modules/base.py
@@ -474,7 +474,7 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
             )
             raise err
 
-    def qasm_str(self) -> str:
+    def __str__(self) -> str:
         """Return the string representation of the QASM program
 
         Returns:

--- a/pyqasm/modules/base.py
+++ b/pyqasm/modules/base.py
@@ -474,7 +474,7 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
             )
             raise err
 
-    def dumps(self) -> str:
+    def qasm_str(self) -> str:
         """Return the string representation of the QASM program
 
         Returns:
@@ -484,15 +484,6 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
         if len(self.unrolled_ast.statements) > 1:
             return self._qasm_ast_to_str(self.unrolled_ast)
         return self._qasm_ast_to_str(self.original_program)
-
-    def formatted_qasm(self) -> str:
-        """Return the formatted QASM program
-           Removes empty lines and comments from the QASM program
-
-        Returns:
-            str: The formatted QASM program
-        """
-        return self.dumps()
 
     def copy(self):
         """Return a deep copy of the module"""

--- a/tests/qasm2/test_declarations.py
+++ b/tests/qasm2/test_declarations.py
@@ -15,7 +15,7 @@ declarations.
 """
 import pytest
 
-from pyqasm.entrypoint import load
+from pyqasm.entrypoint import dumps, loads
 from pyqasm.exceptions import ValidationError
 from tests.utils import check_unrolled_qasm
 
@@ -36,9 +36,9 @@ def test_qubit_declarations():
     qreg q[1];
     """
 
-    result = load(qasm2_string)
+    result = loads(qasm2_string)
     result.unroll()
-    unrolled_qasm = result.dumps()
+    unrolled_qasm = dumps(result)
 
     check_unrolled_qasm(unrolled_qasm, expected_qasm)
 
@@ -60,9 +60,9 @@ def test_clbit_declarations():
     creg c[1];
     """
 
-    result = load(qasm2_string)
+    result = loads(qasm2_string)
     result.unroll()
-    unrolled_qasm = result.dumps()
+    unrolled_qasm = dumps(result)
 
     check_unrolled_qasm(unrolled_qasm, expected_qasm)
 
@@ -91,9 +91,9 @@ def test_qubit_clbit_declarations():
     creg c2[2];
     """
 
-    result = load(qasm2_string)
+    result = loads(qasm2_string)
     result.unroll()
-    unrolled_qasm = result.dumps()
+    unrolled_qasm = dumps(result)
 
     check_unrolled_qasm(unrolled_qasm, expected_qasm)
 
@@ -109,4 +109,4 @@ def test_invalid_qasm2_declarations():
     qubit q3;
     """
     with pytest.raises(ValidationError):
-        load(invalid_qasm2).validate()
+        loads(invalid_qasm2).validate()

--- a/tests/qasm2/test_depth.py
+++ b/tests/qasm2/test_depth.py
@@ -13,7 +13,7 @@ Module containing unit tests for calculating program depth.
 
 """
 
-from pyqasm.entrypoint import load
+from pyqasm.entrypoint import loads
 
 
 def test_gate_depth():
@@ -36,7 +36,7 @@ def test_gate_depth():
     qreg q[1];
     my_gate(1, 2, 3) q;
     """
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
     assert result.num_qubits == 1
     assert result.num_clbits == 0
@@ -57,7 +57,7 @@ def test_qubit_depth_with_unrelated_measure_op():
     // This should affect the depth as measurement will have to wait 
     measure q1 -> c; 
     """
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
     assert result.num_qubits == 4
     assert result.num_clbits == 1
@@ -70,7 +70,7 @@ def test_depth_with_no_ops():
     include "stdgates.inc";
     qreg q;
     """
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
     assert result.num_qubits == 1
     assert result.num_clbits == 0

--- a/tests/qasm2/test_format.py
+++ b/tests/qasm2/test_format.py
@@ -13,7 +13,7 @@ Module containing unit tests for program formatting
 
 """
 
-from pyqasm.entrypoint import load
+from pyqasm.entrypoint import dumps, loads
 from tests.utils import check_unrolled_qasm
 
 
@@ -33,8 +33,8 @@ def test_comments_removed_from_qasm():
     h q[0];
     """
 
-    result = load(qasm2_string)
-    actual_qasm2_string = result.formatted_qasm()
+    result = loads(qasm2_string)
+    actual_qasm2_string = dumps(result)
 
     check_unrolled_qasm(actual_qasm2_string, expected_qasm2_string)
 
@@ -62,7 +62,7 @@ def test_empty_lines_removed_from_qasm():
     h q[0];
     """
 
-    result = load(qasm2_string)
-    actual_qasm2_string = result.formatted_qasm()
+    result = loads(qasm2_string)
+    actual_qasm2_string = dumps(result)
 
     check_unrolled_qasm(actual_qasm2_string, expected_qasm2_string)

--- a/tests/qasm2/test_operations.py
+++ b/tests/qasm2/test_operations.py
@@ -15,7 +15,7 @@ declarations.
 """
 import pytest
 
-from pyqasm.entrypoint import load
+from pyqasm.entrypoint import dumps, loads
 from pyqasm.exceptions import ValidationError
 from tests.utils import check_unrolled_qasm
 
@@ -58,16 +58,16 @@ def test_whitelisted_ops():
     cx q[0], q[1];
     """
 
-    result = load(qasm2_string)
+    result = loads(qasm2_string)
     result.unroll()
-    check_unrolled_qasm(result.dumps(), expected_qasm)
+    check_unrolled_qasm(dumps(result), expected_qasm)
 
 
 def test_subroutine_blacklist():
 
     # subroutines
     with pytest.raises(ValidationError):
-        load(
+        loads(
             """
             OPENQASM 2.0;
             include 'qelib1.inc';
@@ -84,7 +84,7 @@ def test_subroutine_blacklist():
 def test_switch_blacklist():
     # switch statements
     with pytest.raises(ValidationError):
-        load(
+        loads(
             """
             OPENQASM 2.0;
             include 'qelib1.inc';
@@ -104,7 +104,7 @@ def test_switch_blacklist():
 def test_for_blacklist():
     # for loops
     with pytest.raises(ValidationError):
-        load(
+        loads(
             """
             OPENQASM 2.0;
             include 'qelib1.inc';
@@ -121,7 +121,7 @@ def test_for_blacklist():
 def test_while_blacklist():
     # while loops
     with pytest.raises(ValidationError):
-        load(
+        loads(
             """
             OPENQASM 2.0;
             include 'qelib1.inc';

--- a/tests/qasm2/test_rotation_gates.py
+++ b/tests/qasm2/test_rotation_gates.py
@@ -13,7 +13,7 @@ Module containing unit tests for parsing and unrolling programs that contain qua
 rotations in qasm2 format.
 
 """
-from pyqasm.entrypoint import load
+from pyqasm.entrypoint import dumps, loads
 from tests.utils import check_unrolled_qasm
 
 
@@ -39,9 +39,9 @@ cx q[1], q[0];
 rx(-1.5707963267948966) q[1];
 rx(-1.5707963267948966) q[0];
 """
-    result = load(qasm_in)
+    result = loads(qasm_in)
     result.unroll()
-    unrolled_qasm = result.dumps()
+    unrolled_qasm = dumps(result)
     check_unrolled_qasm(unrolled_qasm, expected_out)
 
 
@@ -62,9 +62,9 @@ qreg q[2];
 rz(-5.07865952845335) q[1];
 ry(1.00183605297937) q[0];
 """
-    result = load(qasm_in)
+    result = loads(qasm_in)
     result.unroll()
-    unrolled_qasm = result.dumps()
+    unrolled_qasm = dumps(result)
     check_unrolled_qasm(unrolled_qasm, expected_out)
 
 
@@ -90,9 +90,9 @@ cx q[1], q[0];
 rx(-1.5707963267948966) q[2];
 rx(-1.5707963267948966) q[0];
 """
-    result = load(qasm_in)
+    result = loads(qasm_in)
     result.unroll()
-    unrolled_qasm = result.dumps()
+    unrolled_qasm = dumps(result)
     check_unrolled_qasm(unrolled_qasm, expected_out)
 
 
@@ -114,9 +114,9 @@ rx(1.5707963267948966) q[1];
 cx q[0], q[1];
 x q[0];
 """
-    result = load(qasm_in)
+    result = loads(qasm_in)
     result.unroll()
-    unrolled_qasm = result.dumps()
+    unrolled_qasm = dumps(result)
     check_unrolled_qasm(unrolled_qasm, expected_out)
 
 
@@ -147,7 +147,7 @@ rz(-0.7853981633974483) q[1];
 cx q[0], q[1];
 h q[1];
 """
-    result = load(qasm_in)
+    result = loads(qasm_in)
     result.unroll()
-    unrolled_qasm = result.dumps()
+    unrolled_qasm = dumps(result)
     check_unrolled_qasm(unrolled_qasm, expected_out)

--- a/tests/qasm2/test_to_qasm3.py
+++ b/tests/qasm2/test_to_qasm3.py
@@ -14,7 +14,7 @@ Module containing unit tests for conversion to qasm3.
 """
 import pytest
 
-from pyqasm.entrypoint import load
+from pyqasm.entrypoint import loads
 from pyqasm.modules.qasm3 import Qasm3Module
 from tests.utils import check_unrolled_qasm
 
@@ -106,7 +106,7 @@ c4x q[0], q[1], q[2], q[3], q[4];
 
 @pytest.mark.parametrize("test_input, expected_qasm3", QASM_TEST_DATA)
 def test_to_qasm3_str(test_input, expected_qasm3):
-    result = load(test_input)
+    result = loads(test_input)
     returned_qasm3 = result.to_qasm3(as_str=True)
     assert isinstance(returned_qasm3, str)
     check_unrolled_qasm(returned_qasm3, expected_qasm3)
@@ -121,7 +121,7 @@ def test_to_qasm3_module():
     h q;
     measure q -> c;
     """
-    result = load(qasm2_string)
+    result = loads(qasm2_string)
 
     qasm3_module = result.to_qasm3(as_str=False)
     assert isinstance(qasm3_module, Qasm3Module)

--- a/tests/qasm3/declarations/test_classical.py
+++ b/tests/qasm3/declarations/test_classical.py
@@ -14,7 +14,7 @@ Module containing unit tests for QASM3 to QIR conversion functions.
 """
 import pytest
 
-from pyqasm.entrypoint import load
+from pyqasm.entrypoint import loads
 from pyqasm.exceptions import ValidationError
 from tests.qasm3.resources.variables import ASSIGNMENT_TESTS, DECLARATION_TESTS
 from tests.utils import check_single_qubit_rotation_op
@@ -36,7 +36,7 @@ def test_scalar_declarations():
     bool i;
     """
 
-    load(qasm3_string).validate()
+    loads(qasm3_string).validate()
 
 
 # 2. Test const declarations in different ways
@@ -61,7 +61,7 @@ def test_const_declarations():
     const float[32] f1 = 0.00000023 + f;
     """
 
-    load(qasm3_string).validate()
+    loads(qasm3_string).validate()
 
 
 # 3. Test non-constant scalar assignments
@@ -81,7 +81,7 @@ def test_scalar_assignments():
     r = 12.2;
     """
 
-    load(qasm3_string).validate()
+    loads(qasm3_string).validate()
 
 
 # 4. Scalar value assignment
@@ -103,7 +103,7 @@ def test_scalar_value_assignment():
     b = 5.0
     r = 0.23
     f = 0.5
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
 
     assert result.num_clbits == 0
@@ -138,7 +138,7 @@ def test_scalar_type_casts():
     f = 0
     g = 1
 
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
 
     assert result.num_clbits == 1
@@ -169,7 +169,7 @@ def test_array_type_casts():
     arr_bool_val = 1
     arr_float32_val = 6.0
 
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
 
     assert result.num_clbits == 0
@@ -196,7 +196,7 @@ def test_array_declarations():
     array[float[64], 3, 2] arr_float64;
     array[bool, 3, 2] arr_bool;
     """
-    load(qasm3_string).validate()
+    loads(qasm3_string).validate()
 
 
 # 6. Array assignments
@@ -247,7 +247,7 @@ def test_array_assignments():
     c = 4.5
     d = 6.7
     f = True
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
 
     assert result.num_clbits == 0
@@ -292,7 +292,7 @@ def test_array_expressions():
     b = 3
     c = 4.5
     d = 6.7
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
 
     assert result.num_clbits == 0
@@ -323,7 +323,7 @@ def test_array_initializations():
     rx(arr_bool[0][1]) q;
     """
 
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
 
     assert result.num_clbits == 0
@@ -356,7 +356,7 @@ def test_array_range_assignment():
 
     """
 
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
 
     assert result.num_clbits == 0
@@ -369,11 +369,11 @@ def test_array_range_assignment():
 def test_incorrect_declarations(test_name):
     qasm_input, error_message = DECLARATION_TESTS[test_name]
     with pytest.raises(ValidationError, match=error_message):
-        load(qasm_input).validate()
+        loads(qasm_input).validate()
 
 
 @pytest.mark.parametrize("test_name", ASSIGNMENT_TESTS.keys())
 def test_incorrect_assignments(test_name):
     qasm_input, error_message = ASSIGNMENT_TESTS[test_name]
     with pytest.raises(ValidationError, match=error_message):
-        load(qasm_input).validate()
+        loads(qasm_input).validate()

--- a/tests/qasm3/declarations/test_quantum.py
+++ b/tests/qasm3/declarations/test_quantum.py
@@ -15,7 +15,7 @@ declarations.
 """
 import pytest
 
-from pyqasm.entrypoint import load
+from pyqasm.entrypoint import dumps, loads
 from pyqasm.exceptions import ValidationError
 from tests.utils import check_unrolled_qasm
 
@@ -44,9 +44,9 @@ def test_qubit_declarations():
     qubit[10] q5;
     """
 
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
-    unrolled_qasm = result.dumps()
+    unrolled_qasm = dumps(result)
 
     check_unrolled_qasm(unrolled_qasm, expected_qasm)
 
@@ -75,9 +75,9 @@ def test_clbit_declarations():
     bit[10] c5;
     """
 
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
-    unrolled_qasm = result.dumps()
+    unrolled_qasm = dumps(result)
 
     check_unrolled_qasm(unrolled_qasm, expected_qasm)
 
@@ -114,9 +114,9 @@ def test_qubit_clbit_declarations():
     bit[1] c4;
     """
 
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
-    unrolled_qasm = result.dumps()
+    unrolled_qasm = dumps(result)
 
     check_unrolled_qasm(unrolled_qasm, expected_qasm)
 
@@ -130,7 +130,7 @@ def test_qubit_redeclaration_error():
         qubit q1;
         qubit q1;
         """
-        load(qasm3_string).validate()
+        loads(qasm3_string).validate()
 
 
 def test_invalid_qubit_name():
@@ -143,7 +143,7 @@ def test_invalid_qubit_name():
         include "stdgates.inc";
         qubit pi;
         """
-        load(qasm3_string).validate()
+        loads(qasm3_string).validate()
 
 
 def test_clbit_redeclaration_error():
@@ -155,7 +155,7 @@ def test_clbit_redeclaration_error():
         bit c1;
         bit[4] c1;
         """
-        load(qasm3_string).validate()
+        loads(qasm3_string).validate()
 
 
 def test_non_constant_size():
@@ -169,7 +169,7 @@ def test_non_constant_size():
         int[32] N = 10;
         qubit[N] q;
         """
-        load(qasm3_string).validate()
+        loads(qasm3_string).validate()
 
     with pytest.raises(
         ValidationError, match=r"Variable 'size' is not a constant in given expression"
@@ -180,4 +180,4 @@ def test_non_constant_size():
         int[32] size = 10;
         bit[size] c;
         """
-        load(qasm3_string).validate()
+        loads(qasm3_string).validate()

--- a/tests/qasm3/resources/qasm/custom_gate_complex.qasm
+++ b/tests/qasm3/resources/qasm/custom_gate_complex.qasm
@@ -1,7 +1,7 @@
-OPENQASM 3;
+OPENQASM 3.0;
 include "stdgates.inc";
 
-gate custom1 a{
+gate custom1 a {
     h a;
     x a;
     rx(0.5) a;
@@ -19,5 +19,4 @@ gate custom3(p, q) c, d {
 }
 
 qubit[2] q;
-
 custom3(0.1, 0.2) q[0:];

--- a/tests/qasm3/subroutines/test_subroutines.py
+++ b/tests/qasm3/subroutines/test_subroutines.py
@@ -15,7 +15,7 @@ Module containing unit tests for parsing and unrolling programs that contain sub
 
 import pytest
 
-from pyqasm.entrypoint import load
+from pyqasm.entrypoint import loads
 from pyqasm.exceptions import ValidationError
 from tests.qasm3.resources.subroutines import SUBROUTINE_INCORRECT_TESTS
 from tests.utils import check_single_qubit_gate_op, check_single_qubit_rotation_op
@@ -33,7 +33,7 @@ def test_function_declaration():
     my_function(q);
     """
 
-    result = load(qasm_str)
+    result = loads(qasm_str)
     result.unroll()
     assert result.num_clbits == 0
     assert result.num_qubits == 1
@@ -57,7 +57,7 @@ def test_simple_function_call():
     my_function(q, r);
     """
 
-    result = load(qasm_str)
+    result = loads(qasm_str)
     result.unroll()
     assert result.num_clbits == 0
     assert result.num_qubits == 1
@@ -79,7 +79,7 @@ def test_const_visible_in_function_call():
     my_function(q);
     """
 
-    result = load(qasm_str)
+    result = loads(qasm_str)
     result.unroll()
     assert result.num_clbits == 0
     assert result.num_qubits == 1
@@ -102,7 +102,7 @@ def test_update_variable_in_function():
     my_function(q);
     """
 
-    result = load(qasm_str)
+    result = loads(qasm_str)
     result.unroll()
     assert result.num_clbits == 0
     assert result.num_qubits == 1
@@ -125,12 +125,11 @@ def test_function_call_in_expression():
     bool b = my_function(q);
     """
 
-    result = load(qasm_str)
+    result = loads(qasm_str)
     result.unroll()
     assert result.num_clbits == 0
     assert result.num_qubits == 4
 
-    print(result.dumps())
     check_single_qubit_gate_op(result.unrolled_ast, 4, list(range(4)), "h")
 
 
@@ -157,7 +156,7 @@ def test_classical_quantum_function():
     if(new_var>2)
         h q[0];
     """
-    result = load(qasm_str)
+    result = loads(qasm_str)
     result.unroll()
     assert result.num_clbits == 0
     assert result.num_qubits == 4
@@ -182,7 +181,7 @@ def test_multiple_function_calls():
     my_function(0, q[0]);
     """
 
-    result = load(qasm_str)
+    result = loads(qasm_str)
     result.unroll()
     assert result.num_clbits == 0
     assert result.num_qubits == 3
@@ -204,7 +203,7 @@ def test_function_call_with_return():
     float[32] r = my_function(q);
     """
 
-    result = load(qasm_str)
+    result = loads(qasm_str)
     result.unroll()
     assert result.num_clbits == 0
     assert result.num_qubits == 1
@@ -234,7 +233,7 @@ def test_return_values_from_function():
 
     """
 
-    result = load(qasm_str)
+    result = loads(qasm_str)
     result.unroll()
     assert result.num_clbits == 0
     assert result.num_qubits == 2
@@ -263,7 +262,7 @@ def test_function_call_with_custom_gate():
     my_function(q, r);
     """
 
-    result = load(qasm_str)
+    result = loads(qasm_str)
     result.unroll()
     assert result.num_clbits == 0
     assert result.num_qubits == 1
@@ -290,7 +289,7 @@ def test_function_call_from_within_fn():
     my_function_2(q);
     """
 
-    result = load(qasm_str)
+    result = loads(qasm_str)
     result.unroll()
     assert result.num_clbits == 0
     assert result.num_qubits == 2
@@ -320,7 +319,7 @@ def test_return_value_mismatch(data_type):
     with pytest.raises(
         ValidationError, match=r"Return type mismatch for subroutine 'my_function'.*"
     ):
-        load(qasm_str).validate()
+        loads(qasm_str).validate()
 
 
 @pytest.mark.parametrize("keyword", ["pi", "euler", "tau"])
@@ -338,7 +337,7 @@ def test_subroutine_keyword_naming(keyword):
     """
 
     with pytest.raises(ValidationError, match=f"Subroutine name '{keyword}' is a reserved keyword"):
-        load(qasm_str).validate()
+        loads(qasm_str).validate()
 
 
 @pytest.mark.parametrize("qubit_params", ["q", "q[:2]", "q[{0,1}]"])
@@ -364,11 +363,11 @@ def test_qubit_size_arg_mismatch(qubit_params):
         match="Qubit register size mismatch for function 'my_function'. "
         "Expected 3 in variable 'q' but got 2",
     ):
-        load(qasm_str).validate()
+        loads(qasm_str).validate()
 
 
 @pytest.mark.parametrize("test_name", SUBROUTINE_INCORRECT_TESTS.keys())
 def test_incorrect_custom_ops(test_name):
     qasm_str, error_message = SUBROUTINE_INCORRECT_TESTS[test_name]
     with pytest.raises(ValidationError, match=error_message):
-        load(qasm_str).validate()
+        loads(qasm_str).validate()

--- a/tests/qasm3/subroutines/test_subroutines_arrays.py
+++ b/tests/qasm3/subroutines/test_subroutines_arrays.py
@@ -16,7 +16,7 @@ converting OpenQASM3 programs that contain arrays in subroutines.
 
 import pytest
 
-from pyqasm.entrypoint import load
+from pyqasm.entrypoint import loads
 from pyqasm.exceptions import ValidationError
 from tests.qasm3.resources.subroutines import SUBROUTINE_INCORRECT_TESTS_WITH_ARRAYS
 from tests.utils import check_single_qubit_rotation_op
@@ -36,7 +36,7 @@ def test_simple_function_call():
 
     """
 
-    result = load(qasm_str)
+    result = loads(qasm_str)
     result.unroll()
     assert result.num_clbits == 0
     assert result.num_qubits == 1
@@ -60,7 +60,7 @@ def test_passing_array_to_function():
     my_function(arr, my_q);
     """
 
-    result = load(qasm_str)
+    result = loads(qasm_str)
     result.unroll()
     assert result.num_clbits == 0
     assert result.num_qubits == 1
@@ -88,7 +88,7 @@ def test_passing_subarray_to_function():
 
     """
 
-    result = load(qasm_str)
+    result = loads(qasm_str)
     result.unroll()
     assert result.num_clbits == 0
     assert result.num_qubits == 1
@@ -113,7 +113,7 @@ def test_passing_array_with_dim_identifier():
     my_function(arr[0, :, :], my_q);
     """
 
-    result = load(qasm_str)
+    result = loads(qasm_str)
     result.unroll()
     assert result.num_clbits == 0
     assert result.num_qubits == 1
@@ -144,7 +144,7 @@ def test_pass_multiple_arrays_to_function():
     my_function(arr_1, arr_2, my_q);
     """
 
-    result = load(qasm_str)
+    result = loads(qasm_str)
     result.unroll()
     assert result.num_clbits == 0
     assert result.num_qubits == 1
@@ -158,4 +158,4 @@ def test_pass_multiple_arrays_to_function():
 def test_incorrect_custom_ops_with_arrays(test_name):
     qasm_input, error_message = SUBROUTINE_INCORRECT_TESTS_WITH_ARRAYS[test_name]
     with pytest.raises(ValidationError, match=error_message):
-        load(qasm_input).validate()
+        loads(qasm_input).validate()

--- a/tests/qasm3/test_alias.py
+++ b/tests/qasm3/test_alias.py
@@ -18,7 +18,7 @@ import re
 
 import pytest
 
-from pyqasm.entrypoint import load
+from pyqasm.entrypoint import loads
 from pyqasm.exceptions import ValidationError
 from tests.utils import (
     check_single_qubit_gate_op,
@@ -54,7 +54,7 @@ def test_alias():
     swap myqreg5[0], myqreg5[1];
     cz myqreg6;
     """
-    result = load(qasm3_alias_program)
+    result = loads(qasm3_alias_program)
     result.unroll()
 
     assert result.num_qubits == 5
@@ -81,7 +81,7 @@ def test_alias_update():
 
     x alias[1];
     """
-    result = load(qasm3_alias_program)
+    result = loads(qasm3_alias_program)
     result.unroll()
     assert result.num_qubits == 4
     assert result.num_clbits == 0
@@ -107,7 +107,7 @@ def test_valid_alias_redefinition():
     let alias = q[2];
     x alias;
     """
-    result = load(qasm3_alias_program)
+    result = loads(qasm3_alias_program)
     result.unroll()
     assert result.num_qubits == 5
     assert result.num_clbits == 5
@@ -134,7 +134,7 @@ def test_alias_wrong_indexing():
 
         x myqreg[0];
         """
-        load(qasm3_alias_program).validate()
+        loads(qasm3_alias_program).validate()
 
 
 def test_alias_invalid_discrete_indexing():
@@ -153,7 +153,7 @@ def test_alias_invalid_discrete_indexing():
 
         x myqreg[0];
         """
-        load(qasm3_alias_program).validate()
+        loads(qasm3_alias_program).validate()
 
 
 def test_invalid_alias_redefinition():
@@ -173,7 +173,7 @@ def test_invalid_alias_redefinition():
 
         x alias;
         """
-        load(qasm3_alias_program).validate()
+        loads(qasm3_alias_program).validate()
 
 
 def test_alias_defined_before():
@@ -190,7 +190,7 @@ def test_alias_defined_before():
 
         let myqreg = q2[1];
         """
-        load(qasm3_alias_program).validate()
+        loads(qasm3_alias_program).validate()
 
 
 def test_unsupported_alias():
@@ -207,7 +207,7 @@ def test_unsupported_alias():
 
         let myqreg = q[0] ++ q[1];
         """
-        load(qasm3_alias_program).validate()
+        loads(qasm3_alias_program).validate()
 
 
 # def test_alias_in_scope_1():
@@ -303,4 +303,4 @@ def test_alias_out_of_scope():
             h q[2];
         }
         """
-        load(qasm3_alias_program).validate()
+        loads(qasm3_alias_program).validate()

--- a/tests/qasm3/test_barrier.py
+++ b/tests/qasm3/test_barrier.py
@@ -14,7 +14,7 @@ Module containing unit tests for the barrier operation.
 """
 import pytest
 
-from pyqasm.entrypoint import load
+from pyqasm.entrypoint import dumps, loads
 from pyqasm.exceptions import ValidationError
 from tests.utils import check_unrolled_qasm
 
@@ -60,10 +60,10 @@ def test_barrier():
     barrier q2[1];
     barrier q3[0];
     """
-    module = load(qasm_str)
+    module = loads(qasm_str)
     module.unroll()
 
-    check_unrolled_qasm(module.dumps(), expected_qasm)
+    check_unrolled_qasm(dumps(module), expected_qasm)
 
 
 def test_barrier_in_function():
@@ -87,9 +87,9 @@ def test_barrier_in_function():
     barrier q[2];
     barrier q[3];
     """
-    module = load(qasm_str)
+    module = loads(qasm_str)
     module.unroll()
-    check_unrolled_qasm(module.dumps(), expected_qasm)
+    check_unrolled_qasm(dumps(module), expected_qasm)
 
 
 def test_remove_barriers():
@@ -114,10 +114,10 @@ def test_remove_barriers():
     qubit[3] q2;
     qubit[1] q3;
     """
-    module = load(qasm_str)
+    module = loads(qasm_str)
     module.remove_barriers()
 
-    check_unrolled_qasm(module.dumps(), expected_qasm)
+    check_unrolled_qasm(dumps(module), expected_qasm)
 
 
 def test_incorrect_barrier():
@@ -131,7 +131,7 @@ def test_incorrect_barrier():
     """
 
     with pytest.raises(ValidationError, match=r"Missing register declaration for q2 .*"):
-        load(undeclared).validate()
+        loads(undeclared).validate()
 
     out_of_bounds = """
     OPENQASM 3.0;
@@ -144,7 +144,7 @@ def test_incorrect_barrier():
     with pytest.raises(
         ValidationError, match="Index 3 out of range for register of size 2 in qubit"
     ):
-        load(out_of_bounds).validate()
+        loads(out_of_bounds).validate()
 
     duplicate = """
     OPENQASM 3.0;
@@ -155,4 +155,4 @@ def test_incorrect_barrier():
     """
 
     with pytest.raises(ValidationError, match=r"Duplicate qubit .*argument"):
-        load(duplicate).validate()
+        loads(duplicate).validate()

--- a/tests/qasm3/test_depth.py
+++ b/tests/qasm3/test_depth.py
@@ -14,7 +14,7 @@ Module containing unit tests for calculating program depth.
 """
 import pytest
 
-from pyqasm.entrypoint import load
+from pyqasm.entrypoint import loads
 
 
 def test_gate_depth():
@@ -40,7 +40,7 @@ def test_gate_depth():
     bool o = true;
     my_gate(m, n, o) q;
     """
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
     assert result.num_qubits == 1
     assert result.num_clbits == 0
@@ -61,7 +61,7 @@ def test_gate_depth_external_function():
     qubit q;
     my_gate() q;
     """
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll(external_gates=["my_gate"])
     assert result.num_qubits == 1
     assert result.num_clbits == 0
@@ -76,7 +76,7 @@ def test_pow_gate_depth():
     inv @ pow(2) @ pow(4) @ h q;
     pow(-2) @ h q;
     """
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
     assert result.num_qubits == 1
     assert result.num_clbits == 0
@@ -97,7 +97,7 @@ def test_inv_gate_depth():
     inv @ cx q2;
     inv @ ccx q[0], q2;
     """
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
     assert result.num_qubits == 3
     assert result.num_clbits == 0
@@ -123,7 +123,7 @@ def test_qubit_depth_with_unrelated_measure_op():
     // This should affect the depth as measurement will have to wait 
     c[0] = measure q1; 
     """
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
     assert result.num_qubits == 4
     assert result.num_clbits == 1
@@ -146,7 +146,7 @@ def test_subroutine_depth():
     my_function(0, q[0]);
     """
 
-    result = load(qasm_str)
+    result = loads(qasm_str)
     result.unroll()
     assert result.num_clbits == 0
     assert result.num_qubits == 3
@@ -169,7 +169,7 @@ def test_depth_with_multi_control():
     cx q2[0], q[0];
     
     """
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
     assert result.num_qubits == 6
     assert result.num_clbits == 0
@@ -182,7 +182,7 @@ def test_depth_with_no_ops():
     include "stdgates.inc";
     qubit q;
     """
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
     assert result.num_qubits == 1
     assert result.num_clbits == 0
@@ -201,7 +201,7 @@ def test_after_removing_measurement():
     cx q[1], q[2];
 
     """
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
     assert result.num_qubits == 3
     assert result.num_clbits == 3
@@ -224,7 +224,7 @@ def test_after_removing_barriers():
     cx q[1], q[2];
 
     """
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
     assert result.num_qubits == 3
     assert result.num_clbits == 0
@@ -251,7 +251,7 @@ def test_qasm3_depth_sparse_operations():
     barrier q;
     z q[1];
     """
-    result = load(qasm_string)
+    result = loads(qasm_string)
     result.unroll()
 
     assert result.depth() == 8
@@ -270,7 +270,7 @@ z q[1];
 b[0] = measure q[0];
 b[1] = measure q[1];
     """
-    result = load(qasm_string)
+    result = loads(qasm_string)
     result.unroll()
 
     assert result.depth() == 8
@@ -292,7 +292,7 @@ c[0] = measure q[0];
 c[1] = measure q[1];
 c[2] = measure q[2];
     """
-    result = load(qasm_string)
+    result = loads(qasm_string)
     result.unroll()
 
     assert result.depth() == 4
@@ -366,7 +366,7 @@ h q[1];
 )
 def test_qasm3_depth_no_branching(program, expected_depth):
     """Test calculating depth of qasm3 circuit"""
-    result = load(program)
+    result = loads(program)
     result.unroll()
     assert result.depth() == expected_depth
 
@@ -437,6 +437,6 @@ measure q2 -> c2;
 )
 def test_qasm3_depth_branching(program, expected_depth):
     """Test calculating depth of qasm3 circuit with branching conditions"""
-    result = load(program)
+    result = loads(program)
     result.unroll()
     assert result.depth() == expected_depth

--- a/tests/qasm3/test_entrypoint.py
+++ b/tests/qasm3/test_entrypoint.py
@@ -1,0 +1,63 @@
+# Copyright (C) 2024 qBraid
+#
+# This file is part of pyqasm
+#
+# Pyqasm is free software released under the GNU General Public License v3
+# or later. You can redistribute and/or modify it under the terms of the GPL v3.
+# See the LICENSE file in the project root or <https://www.gnu.org/licenses/gpl-3.0.html>.
+#
+# THERE IS NO WARRANTY for pyqasm, as per Section 15 of the GPL v3.
+
+"""
+Module containing unit tests for entrypoint functions.
+
+"""
+import os
+
+import pytest
+
+from pyqasm.entrypoint import dump, dumps, load, loads
+from pyqasm.exceptions import ValidationError
+from tests.utils import check_unrolled_qasm
+
+
+def test_correct_file_read():
+    file_path = "tests/qasm3/resources/qasm/custom_gate_complex.qasm"
+    result = load(file_path)
+    actual_qasm = dumps(result)
+    with open(file_path, "r", encoding="utf-8") as file:
+        check_unrolled_qasm(actual_qasm, file.read())
+
+
+def test_correct_module_dump():
+    file_path = "tests/qasm3/resources/qasm/test.qasm"
+    qasm_str = 'OPENQASM 3.0;\n include "stdgates.inc";\n qubit q;'
+    module = loads(qasm_str)
+    dump(module, file_path)
+    with open(file_path, "r", encoding="utf-8") as file:
+        check_unrolled_qasm(file.read(), qasm_str)
+    os.remove(file_path)
+
+
+def test_incorrect_module_loading_file():
+    with pytest.raises(TypeError, match="Input 'filename' must be of type 'str'."):
+        load(1)
+
+
+def test_incorrect_module_loading_program():
+    with pytest.raises(
+        TypeError, match="Input quantum program must be of type 'str' or 'openqasm3.ast.Program'."
+    ):
+        loads(1)
+
+
+def test_incorrect_module_dump():
+    with pytest.raises(
+        TypeError, match="Input 'module' must be of type pyqasm.modules.base.QasmModule"
+    ):
+        dumps(1)
+
+
+def test_incorrect_qasm_version():
+    with pytest.raises(ValidationError, match=r"Unsupported OpenQASM version"):
+        loads("OPENQASM 4.0;\n qubit q;")

--- a/tests/qasm3/test_expressions.py
+++ b/tests/qasm3/test_expressions.py
@@ -14,7 +14,7 @@ Module containing unit tests for expressions.
 """
 import pytest
 
-from pyqasm.entrypoint import load
+from pyqasm.entrypoint import loads
 from pyqasm.exceptions import ValidationError
 from tests.utils import check_measure_op, check_single_qubit_gate_op, check_single_qubit_rotation_op
 
@@ -37,7 +37,7 @@ def test_correct_expressions():
     c[1] = c[0] + 2;
     """
 
-    result = load(qasm_str)
+    result = loads(qasm_str)
     result.unroll()
     assert result.num_qubits == 1
     assert result.num_clbits == 0
@@ -60,7 +60,7 @@ def test_bit_in_expression():
     dummy_int = c3[0];
     """
 
-    result = load(qasm_str)
+    result = loads(qasm_str)
     result.unroll()
 
     assert result.num_qubits == 1
@@ -72,16 +72,16 @@ def test_bit_in_expression():
 
 def test_incorrect_expressions():
     with pytest.raises(ValidationError, match=r"Unsupported expression type .*"):
-        load("OPENQASM 3; qubit q; rz(1 - 2 + 32im) q;").validate()
+        loads("OPENQASM 3; qubit q; rz(1 - 2 + 32im) q;").validate()
 
     with pytest.raises(ValidationError, match=r"Unsupported expression type .* in ~ operation"):
-        load("OPENQASM 3; qubit q; rx(~1.3) q;").validate()
+        loads("OPENQASM 3; qubit q; rx(~1.3) q;").validate()
 
     with pytest.raises(ValidationError, match=r"Unsupported expression type .* in ~ operation"):
-        load("OPENQASM 3; qubit q; rx(~1.3+5im) q;").validate()
+        loads("OPENQASM 3; qubit q; rx(~1.3+5im) q;").validate()
 
     with pytest.raises(ValidationError, match="Undefined identifier x in expression"):
-        load("OPENQASM 3; qubit q; rx(x) q;").validate()
+        loads("OPENQASM 3; qubit q; rx(x) q;").validate()
 
     with pytest.raises(ValidationError, match="Uninitialized variable x in expression"):
-        load("OPENQASM 3; qubit q; int x; rx(x) q;").validate()
+        loads("OPENQASM 3; qubit q; int x; rx(x) q;").validate()

--- a/tests/qasm3/test_format.py
+++ b/tests/qasm3/test_format.py
@@ -13,7 +13,7 @@ Module containing unit tests for program formatting
 
 """
 
-from pyqasm.entrypoint import load
+from pyqasm.entrypoint import dumps, loads
 from tests.utils import check_unrolled_qasm
 
 
@@ -33,8 +33,8 @@ def test_comments_removed_from_qasm():
     h q;
     """
 
-    result = load(qasm3_string)
-    actual_qasm3_string = result.formatted_qasm()
+    result = loads(qasm3_string)
+    actual_qasm3_string = dumps(result)
 
     check_unrolled_qasm(actual_qasm3_string, expected_qasm3_string)
 
@@ -62,7 +62,7 @@ def test_empty_lines_removed_from_qasm():
     h q;
     """
 
-    result = load(qasm3_string)
-    actual_qasm3_string = result.formatted_qasm()
+    result = loads(qasm3_string)
+    actual_qasm3_string = dumps(result)
 
     check_unrolled_qasm(actual_qasm3_string, expected_qasm3_string)

--- a/tests/qasm3/test_gates.py
+++ b/tests/qasm3/test_gates.py
@@ -14,7 +14,7 @@ Module containing unit tests for unrolling quantum gates.
 """
 import pytest
 
-from pyqasm.entrypoint import load
+from pyqasm.entrypoint import loads
 from pyqasm.exceptions import ValidationError
 from tests.qasm3.resources.gates import (
     CUSTOM_GATE_INCORRECT_TESTS,
@@ -43,7 +43,7 @@ def test_single_qubit_qasm3_gates(circuit_name, request):
     gate_name = circuit_name.removeprefix("Fixture_")
 
     qasm3_string = request.getfixturevalue(circuit_name)
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
     assert result.num_qubits == 2
     assert result.num_clbits == 0
@@ -56,11 +56,10 @@ def test_two_qubit_qasm3_gates(circuit_name, request):
     gate_name = circuit_name.removeprefix("Fixture_")
 
     qasm3_string = request.getfixturevalue(circuit_name)
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
     assert result.num_qubits == 2
     assert result.num_clbits == 0
-    print(result.dumps())
     check_two_qubit_gate_op(result.unrolled_ast, 2, qubit_list, gate_name)
 
 
@@ -71,7 +70,7 @@ def test_rotation_qasm3_gates(circuit_name, request):
     gate_name = circuit_name.removeprefix("Fixture_")
 
     qasm3_string = request.getfixturevalue(circuit_name)
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
     assert result.num_qubits == 2
     assert result.num_clbits == 0
@@ -84,7 +83,7 @@ def test_three_qubit_qasm3_gates(circuit_name, request):
     gate_name = circuit_name.removeprefix("Fixture_")
 
     qasm3_string = request.getfixturevalue(circuit_name)
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
     assert result.num_qubits == 3
     assert result.num_clbits == 0
@@ -114,7 +113,7 @@ def test_gate_body_param_expression():
     bool o = true;
     my_gate(m, n, o) q;
     """
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
     assert result.num_qubits == 1
     assert result.num_clbits == 0
@@ -132,7 +131,7 @@ def test_qasm_u3_gates():
     qubit[2] q1;
     u3(0.5, 0.5, 0.5) q1[0];
     """
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
     assert result.num_qubits == 2
     assert result.num_clbits == 0
@@ -147,7 +146,7 @@ def test_qasm_u3_gates_external():
     qubit[2] q1;
     u3(0.5, 0.5, 0.5) q1[0];
     """
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll(external_gates=["u3"])
     assert result.num_qubits == 2
     assert result.num_clbits == 0
@@ -162,7 +161,7 @@ def test_qasm_u3_gates_external_with_multiple_qubits():
     qubit[2] q1;
     u3(0.5, 0.5, 0.5) q1;
     """
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll(external_gates=["u3"])
     assert result.num_qubits == 2
     assert result.num_clbits == 0
@@ -177,7 +176,7 @@ def test_qasm_u2_gates():
     qubit[2] q1;
     u2(0.5, 0.5) q1[0];
     """
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
     assert result.num_qubits == 2
     assert result.num_clbits == 0
@@ -188,14 +187,14 @@ def test_qasm_u2_gates():
 def test_incorrect_single_qubit_gates(test_name):
     qasm_input, error_message = SINGLE_QUBIT_GATE_INCORRECT_TESTS[test_name]
     with pytest.raises(ValidationError, match=error_message):
-        load(qasm_input).validate()
+        loads(qasm_input).validate()
 
 
 @pytest.mark.parametrize("test_name", custom_op_tests)
 def test_custom_ops(test_name, request):
     qasm3_string = request.getfixturevalue(test_name)
     gate_type = test_name.removeprefix("Fixture_")
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
 
     assert result.num_qubits == 2
@@ -209,7 +208,7 @@ def test_custom_ops(test_name, request):
 def test_custom_ops_with_external_gates(test_name, request):
     qasm3_string = request.getfixturevalue(test_name)
     gate_type = test_name.removeprefix("Fixture_")
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll(external_gates=["custom", "custom1"])
 
     assert result.num_qubits == 2
@@ -227,7 +226,7 @@ def test_pow_gate_modifier():
     inv @ pow(2) @ pow(4) @ h q;
     pow(-2) @ h q;
     """
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
     assert result.num_qubits == 1
     assert result.num_clbits == 0
@@ -248,7 +247,7 @@ def test_inv_gate_modifier():
     inv @ cx q2;
     inv @ ccx q[0], q2;
     """
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
     assert result.num_qubits == 3
     assert result.num_clbits == 0
@@ -275,7 +274,7 @@ def test_nested_gate_modifiers():
     pow(1) @ inv @ pow(2) @ custom q;
     pow(-1) @ custom q;
     """
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
     assert result.num_qubits == 2
     assert result.num_clbits == 0
@@ -290,7 +289,7 @@ def test_unsupported_modifiers():
             NotImplementedError,
             match=r"Controlled modifier gates not yet supported .*",
         ):
-            load(
+            loads(
                 f"""
                 OPENQASM 3;
                 include "stdgates.inc";
@@ -304,4 +303,4 @@ def test_unsupported_modifiers():
 def test_incorrect_custom_ops(test_name):
     qasm_input, error_message = CUSTOM_GATE_INCORRECT_TESTS[test_name]
     with pytest.raises(ValidationError, match=error_message):
-        load(qasm_input).validate()
+        loads(qasm_input).validate()

--- a/tests/qasm3/test_if.py
+++ b/tests/qasm3/test_if.py
@@ -15,7 +15,7 @@ Module containing unit tests for the if statements.
 
 import pytest
 
-from pyqasm.entrypoint import load
+from pyqasm.entrypoint import dumps, loads
 from pyqasm.exceptions import ValidationError
 from tests.utils import check_unrolled_qasm
 
@@ -62,12 +62,12 @@ def test_simple_if():
     }
     """
 
-    result = load(qasm)
+    result = loads(qasm)
     result.unroll()
     assert result.num_clbits == 4
     assert result.num_qubits == 4
 
-    check_unrolled_qasm(result.dumps(), expected_qasm)
+    check_unrolled_qasm(dumps(result), expected_qasm)
 
 
 def test_complex_if():
@@ -129,18 +129,17 @@ def test_complex_if():
     h q[0];
     h q[1];
     """
-    result = load(qasm)
+    result = loads(qasm)
     result.unroll()
     assert result.num_clbits == 8
     assert result.num_qubits == 4
-    print(result.dumps())
-    check_unrolled_qasm(result.dumps(), expected_qasm)
+    check_unrolled_qasm(dumps(result), expected_qasm)
 
 
 def test_incorrect_if():
 
     with pytest.raises(ValidationError, match=r"Missing if block"):
-        load(
+        loads(
             """
             OPENQASM 3.0;
            include "stdgates.inc";
@@ -156,7 +155,7 @@ def test_incorrect_if():
         ).validate()
 
     with pytest.raises(ValidationError, match=r"Undefined identifier c2 in expression"):
-        load(
+        loads(
             """
             OPENQASM 3.0;
            include "stdgates.inc";
@@ -173,7 +172,7 @@ def test_incorrect_if():
         ).validate()
 
     with pytest.raises(ValidationError, match=r"Only '!' supported .*"):
-        load(
+        loads(
             """
             OPENQASM 3.0;
            include "stdgates.inc";
@@ -189,7 +188,7 @@ def test_incorrect_if():
            """
         ).validate()
     with pytest.raises(ValidationError, match=r"Only '==' supported .*"):
-        load(
+        loads(
             """
             OPENQASM 3.0;
            include "stdgates.inc";
@@ -208,7 +207,7 @@ def test_incorrect_if():
         ValidationError,
         match=r"Only simple comparison supported .*",
     ):
-        load(
+        loads(
             """
             OPENQASM 3.0;
            include "stdgates.inc";
@@ -227,7 +226,7 @@ def test_incorrect_if():
         ValidationError,
         match=r"RangeDefinition not supported in branching condition",
     ):
-        load(
+        loads(
             """
             OPENQASM 3.0;
            include "stdgates.inc";
@@ -247,7 +246,7 @@ def test_incorrect_if():
         ValidationError,
         match=r"DiscreteSet not supported in branching condition",
     ):
-        load(
+        loads(
             """
             OPENQASM 3.0;
            include "stdgates.inc";

--- a/tests/qasm3/test_loop.py
+++ b/tests/qasm3/test_loop.py
@@ -15,7 +15,7 @@ Module containing unit tests for parsing and unrolling programs that contain loo
 
 import pytest
 
-from pyqasm.entrypoint import load
+from pyqasm.entrypoint import loads
 from pyqasm.exceptions import ValidationError
 from tests.utils import (
     check_single_qubit_gate_op,
@@ -42,7 +42,7 @@ measure q->c;
 
 def test_convert_qasm3_for_loop():
     """Test converting a QASM3 program that contains a for loop."""
-    result = load(
+    result = loads(
         """
         OPENQASM 3.0;
         include "stdgates.inc";
@@ -61,15 +61,13 @@ def test_convert_qasm3_for_loop():
     assert result.num_qubits == 4
     assert result.num_clbits == 4
 
-    print(result.dumps())
-
     check_single_qubit_gate_op(result.unrolled_ast, 4, [0, 1, 2, 3], "h")
     check_two_qubit_gate_op(result.unrolled_ast, 3, [(0, 1), (1, 2), (2, 3)], "cx")
 
 
 def test_convert_qasm3_for_loop_shadow():
     """Test for loop where loop variable shadows variable from global scope."""
-    result = load(
+    result = loads(
         """
         OPENQASM 3.0;
         include "stdgates.inc";
@@ -98,7 +96,7 @@ def test_convert_qasm3_for_loop_shadow():
 
 def test_convert_qasm3_for_loop_enclosing():
     """Test for loop where variable from outer loop is accessed from inside the loop."""
-    result = load(
+    result = loads(
         """
         OPENQASM 3.0;
         include "stdgates.inc";
@@ -127,7 +125,7 @@ def test_convert_qasm3_for_loop_enclosing():
 
 def test_convert_qasm3_for_loop_enclosing_modifying():
     """Test for loop where variable from outer loop is modified from inside the loop."""
-    result = load(
+    result = loads(
         """
         OPENQASM 3.0;
         include "stdgates.inc";
@@ -158,7 +156,7 @@ def test_convert_qasm3_for_loop_enclosing_modifying():
 
 def test_convert_qasm3_for_loop_discrete_set():
     """Test converting a QASM3 program that contains a for loop initialized from a DiscreteSet."""
-    result = load(
+    result = loads(
         """
         OPENQASM 3.0;
         include "stdgates.inc";
@@ -201,7 +199,7 @@ def test_function_executed_in_loop():
     }
     """
 
-    result = load(qasm_str)
+    result = loads(qasm_str)
     result.unroll()
 
     assert result.num_qubits == 5
@@ -227,7 +225,7 @@ def test_loop_inside_function():
     my_function(q1);
     """
 
-    result = load(qasm_str)
+    result = loads(qasm_str)
     result.unroll()
 
     assert result.num_qubits == 3
@@ -259,7 +257,7 @@ def test_function_in_nested_loop():
     my_function(q[0], 2*b);
     """
 
-    result = load(qasm_str)
+    result = loads(qasm_str)
     result.unroll()
 
     assert result.num_qubits == 5
@@ -292,7 +290,7 @@ def test_loop_in_nested_function_call():
     qubit q;
     my_function_2(q, 3);
     """
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
 
     assert result.num_clbits == 0
@@ -311,7 +309,7 @@ def test_convert_qasm3_for_loop_unsupported_type():
             " of set_declaration in loop."
         ),
     ):
-        load(
+        loads(
             """
             OPENQASM 3.0;
             include "stdgates.inc";

--- a/tests/qasm3/test_measurement.py
+++ b/tests/qasm3/test_measurement.py
@@ -14,7 +14,7 @@ Module containing unit tests for loading measurement operations.
 """
 import pytest
 
-from pyqasm.entrypoint import load
+from pyqasm.entrypoint import dumps, loads
 from pyqasm.exceptions import ValidationError
 from tests.utils import check_unrolled_qasm
 
@@ -57,9 +57,9 @@ def test_measure():
     c1[0] = measure q2[1]; 
     """
 
-    module = load(qasm3_string)
+    module = loads(qasm3_string)
     module.unroll()
-    check_unrolled_qasm(module.dumps(), expected_qasm)
+    check_unrolled_qasm(dumps(module), expected_qasm)
 
 
 def test_has_measurements():
@@ -80,7 +80,7 @@ def test_has_measurements():
     measure q2[{0, 1}] -> c1[{1, 0}];
 
     """
-    qasm_module = load(qasm3_string_with_measure)
+    qasm_module = loads(qasm3_string_with_measure)
     assert qasm_module.has_measurements()
 
     qasm3_string_without_measure = """
@@ -89,7 +89,7 @@ def test_has_measurements():
     qubit[2] q1;
     qubit[5] q2;
     """
-    qasm_module = load(qasm3_string_without_measure)
+    qasm_module = loads(qasm3_string_without_measure)
     assert not qasm_module.has_measurements()
 
 
@@ -121,17 +121,17 @@ def test_remove_measurement():
     bit[1] c2;
     """
 
-    module = load(qasm3_string)
+    module = loads(qasm3_string)
     module.unroll()
     module.remove_measurements()
 
-    check_unrolled_qasm(module.dumps(), expected_qasm)
+    check_unrolled_qasm(dumps(module), expected_qasm)
 
 
 def test_incorrect_measure():
     def run_test(qasm3_code, error_message):
         with pytest.raises(ValidationError, match=error_message):
-            load(qasm3_code).validate()
+            loads(qasm3_code).validate()
 
     # Test for undeclared register q2
     run_test(

--- a/tests/qasm3/test_reset.py
+++ b/tests/qasm3/test_reset.py
@@ -14,7 +14,7 @@ Module containing unit tests for reset operation.
 """
 import pytest
 
-from pyqasm.entrypoint import load
+from pyqasm.entrypoint import dumps, loads
 from pyqasm.exceptions import ValidationError
 from tests.utils import check_unrolled_qasm
 
@@ -50,9 +50,9 @@ def test_reset_operations():
     reset q3[1];
     """
 
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
-    check_unrolled_qasm(result.dumps(), expected_qasm)
+    check_unrolled_qasm(dumps(result), expected_qasm)
 
 
 def test_reset_inside_function():
@@ -74,9 +74,9 @@ def test_reset_inside_function():
     reset q[1];
     """
 
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
-    check_unrolled_qasm(result.dumps(), expected_qasm)
+    check_unrolled_qasm(dumps(result), expected_qasm)
 
 
 def test_incorrect_resets():
@@ -90,7 +90,7 @@ def test_incorrect_resets():
     reset q2[0];
     """
     with pytest.raises(ValidationError):
-        load(undeclared).validate()
+        loads(undeclared).validate()
 
     index_error = """
     OPENQASM 3.0;
@@ -102,4 +102,4 @@ def test_incorrect_resets():
     reset q1[4];
     """
     with pytest.raises(ValidationError):
-        load(index_error).validate()
+        loads(index_error).validate()

--- a/tests/qasm3/test_sizeof.py
+++ b/tests/qasm3/test_sizeof.py
@@ -14,7 +14,7 @@ Module containing unit tests for sizeof operation.
 """
 import pytest
 
-from pyqasm.entrypoint import load
+from pyqasm.entrypoint import loads
 from pyqasm.exceptions import ValidationError
 from tests.utils import check_single_qubit_rotation_op
 
@@ -42,7 +42,7 @@ def test_simple_sizeof():
     rx(size3) q[1];
     """
 
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
 
     assert result.num_qubits == 2
@@ -68,7 +68,7 @@ def test_sizeof_multiple_types():
     rx(size2) q[1];
     """
 
-    result = load(qasm3_string)
+    result = loads(qasm3_string)
     result.unroll()
 
     assert result.num_qubits == 2
@@ -86,7 +86,7 @@ def test_unsupported_target():
 
         int[32] size1 = sizeof(my_ints[0]); // this is invalid
         """
-        load(qasm3_string).validate()
+        loads(qasm3_string).validate()
 
 
 def test_sizeof_on_non_array():
@@ -102,7 +102,7 @@ def test_sizeof_on_non_array():
 
         int[32] size1 = sizeof(my_int); // this is invalid
         """
-        load(qasm3_string).validate()
+        loads(qasm3_string).validate()
 
 
 def test_out_of_bounds_reference():
@@ -118,4 +118,4 @@ def test_out_of_bounds_reference():
 
         int[32] size1 = sizeof(my_ints, 3); // this is invalid
         """
-        load(qasm3_string).validate()
+        loads(qasm3_string).validate()

--- a/tests/qasm3/test_switch.py
+++ b/tests/qasm3/test_switch.py
@@ -17,7 +17,7 @@ import re
 
 import pytest
 
-from pyqasm.entrypoint import load
+from pyqasm.entrypoint import loads
 from pyqasm.exceptions import ValidationError
 from tests.utils import check_single_qubit_gate_op, check_single_qubit_rotation_op
 
@@ -45,7 +45,7 @@ def test_switch():
     }
     """
 
-    result = load(qasm3_switch_program)
+    result = loads(qasm3_switch_program)
     result.unroll()
 
     assert result.num_clbits == 0
@@ -77,7 +77,7 @@ def test_switch_default():
     }
     """
 
-    result = load(qasm3_switch_program)
+    result = loads(qasm3_switch_program)
     result.unroll()
 
     assert result.num_clbits == 0
@@ -106,7 +106,7 @@ def test_switch_identifier_case():
     }
     """
 
-    result = load(qasm3_switch_program)
+    result = loads(qasm3_switch_program)
     result.unroll()
 
     assert result.num_clbits == 0
@@ -136,7 +136,7 @@ def test_switch_const_int():
     }
     """
 
-    result = load(qasm3_switch_program)
+    result = loads(qasm3_switch_program)
     result.unroll()
 
     assert result.num_clbits == 0
@@ -168,7 +168,7 @@ def test_switch_duplicate_cases():
         }
         """
 
-        load(qasm3_switch_program).validate()
+        loads(qasm3_switch_program).validate()
 
 
 def test_no_case_switch():
@@ -191,7 +191,7 @@ def test_no_case_switch():
         }
         """
 
-        load(qasm3_switch_program).validate()
+        loads(qasm3_switch_program).validate()
 
 
 def test_nested_switch():
@@ -229,7 +229,7 @@ def test_nested_switch():
     }
     """
 
-    result = load(qasm3_switch_program)
+    result = loads(qasm3_switch_program)
     result.unroll()
 
     assert result.num_clbits == 0
@@ -262,7 +262,7 @@ def test_subroutine_inside_switch():
     }
     """
 
-    result = load(qasm_str)
+    result = loads(qasm_str)
     result.unroll()
     assert result.num_clbits == 0
     assert result.num_qubits == 2
@@ -297,7 +297,7 @@ def test_invalid_scalar_switch_target(invalid_type):
 
     with pytest.raises(ValidationError, match=re.escape("Switch target i must be of type int")):
         qasm3_switch_program = base_invalid_program
-        load(qasm3_switch_program).validate()
+        loads(qasm3_switch_program).validate()
 
 
 @pytest.mark.parametrize("invalid_type", ["float", "bool"])
@@ -327,7 +327,7 @@ def test_invalid_array_switch_target(invalid_type):
 
     with pytest.raises(ValidationError, match=re.escape("Switch target i must be of type int")):
         qasm3_switch_program = base_invalid_program
-        load(qasm3_switch_program).validate()
+        loads(qasm3_switch_program).validate()
 
 
 @pytest.mark.parametrize(
@@ -360,7 +360,7 @@ def test_unsupported_statements_in_case(invalid_stmt):
     )
     with pytest.raises(ValidationError, match=r"Unsupported statement .*"):
         qasm3_switch_program = base_invalid_program
-        load(qasm3_switch_program).validate()
+        loads(qasm3_switch_program).validate()
 
 
 def test_non_int_expression_case():
@@ -387,7 +387,7 @@ def test_non_int_expression_case():
         match=r"Invalid value 4.3 with type .* for required type <class 'openqasm3.ast.IntType'>",
     ):
         qasm3_switch_program = base_invalid_program
-        load(qasm3_switch_program).validate()
+        loads(qasm3_switch_program).validate()
 
 
 def test_non_int_variable_expression():
@@ -415,7 +415,7 @@ def test_non_int_variable_expression():
         match=r"Invalid type of variable .* for required type <class 'openqasm3.ast.IntType'>",
     ):
         qasm3_switch_program = base_invalid_program
-        load(qasm3_switch_program).validate()
+        loads(qasm3_switch_program).validate()
 
 
 def test_non_constant_expression_case():
@@ -441,4 +441,4 @@ def test_non_constant_expression_case():
 
     with pytest.raises(ValidationError, match=r"Variable .* is not a constant in given expression"):
         qasm3_switch_program = base_invalid_program
-        load(qasm3_switch_program).validate()
+        loads(qasm3_switch_program).validate()

--- a/tests/qasm3/test_transformations.py
+++ b/tests/qasm3/test_transformations.py
@@ -13,7 +13,7 @@ Module containing unit tests for transformations on qasm3 programs
 
 """
 
-from pyqasm.entrypoint import load
+from pyqasm.entrypoint import dumps, loads
 from tests.utils import check_unrolled_qasm
 
 
@@ -34,11 +34,11 @@ def test_remove_idle_qubits_qasm3_small():
     h q[0];
     cx q[0], q[1];
     """
-    module = load(qasm3_str)
+    module = loads(qasm3_str)
     assert module.num_qubits == 4
     module.remove_idle_qubits()
     assert module.num_qubits == 2
-    check_unrolled_qasm(module.dumps(), expected_qasm3_str)
+    check_unrolled_qasm(dumps(module), expected_qasm3_str)
 
 
 def test_remove_idle_qubits_qasm3():
@@ -83,12 +83,12 @@ def test_remove_idle_qubits_qasm3():
     cx q6[0], q6[1];
     """
 
-    module = load(qasm3_str)
+    module = loads(qasm3_str)
     assert module.num_qubits == 19
     module.remove_idle_qubits()
     assert module.num_qubits == 7
 
-    check_unrolled_qasm(module.dumps(), expected_qasm3_str)
+    check_unrolled_qasm(dumps(module), expected_qasm3_str)
 
 
 def test_reverse_qubit_order_qasm3():
@@ -126,9 +126,9 @@ def test_reverse_qubit_order_qasm3():
     c[0] = measure q2[3];
     """
 
-    module = load(qasm3_str)
+    module = loads(qasm3_str)
     module.reverse_qubit_order()
-    check_unrolled_qasm(module.dumps(), expected_qasm3_str)
+    check_unrolled_qasm(dumps(module), expected_qasm3_str)
 
 
 def test_populate_idle_qubits_qasm3():
@@ -161,9 +161,9 @@ def test_populate_idle_qubits_qasm3():
     id q3[0];
     """
 
-    module = load(qasm3_str)
+    module = loads(qasm3_str)
     module.populate_idle_qubits()
-    check_unrolled_qasm(module.dumps(), expected_qasm3_str)
+    check_unrolled_qasm(dumps(module), expected_qasm3_str)
 
 
 def test_populate_idle_qubits_for_no_idle_qubits():
@@ -195,9 +195,9 @@ def test_populate_idle_qubits_for_no_idle_qubits():
     h q3;
     """
 
-    module = load(qasm3_str)
+    module = loads(qasm3_str)
     module.populate_idle_qubits()
-    check_unrolled_qasm(module.dumps(), expected_qasm3_str)
+    check_unrolled_qasm(dumps(module), expected_qasm3_str)
 
 
 def test_populate_idle_qubits_increases_depth_by_one():
@@ -210,7 +210,7 @@ def test_populate_idle_qubits_increases_depth_by_one():
     qubit q3;
     
     """
-    module = load(qasm3_str)
+    module = loads(qasm3_str)
     original_depth = module.depth()
     module.populate_idle_qubits()
     assert module.depth() == original_depth + 1


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

## Summary of changes
This pull request introduces several changes to the `pyqasm` library, primarily focusing on adding new functions for loading and dumping QASM programs, as well as updating existing code to use these new functions. The changes also include updates to documentation and tests to reflect these new functions.

### New Functions and Updates:
* [`pyqasm/entrypoint.py`](diffhunk://#diff-39954afd8ebe825446b45bb11a3edcd56ff2dc39c3e50437dd757aad7588989cL29-R57): Added new functions `loads`, `dump`, and `dumps` to handle QASM program loading and dumping. The `load` function was updated to read from a file and call `loads`. [[1]](diffhunk://#diff-39954afd8ebe825446b45bb11a3edcd56ff2dc39c3e50437dd757aad7588989cL29-R57) [[2]](diffhunk://#diff-39954afd8ebe825446b45bb11a3edcd56ff2dc39c3e50437dd757aad7588989cL51-R71) [[3]](diffhunk://#diff-39954afd8ebe825446b45bb11a3edcd56ff2dc39c3e50437dd757aad7588989cR80-R112)

### Documentation Updates:
* [`pyqasm/__init__.py`](diffhunk://#diff-6d7a3e1d2ab5ef98f0b8653434261a6a2785a8c8a3ca95790401e42e94efc0a5R23-R25): Updated to include new functions `loads`, `dump`, and `dumps` in the module exports. [[1]](diffhunk://#diff-6d7a3e1d2ab5ef98f0b8653434261a6a2785a8c8a3ca95790401e42e94efc0a5R23-R25) [[2]](diffhunk://#diff-6d7a3e1d2ab5ef98f0b8653434261a6a2785a8c8a3ca95790401e42e94efc0a5L54-R57) [[3]](diffhunk://#diff-6d7a3e1d2ab5ef98f0b8653434261a6a2785a8c8a3ca95790401e42e94efc0a5R66-R68)

### Code Refactoring:
* Updated various example scripts and documentation files to use the new `loads` and `dumps` functions instead of `load` and `dumps` methods. 

### Test Updates:
* Updated test files to use the new `loads` and `dumps` functions. This includes changes across multiple test files to ensure compatibility with the new functions.

### Internal Function Renaming:
* [`pyqasm/modules/base.py`](diffhunk://#diff-026023a6d07afc34f0e55c76079b5a4f28fe899adacb5bde5f7f4ee880d43244L477-R477): Renamed the `dumps` method to `qasm_str` to avoid conflicts with the new `dumps` function. [[1]](diffhunk://#diff-026023a6d07afc34f0e55c76079b5a4f28fe899adacb5bde5f7f4ee880d43244L477-R477) [[2]](diffhunk://#diff-026023a6d07afc34f0e55c76079b5a4f28fe899adacb5bde5f7f4ee880d43244L488-L496)