### PR TITLE
elements to dataclasses & reduce redundant code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Types of changes:
 
 ### Improved / Modified
 - Changed the `__init__` method for the `QasmModule` class to only accept an `openqasm3.ast.Program` object as input ([#71](https://github.com/qBraid/pyqasm/pull/71))
-- Changed `DepthNode`, `QubitDepthNode` and `ClbitDepthNode` to dataclasses. `__repr__` method is therefore handled automatically and you don't need all of the redundant private / public attribute and setters ([#79](https://github.com/qBraid/pyqasm/pull/79))
+- Changed `DepthNode`, `QubitDepthNode`, `ClbitDepthNode`, and `Variable` to dataclasses. `__repr__` method is therefore handled automatically and you don't need all of the redundant private / public attribute and setters ([#79](https://github.com/qBraid/pyqasm/pull/79))
 - Simplified `map_qasm_op_to_callable` redundant `KeyError` handling with loop ([#79](https://github.com/qBraid/pyqasm/pull/79))
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Types of changes:
 
 ### Improved / Modified
 - Changed the `__init__` method for the `QasmModule` class to only accept an `openqasm3.ast.Program` object as input ([#71](https://github.com/qBraid/pyqasm/pull/71))
+- Changed `DepthNode`, `QubitDepthNode` and `ClbitDepthNode` to dataclasses. `__repr__` method is therefore handled automatically and you don't need all of the redundant private / public attribute and setters ([#79](https://github.com/qBraid/pyqasm/pull/79))
+- Simplified `map_qasm_op_to_callable` redundant `KeyError` handling with loop ([#79](https://github.com/qBraid/pyqasm/pull/79))
 
 ### Deprecated
 

--- a/pyqasm/elements.py
+++ b/pyqasm/elements.py
@@ -12,6 +12,7 @@
 Module defining Qasm Converter elements.
 
 """
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Optional, Union
 
@@ -38,127 +39,62 @@ class Context(Enum):
     GATE = "gate"
 
 
+@dataclass
 class DepthNode:
     """Base class for depth nodes."""
 
-    def __init__(self, reg_name: str, reg_index: int):
-        self._depth = 0
-        self._reg_name = reg_name
-        self._reg_index = reg_index
-
-    @property
-    def depth(self) -> int:
-        """Return the depth of the node."""
-        return self._depth
-
-    @depth.setter
-    def depth(self, value: int):
-        """Set the depth of the node."""
-        self._depth = value
-
-    @property
-    def reg_name(self) -> str:
-        """Return the register name."""
-        return self._reg_name
-
-    @reg_name.setter
-    def reg_name(self, value: str):
-        """Set the register name."""
-        self._reg_name = value
-
-    @property
-    def reg_index(self) -> int:
-        """Return the register index."""
-        return self._reg_index
-
-    @reg_index.setter
-    def reg_index(self, value: int):
-        """Set the register index."""
-        self._reg_index = value
+    reg_name: str
+    reg_index: int
+    depth: int = 0
 
 
+@dataclass
 class QubitDepthNode(DepthNode):
     """Qubit depth node."""
 
-    def __init__(self, reg_name: str, reg_index: int):
-        super().__init__(reg_name, reg_index)
-        self.num_resets = 0
-        self.num_measurements = 0
-        self.num_gates = 0
-        self.num_barriers = 0
+    num_resets: int = 0
+    num_measurements: int = 0
+    num_gates: int = 0
+    num_barriers: int = 0
 
-    def __repr__(self) -> str:
-        return (
-            f"QubitDepthNode(reg_name = {self.reg_name}, reg_index = {self.reg_index}, "
-            f"depth = {self.depth})"
-        )
-
-    def _total_ops(self):
+    def _total_ops(self) -> int:
         return self.num_resets + self.num_measurements + self.num_gates + self.num_barriers
 
-    def is_idle(self):
+    def is_idle(self) -> bool:
         return self._total_ops() == 0
 
 
+@dataclass
 class ClbitDepthNode(DepthNode):
     """Classical bit depth node."""
 
-    def __init__(self, reg_name: str, reg_index: int):
-        super().__init__(reg_name, reg_index)
-        self.num_measurements = 0
+    num_measurements: int = 0
 
-    def __repr__(self) -> str:
-        return (
-            f"ClbitDepthNode(reg_name = {self.reg_name}, reg_index = {self.reg_index},"
-            f" depth = {self.depth})"
-        )
-
-    def is_idle(self):
+    def is_idle(self) -> bool:
         return self.num_measurements == 0
 
 
-# pylint: disable-next=too-many-instance-attributes
-class Variable:
+@dataclass
+class Variable:  # pylint: disable=too-many-instance-attributes
     """
-    Class representing an openqasm variable.
+    Class representing an OpenQASM variable.
 
-    Args:
+    Attributes:
         name (str): Name of the variable.
         base_type (Any): Base type of the variable.
         base_size (int): Base size of the variable.
-        dims (list[int]): Dimensions of the variable.
-        value (Optional[Union[int, float, list]]): Value of the variable.
+        dims (Optional[List[int]]): Dimensions of the variable.
+        value (Optional[Union[int, float, np.ndarray]]): Value of the variable.
         is_constant (bool): Flag indicating if the variable is constant.
         is_register (bool): Flag indicating if the variable is a register.
-        readonly(bool): Flag indicating if the variable is readonly.
-
+        readonly (bool): Flag indicating if the variable is readonly.
     """
 
-    # pylint: disable-next=too-many-arguments,
-    def __init__(
-        self,
-        name: str,
-        base_type: Any,
-        base_size: int,
-        dims: Optional[list[int]] = None,
-        value: Optional[Union[int, float, np.ndarray]] = None,
-        is_constant: bool = False,
-        is_register: bool = False,
-        readonly: bool = False,
-    ):
-        self.name = name
-        self.base_type = base_type
-        self.base_size = base_size
-        self.dims = dims
-        self.value = value
-        self.is_constant = is_constant
-        self.is_register = is_register
-        self.readonly = readonly
-
-    def __repr__(self) -> str:
-        return (
-            f"Variable(name = {self.name}, base_type = {self.base_type}, "
-            f"base_size = {self.base_size}, dimensions = {self.dims}, "
-            f"value = {self.value}, is_constant = {self.is_constant}, "
-            f"readonly = {self.readonly}, is_register = {self.is_register})"
-        )
+    name: str
+    base_type: Any
+    base_size: int
+    dims: Optional[list[int]] = None
+    value: Optional[Union[int, float, np.ndarray]] = None
+    is_constant: bool = False
+    is_register: bool = False
+    readonly: bool = False

--- a/pyqasm/maps.py
+++ b/pyqasm/maps.py
@@ -910,7 +910,7 @@ THREE_QUBIT_OP_MAP = {
 }
 
 
-def map_qasm_op_to_callable(op_name: str):
+def map_qasm_op_to_callable(op_name: str) -> tuple[Callable, int]:
     """
     Map a QASM operation to a callable.
 
@@ -919,23 +919,24 @@ def map_qasm_op_to_callable(op_name: str):
 
     Returns:
         tuple: A tuple containing the callable and the number of qubits the operation acts on.
+
+    Raises:
+        ValidationError: If the QASM operation is unsupported or undeclared.
     """
-    try:
-        return ONE_QUBIT_OP_MAP[op_name], 1
-    except KeyError:
-        pass
-    try:
-        return ONE_QUBIT_ROTATION_MAP[op_name], 1
-    except KeyError:
-        pass
-    try:
-        return TWO_QUBIT_OP_MAP[op_name], 2
-    except KeyError:
-        pass
-    try:
-        return THREE_QUBIT_OP_MAP[op_name], 3
-    except KeyError as exc:
-        raise ValidationError(f"Unsupported / undeclared QASM operation: {op_name}") from exc
+    op_maps: list[tuple[dict, int]] = [
+        (ONE_QUBIT_OP_MAP, 1),
+        (ONE_QUBIT_ROTATION_MAP, 1),
+        (TWO_QUBIT_OP_MAP, 2),
+        (THREE_QUBIT_OP_MAP, 3),
+    ]
+
+    for op_map, qubit_count in op_maps:
+        try:
+            return op_map[op_name], qubit_count
+        except KeyError:
+            continue
+
+    raise ValidationError(f"Unsupported / undeclared QASM operation: {op_name}")
 
 
 SELF_INVERTING_ONE_QUBIT_OP_SET = {"id", "h", "x", "y", "z"}


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

## Summary of changes

- Changed `DepthNode`, `QubitDepthNode`, `ClbitDepthNode`, and `Variable` to dataclasses. `__repr__` method is therefore handled automatically and you don't need all of the redundant private / public attribute and setters
- Simplified `map_qasm_op_to_callable` redundant `KeyError` handling with loop
