### PR TITLE
Add check for duplicate qubits post gate broadcast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,34 @@ Types of changes:
 
 ### Fixed
 - Fixed bug in release workflow(s) that caused discrepancy between `pyqasm.__version__` and `importlib.metadata.version` ([#147](https://github.com/qBraid/pyqasm/pull/147))
+- Fixed a bug in broadcast operation for duplicate qubits so that the following  - 
+
+```qasm
+OPENQASM 3.0;
+include "stdgates.inc";
+qubit[3] q;
+qubit[2] q2;
+cx q[0], q[1], q[1], q[2];
+cx q2, q2;
+```
+
+will unroll correctly to - 
+
+```qasm
+OPENQASM 3.0;
+include "stdgates.inc";
+qubit[3] q;
+qubit[2] q2;
+// cx q[0], q[1], q[1], q[2];
+cx q[0], q[1];
+cx q[1], q[2];
+
+// cx q2, q2;
+cx q2[0], q2[1];
+cx q2[0], q2[1];
+```
+
+The logic for duplicate qubit detection is moved out of the `QasmVisitor._get_op_bits` into `Qasm3Analyzer` class and is executed post gate broadcast operation ([#155](https://github.com/qBraid/pyqasm/pull/155)).
 
 ### Dependencies
 

--- a/tests/qasm3/resources/gates.py
+++ b/tests/qasm3/resources/gates.py
@@ -304,6 +304,16 @@ SINGLE_QUBIT_GATE_INCORRECT_TESTS = {
         """,
         "Undefined identifier a in.*",
     ),
+    "duplicate_qubits": (
+        """
+        OPENQASM 3;
+        include "stdgates.inc";
+
+        qubit[2] q1;
+        cx q1[0] , q1[0];  // duplicate qubit
+        """,
+        r"Duplicate qubit q1\[0\] in gate cx",
+    ),
 }
 
 # qasm_input, expected_error

--- a/tests/qasm3/test_barrier.py
+++ b/tests/qasm3/test_barrier.py
@@ -146,14 +146,3 @@ def test_incorrect_barrier():
         ValidationError, match="Index 3 out of range for register of size 2 in qubit"
     ):
         loads(out_of_bounds).validate()
-
-    duplicate = """
-    OPENQASM 3.0;
-
-    qubit[2] q1;
-
-    barrier q1, q1;
-    """
-
-    with pytest.raises(ValidationError, match=r"Duplicate qubit .*argument"):
-        loads(duplicate).validate()

--- a/tests/qasm3/test_gates.py
+++ b/tests/qasm3/test_gates.py
@@ -333,6 +333,23 @@ def test_inverse_global_phase():
     check_unrolled_qasm(dumps(module), qasm3_expected)
 
 
+def test_duplicate_qubit_broadcast():
+    qasm3_string = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[3] q;
+    
+    cx q[0], q[1], q[1], q[2];"""
+
+    module = loads(qasm3_string)
+    module.unroll()
+
+    assert module.num_qubits == 3
+    assert module.num_clbits == 0
+
+    check_two_qubit_gate_op(module.unrolled_ast, 2, [[0, 1], [1, 2]], "cx")
+
+
 @pytest.mark.parametrize("test_name", custom_op_tests)
 def test_custom_ops_with_external_gates(test_name, request):
     qasm3_string = request.getfixturevalue(test_name)


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->
Fixes #75 

## Summary of changes

* Introduced the static methods `extract_duplicate_qubit` and `verify_gate_qubits` in `Qasm3Analyzer` to detect and raise errors for duplicate qubits in quantum gates.

* Removed the duplicate bit check logic from the `_get_op_bits` method in `src/pyqasm/visitor.py`, as this validation is now handled by the new `verify_gate_qubits` method. [[1]](diffhunk://#diff-802ca57af29fc92ca8eb2f536fb5217c61c874c4c35bd39b7fd82512ee0e9a84L341) [[2]](diffhunk://#diff-802ca57af29fc92ca8eb2f536fb5217c61c874c4c35bd39b7fd82512ee0e9a84L416-L425)

* Updated the `_visit_basic_gate_operation` and `gate_function` methods in `src/pyqasm/visitor.py` to use the new `verify_gate_qubits` method for checking duplicate qubits. [[1]](diffhunk://#diff-802ca57af29fc92ca8eb2f536fb5217c61c874c4c35bd39b7fd82512ee0e9a84R786-R790) [[2]](diffhunk://#diff-802ca57af29fc92ca8eb2f536fb5217c61c874c4c35bd39b7fd82512ee0e9a84R947-R950)

* Added a new test case for duplicate qubits in `tests/qasm3/resources/gates.py` to ensure the new validation logic works as expected.