### PR TITLE
Solve version discrepancy in release

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -129,6 +129,8 @@ jobs:
         run: bash bin/build_sdist.sh
 
       - name: Test source distribution
+        env:
+          RELEASE_BUILD: "true"
         run: bash bin/test_sdist.sh
 
       - name: Store artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,8 @@ jobs:
         run: bash bin/build_sdist.sh
 
       - name: Test source distribution
+        env:
+          RELEASE_BUILD: "true"
         run: bash bin/test_sdist.sh
 
       - name: Store artifacts

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include README.md
 recursive-include src/pyqasm *.py *.pyx
 include src/pyqasm/py.typed
+
+exclude tests/*

--- a/bin/build_sdist.sh
+++ b/bin/build_sdist.sh
@@ -19,6 +19,10 @@ set -x
 # current working directory
 TARGET_PATH="${1:-$(pwd)}"
 
+# Reset the uncommitted changes which may have been made
+git reset --hard HEAD
+git clean -xdf
+
 # Create a temporary dir, XXXXX will be replaced by a random string
 # of 5 chars to make the directory unique
 TEMP_ENV_DIR=$(mktemp -d -t build_env_XXXXX)

--- a/bin/cibw/pre_build.sh
+++ b/bin/cibw/pre_build.sh
@@ -23,6 +23,10 @@ echo "Running pre_build.sh"
 # Script has an argument which is the project path 
 project=$1
 
+# Reset any uncommitted changes which may have been made
+git reset --hard HEAD 
+git clean -xdf
+
 # Upgrade pip
 python -m pip install --upgrade pip
 

--- a/bin/test_sdist.sh
+++ b/bin/test_sdist.sh
@@ -30,8 +30,27 @@ SCRIPT_DIR="$TARGET_PATH/bin"
 
 "$SCRIPT_DIR/install_wheel_extras.sh" "$TARGET_PATH/dist" --type sdist --extra cli --extra test
 
-# Check the installed version
+# Print the installed version
 python -c "import pyqasm; print('Installed pyqasm version:', pyqasm.__version__)"
+
+# Verify the installed version if release build
+if [[ ${RELEASE_BUILD:-false} == "true" ]]; then
+    echo "Testing release build version"
+    
+    # get version from importlib 
+    IMPORTLIB_VERSION=$(python -c "import importlib.metadata; print(importlib.metadata.version('pyqasm'))")
+    echo "Importlib version: $IMPORTLIB_VERSION"
+    
+    # get version from __version__ 
+    VERSION_ATTRIBUTE=$(python -c "import pyqasm; print(pyqasm.__version__)")
+    echo "Version attribute: $VERSION_ATTRIBUTE"
+    
+    # check if the versions are the same
+    if [[ $IMPORTLIB_VERSION != $VERSION_ATTRIBUTE ]]; then
+        echo "Versions do not match"
+        exit 1
+    fi
+fi
 
 # Run the tests on the installed source distribution
 pytest "$TARGET_PATH/tests"

--- a/bin/test_sdist.sh
+++ b/bin/test_sdist.sh
@@ -30,6 +30,9 @@ SCRIPT_DIR="$TARGET_PATH/bin"
 
 "$SCRIPT_DIR/install_wheel_extras.sh" "$TARGET_PATH/dist" --type sdist --extra cli --extra test
 
+# Check the installed version
+python -c "import pyqasm; print('Installed pyqasm version:', pyqasm.__version__)"
+
 # Run the tests on the installed source distribution
 pytest "$TARGET_PATH/tests"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyqasm"
-version = "0.2.0"
+version = "0.2.1-alpha"
 description = "Python toolkit providing an OpenQASM 3 semantic analyzer and utilities for program analysis and compilation."
 authors = [{name = "qBraid Development Team"}, {email = "contact@qbraid.com"}]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ lint = ["black", "isort>=6.0.0", "pylint", "mypy", "qbraid-cli>=0.8.5"]
 docs = ["sphinx>=7.3.7,<8.2.0", "sphinx-autodoc-typehints>=1.24,<3.1", "sphinx-rtd-theme>=2.0.0,<4.0.0", "docutils<0.22", "sphinx-copybutton"]
 
 [tool.setuptools_scm]
+version_scheme = "no-guess-dev"
 write_to = "src/pyqasm/_version.py"
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

### Issue
- Releasing `v0.2.0` resulted in a version discrepancy - 

```bash
>> python3 --version
Python 3.11.6

>> pip install pyqasm==0.2.0
Collecting pyqasm==0.2.0
  Using cached pyqasm-0.2.0-cp311-cp311-macosx_11_0_arm64.whl.metadata (5.8 kB)
Requirement already satisfied: numpy in /Users/thegupta/Desktop/qBraid/envs/pyqasm/lib/python3.11/site-packages (from pyqasm==0.2.0) (2.2.3)
Requirement already satisfied: openqasm3<2.0.0,>=1.0.0 in /Users/thegupta/Desktop/qBraid/envs/pyqasm/lib/python3.11/site-packages (from openqasm3[parser]<2.0.0,>=1.0.0->pyqasm==0.2.0) (1.0.0)
Requirement already satisfied: antlr4-python3-runtime<4.14,>=4.7 in /Users/thegupta/Desktop/qBraid/envs/pyqasm/lib/python3.11/site-packages (from openqasm3[parser]<2.0.0,>=1.0.0->pyqasm==0.2.0) (4.13.2)
Using cached pyqasm-0.2.0-cp311-cp311-macosx_11_0_arm64.whl (171 kB)
Installing collected packages: pyqasm
Successfully installed pyqasm-0.2.0

>> python3 -c 'import importlib.metadata
print(importlib.metadata.version("pyqasm"))
import pyqasm
print(pyqasm.__version__)
'
0.2.0
0.2.1.dev0+g0fd2956.d20250214
```

It is unclear why this happened but one change might be the `pip` version used by `cibuildwheel` in GitHub runner. The release [`v0.2.0` used `pip==25.0.1`](https://github.com/qBraid/pyqasm/actions/runs/13328675191/job/37227561706#step:4:254) whereas [`v0.1.0` used `pip==24.3.1`](https://github.com/qBraid/pyqasm/actions/runs/12250020169/job/34172285892#step:4:234) on the runners. 

## Summary of changes
- To get reproducible results, have added `_version.py` in the repo and used the `dynamic` attribute in `.toml` to get the version ([as in the qBraid SDK](https://github.com/qBraid/qBraid/blob/c44a871ecb74cf01b0c0927175bf15b7a6673610/qbraid/_version.py)). 

- This eliminates the dependency on `setuptools_scm`

--- 

> ## **Edit** : 19 / 02 / 2025
- The version `0.2.1.dev0+g0fd2956.d20250214` matches the [4th option of **Default Versioning Scheme** in the docs] (https://setuptools-scm.readthedocs.io/en/latest/usage/)
- This implies that there were uncommited changes in the repository during the build process
- Even though the commit `0fd2956` was tagged with `v0.2.0`, EOL changes might have happened due to the newly added `.gitattributes` file

## Summary of changes
- Added `git reset` in the pre-build script to ensure that no uncommitted changes are passed into the build process
- Using `no-guess-dev` value for `version_scheme` to ensure that no `dev` suffixes are present in the version
