### PR TITLE
Add more gate definitions for `maps.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ include "stdgates.inc";
 qubit[2] q1;
 qubit[2] q2;
 ```
+- Added definitions for various gates in `maps.py` and tests for qasm formatting functions of the qbraid-sdk([#82](https://github.com/qBraid/pyqasm/pull/82))
 
 ### Improved / Modified
 - Changed the `__init__` method for the `QasmModule` class to only accept an `openqasm3.ast.Program` object as input ([#71](https://github.com/qBraid/pyqasm/pull/71))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ include "stdgates.inc";
 qubit[2] q1;
 qubit[2] q2;
 ```
-- Added definitions for various gates in `maps.py` and tests for qasm formatting functions of the qbraid-sdk([#82](https://github.com/qBraid/pyqasm/pull/82))
+- Added definitions for various gates in `maps.py` and tests for qasm formatting functions of the qbraid-sdk ([#82](https://github.com/qBraid/pyqasm/pull/82), [#84](https://github.com/qBraid/pyqasm/pull/84))
 
 ### Improved / Modified
 - Changed the `__init__` method for the `QasmModule` class to only accept an `openqasm3.ast.Program` object as input ([#71](https://github.com/qBraid/pyqasm/pull/71))

--- a/tests/qasm3/resources/gates.py
+++ b/tests/qasm3/resources/gates.py
@@ -24,7 +24,7 @@ from pyqasm.maps import (
     THREE_QUBIT_OP_MAP,
     TWO_QUBIT_OP_MAP,
 )
-from tests.utils import CONTROLLED_ROTATION_ANGLE_1
+from tests.utils import CONTROLLED_ROTATION_TEST_ANGLE
 
 CUSTOM_OPS = ["simple", "nested", "complex"]
 
@@ -106,17 +106,20 @@ def _generate_two_qubit_fixture(gate_name: str):
         if not _validate_gate_name(gate_name):
             raise ValueError(f"Unknown qasm3 gate {gate_name}")
 
-        theta = ""
-        if gate_name in ["crz", "crx", "cry", "rzz", "rxx"]:
-            theta = f"({CONTROLLED_ROTATION_ANGLE_1})"
+        params = ""
+        if gate_name in ["crz", "crx", "cry", "rzz", "rxx", "ryy"]:
+            params = f"({CONTROLLED_ROTATION_TEST_ANGLE})"
+
+        if gate_name in ["xx_plus_yy"]:
+            params = f"({CONTROLLED_ROTATION_TEST_ANGLE},{CONTROLLED_ROTATION_TEST_ANGLE})"
 
         qasm3_string = f"""
         OPENQASM 3;
         include "stdgates.inc";
 
         qubit[2] q;
-        {gate_name}{theta} q[0], q[1];
-        {gate_name}{theta} q;
+        {gate_name}{params} q[0], q[1];
+        {gate_name}{params} q;
         """
         return qasm3_string
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

## Summary of changes

### New Gate Definitions and Updates:
* Added definitions for various gates in `maps.py`, including `xy_gate`, `xx_plus_yy_gate`, and `ryy_gate`. The `cv_gate` was replaced with `csx_gate` [[1]](diffhunk://#diff-8d578f59e7a96eb1bc542fd42dec5ee0d9efbffbe9c0d0b0a00d098723ddf666L169-L190)], [[2]](diffhunk://#diff-8d578f59e7a96eb1bc542fd42dec5ee0d9efbffbe9c0d0b0a00d098723ddf666R213-R302)]).
* Updated the `two_qubit_gate_op` function to include new gates such as `rxx`, `ryy`, and `xx_plus_yy` [[1]](diffhunk://#diff-8d578f59e7a96eb1bc542fd42dec5ee0d9efbffbe9c0d0b0a00d098723ddf666L965-R1005)], [[2]](diffhunk://#diff-8d578f59e7a96eb1bc542fd42dec5ee0d9efbffbe9c0d0b0a00d098723ddf666L979)]).

### Test Enhancements:
* Updated `tests/qasm3/resources/gates.py` to include new test angles and gate parameters for the newly added gates [[1]](diffhunk://#diff-f98ff4dd2f7e035aff7a3fdc729d8fed702d9d31ca8cd478ed6aea611f0cfe4fL27-R27)], [[2]](diffhunk://#diff-f98ff4dd2f7e035aff7a3fdc729d8fed702d9d31ca8cd478ed6aea611f0cfe4fL109-R122)]).
* Added new test functions in `tests/utils.py` to validate the unrolling of new gates like `ryy` and `xx_plus_yy` [[1]](diffhunk://#diff-9e08e8c7769db7b58089fd7659d75ca96df40bb7b5d50299d3a30abd54da9ad6R136-R155)], [[2]](diffhunk://#diff-9e08e8c7769db7b58089fd7659d75ca96df40bb7b5d50299d3a30abd54da9ad6R172-R198)]).
