### PR TITLE
Add check for unix style EOL

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,6 +21,6 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install tox>=4.2.0
-      - name: Check isort, black, mypy, pylint, headers
+      - name: Check isort, black, EOL, mypy, pylint, headers
         run: |
           tox -e format-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ if (c[0] == false) {
   }
 }
 ```
+- Add formatting check for Unix style line endings i.e. `\n`. For any other line endings, errors are raised. ([#130](https://github.com/qBraid/pyqasm/pull/130))
 
 ### Improved / Modified
  - Refactored the initialization of `QasmModule` to remove default include statements. Only user supplied include statements are now added to the generated QASM code ([#86](https://github.com/qBraid/pyqasm/pull/86))

--- a/bin/check_line_endings.py
+++ b/bin/check_line_endings.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2025 qBraid
+#
+# This file is part of PyQASM
+#
+# PyQASM is free software released under the GNU General Public License v3
+# or later. You can redistribute and/or modify it under the terms of the GPL v3.
+# See the LICENSE file in the project root or <https://www.gnu.org/licenses/gpl-3.0.html>.
+#
+# THERE IS NO WARRANTY for PyQASM, as per Section 15 of the GPL v3.
+
+"""
+Check that all Python files in the project have Unix line endings (LF).
+"""
+
+import os
+
+
+def check_line_endings(directory):
+    failures = []
+    for root, _, files in os.walk(directory):
+        for file in files:
+            if not file.endswith(".py"):
+                continue
+            file_path = os.path.join(root, file)
+            try:
+                with open(file_path, "rb") as f:
+                    for line in f:
+                        if line.endswith(b"\r\n") or line.endswith(b"\r"):
+                            failures.append(file_path)
+                            break
+            except OSError as e:
+                print(f"Could not check file '{file_path}': {e}")
+
+    return failures
+
+
+if __name__ == "__main__":
+    failed_files = []
+
+    pyqasm_root = os.path.join(os.getcwd(), "src", "pyqasm")
+    failed_files.extend(check_line_endings(pyqasm_root))
+
+    tests = os.path.join(os.getcwd(), "tests")
+    failed_files.extend(check_line_endings(tests))
+
+    bin_dir = os.path.join(os.getcwd(), "bin")
+    failed_files.extend(check_line_endings(bin_dir))
+
+    if failed_files:
+        raise ValueError(
+            f"Error: {len(failed_files)} have incorrect line endings:\n" + "\n".join(failed_files)
+        )
+    print("\033[92mSuccess: All Python files have Unix line endings (LF).\033[0m")

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,11 @@ deps = black
 commands =
     black src tests bin examples {posargs}
 
+[testenv:line_endings]
+skip_install = true
+commands = 
+    python bin/check_line_endings.py
+
 [testenv:mypy]
 envdir = .tox/linters
 skip_install = true
@@ -86,5 +91,6 @@ commands =
     {[testenv:pylint]commands}
     {[testenv:isort]commands} {posargs:--check-only}
     {[testenv:black]commands} {posargs:--check}
+    {[testenv:line_endings]commands}
     {[testenv:mypy]commands}
     {[testenv:headers]commands}


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

## Summary of changes
- Add a format check in `tox` for Unix style line ending for `.py` files 