### PR TITLE
Add more gate definitions for sdk integration

### DIFF
--- a/tests/qasm3/test_format.py
+++ b/tests/qasm3/test_format.py
@@ -12,6 +12,7 @@
 Module containing unit tests for program formatting
 
 """
+import pytest
 
 from pyqasm.entrypoint import dumps, loads
 from tests.utils import check_unrolled_qasm
@@ -66,3 +67,167 @@ def test_empty_lines_removed_from_qasm():
     actual_qasm3_string = dumps(result)
 
     check_unrolled_qasm(actual_qasm3_string, expected_qasm3_string)
+
+
+def test_convert_qasm_pi_to_decimal_qasm3_fns_gates_vars():
+    """Test converting pi symbol to decimal in a qasm3 string
+    with custom functions, gates, and variables."""
+    qasm3_string = """
+    OPENQASM 3;
+    include "stdgates.inc";
+
+    gate pipe q {
+        gpi(0) q;
+    }
+
+    const int[32] primeN = 3;
+    const float[32] c = primeN*pi/4;
+    qubit[3] q;
+
+    def spiral(qubit[primeN] q_func) {
+    for int i in [0:primeN-1] { 
+        pipe q_func[i]; 
+        }
+    }
+
+    spiral(q);
+
+    ry(c) q[0];
+
+    bit[3] result;
+    result = measure q;
+    """
+
+    expected_qasm3_string = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[3] q;
+    gpi(0) q[0];
+    gpi(0) q[1];
+    gpi(0) q[2];
+    ry(2.356194490192345) q[0];
+    bit[3] result;
+    result[0] = measure q[0];
+    result[1] = measure q[1];
+    result[2] = measure q[2];"""
+
+    result = loads(qasm3_string)
+    result.unroll(external_gates=["gpi"])
+    actual_qasm3_string = dumps(result)
+
+    check_unrolled_qasm(actual_qasm3_string, expected_qasm3_string)
+
+
+def test_convert_qasm_pi_to_decimal():
+    """Test converting pi symbol to decimal in qasm string with gpi2 gate on its own."""
+    qasm3_string = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    gpi(pi/4) q[0];
+    h q[0];
+    rx(pi / 4) q[0];
+    ry(2*pi) q[0];
+    rz(3 * pi/4) q[0];
+    cry(pi/4/2) q[0], q[1];
+    """
+
+    expected_qasm3_string = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    gpi(0.7853981633974483) q[0];
+    h q[0];
+    rx(0.7853981633974483) q[0];
+    ry(6.283185307179586) q[0];
+    rz(2.356194490192345) q[0];
+    cry(0.39269908169872414) q[0], q[1];
+    """
+    result = loads(qasm3_string)
+    result.unroll(external_gates=["gpi", "cry"])
+    actual_qasm3_string = dumps(result)
+
+    check_unrolled_qasm(actual_qasm3_string, expected_qasm3_string)
+
+
+@pytest.mark.parametrize(
+    "qasm_input, expected_result",
+    [
+        (
+            """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    cry((0.39269908169872414)) q[0], q[1];
+    """,
+            """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    cry(0.39269908169872414) q[0], q[1];
+    """,
+        ),
+        (
+            """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    crx(-(0.39269908169872414)) q[0], q[1];
+    """,
+            """OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    crx(-0.39269908169872414) q[0], q[1];""",
+        ),
+        (
+            """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    cry((0.7853981633974483)) q[0], q[1];
+    ry(-(0.39269908169872414)) q[1];
+    """,
+            """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    cry(0.7853981633974483) q[0], q[1];
+    ry(-0.39269908169872414) q[1];
+    """,
+        ),
+    ],
+)
+def test_simplify_redundant_parentheses(qasm_input, expected_result):
+    """Test simplifying redundant parentheses in qasm string"""
+    module = loads(qasm_input)
+    module.unroll(external_gates=["cry", "crx", "ry"])
+    actual_result = dumps(module)
+    check_unrolled_qasm(actual_result, expected_result)
+
+
+@pytest.mark.parametrize(
+    "qasm3_without, qasm3_with",
+    [
+        (
+            """
+        OPENQASM 3.0;
+        qubit[1] q;
+        h q[0];
+        ry(pi/4) q[0];
+                """,
+            """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        qubit[1] q;
+        h q[0];
+        ry(0.7853981633974483) q[0];
+        """,
+        ),
+    ],
+)
+def test_add_stdgates_include(qasm3_without, qasm3_with):
+    """Test adding stdgates include to OpenQASM 3.0 string"""
+    module = loads(qasm3_without)
+    module.unroll()
+    actual_qasm3 = dumps(module)
+    check_unrolled_qasm(actual_qasm3, qasm3_with)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -63,6 +63,13 @@ def _check_ch_gate_op(unrolled_ast, num_gates, qubits):
     check_single_qubit_gate_op(unrolled_ast, num_gates, [qubits[1]] * num_gates, "sdg")
 
 
+def _check_iswap_gate_op(unrolled_ast, num_gates, qubits):
+    check_single_qubit_gate_op(unrolled_ast, 2 * num_gates, qubits * num_gates, "s")
+    cx_gate_qubits = [qubits, qubits[::-1]] * num_gates
+    check_two_qubit_gate_op(unrolled_ast, 2 * num_gates, cx_gate_qubits, "cx")
+    check_single_qubit_gate_op(unrolled_ast, 2 * num_gates, qubits * num_gates, "h")
+
+
 def _check_crx_gate_op(unrolled_ast, num_gates, qubits, theta):
     num_u3_gates = 3 * num_gates
     check_u3_gate_op(
@@ -147,9 +154,7 @@ def check_two_qubit_gate_op(unrolled_ast, num_gates, qubit_list, gate_name):
     if gate_name == "cnot":
         gate_name = "cx"
 
-    controlled_gate_tests = {
-        "ch": _check_ch_gate_op,
-    }
+    controlled_gate_tests = {"ch": _check_ch_gate_op, "iswap": _check_iswap_gate_op}
     controlled_rotation_gate_tests = {
         "crx": _check_crx_gate_op,
         "crz": _check_crz_gate_op,


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

## Summary of changes
This pull request includes several changes to the `pyqasm/maps.py` file, mainly focusing on adding new gate implementations and updating existing ones. 

### New Gate Implementations:
* Added the `iswap_gate` function to implement the iSwap gate as a decomposition of other gates.
* Added the `cu_gate` function to implement the CU gate, and updated the `cu3_gate` function to use `u3_gate` for decomposition.
* Added the `cu1_gate` function to implement the CU1 gate as a decomposition of other gates.
* Added the `cphaseshift_gate` function to implement the controlled phase shift gate using `u3_gate` for decomposition.

### Removed/Updated Gate Implementations:
* Removed the `xx_gate` function and replaced its usage with `rxx_gate` in the gate map. [[1]](diffhunk://#diff-8d578f59e7a96eb1bc542fd42dec5ee0d9efbffbe9c0d0b0a00d098723ddf666L232-L250) [[2]](diffhunk://#diff-8d578f59e7a96eb1bc542fd42dec5ee0d9efbffbe9c0d0b0a00d098723ddf666L879-R984)
* Updated the `cu3_gate` function to use `u3_gate` instead of `phaseshift_gate` for decomposition.

### Test Updates:
* Added `_check_iswap_gate_op` function to test the `iswap_gate` implementation.
* Updated the `check_two_qubit_gate_op` function to include the `iswap` gate.
* Migrated tests from `tests.passes.test_qasm3_format.py` 
