### PR TITLE
Fix pre-release for linux

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -86,6 +86,11 @@ jobs:
       - name: Build and Test Wheels
         env: 
           PRE_RELEASE_BUILD: "true"
+          # The linux builds happen inside a docker container 
+          # and if we are using the pre-release build, we need to pass
+          # the pre-release env variable to the docker container
+          # Ref : https://cibuildwheel.pypa.io/en/stable/options/#environment-pass
+          CIBW_ENVIRONMENT_PASS_LINUX: PRE_RELEASE_BUILD
           CIBW_BUILD: "cp${{ matrix.python }}-${{ matrix.platform_id }}"
           CIBW_ARCHS_LINUX: x86_64
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

## Summary of changes
This pull request includes a small change to the `.github/workflows/pre-release.yml` file. The change ensures that the `PRE_RELEASE_BUILD` environment variable is passed to the Docker container during the Linux builds for pre-release builds.

* [`.github/workflows/pre-release.yml`](diffhunk://#diff-8f0c4d810b263ab478547020c847ee0297cc98c11c67fc2209ce604e52719607R89-R93): Added the `CIBW_ENVIRONMENT_PASS_LINUX` environment variable to pass the `PRE_RELEASE_BUILD` variable to the Docker container during pre-release builds.