### PR TITLE
Fix draw bug in pyqasm printer 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ barrier q3[0];
 ### Removed
 
 ### Fixed
+- Resolved the inconsistency in `pyqasm.printer.draw` and `pyqasm.printer.mpl_draw` behaviour for multiple function calls. See issue [#165](https://github.com/qBraid/pyqasm/issues/165) for bug details. ([#168](https://github.com/qBraid/pyqasm/pull/168))
 
 ### Dependencies
 

--- a/src/pyqasm/printer.py
+++ b/src/pyqasm/printer.py
@@ -89,13 +89,21 @@ def draw(
         program = loads(program)
 
     if output == "mpl":
-        mpl_draw(program, idle_wires=idle_wires, **kwargs)
+        _ = mpl_draw(program, idle_wires=idle_wires, external_draw=False, **kwargs)
+
+        import matplotlib.pyplot as plt
+
+        if not plt.isinteractive():
+            plt.show()
     else:
         raise ValueError(f"Unsupported output format: {output}")
 
 
-def mpl_draw(
-    program: str | QasmModule, idle_wires: bool = True, filename: str | Path | None = None
+def mpl_draw(  # pylint: disable=too-many-locals
+    program: str | QasmModule,
+    idle_wires: bool = True,
+    filename: str | Path | None = None,
+    external_draw: bool = True,
 ) -> plt.Figure:
     """Internal matplotlib drawing implementation."""
     if isinstance(program, str):
@@ -141,6 +149,9 @@ def mpl_draw(
 
     if filename is not None:
         plt.savefig(filename, bbox_inches="tight", dpi=300)
+
+    if external_draw:
+        plt.close(fig)
 
     return fig
 

--- a/tests/visualization/test_mpl_draw.py
+++ b/tests/visualization/test_mpl_draw.py
@@ -18,9 +18,8 @@ Tests for the QASM printer module.
 
 import pytest
 
-from pyqasm import draw
 from pyqasm.entrypoint import loads
-from pyqasm.printer import mpl_draw
+from pyqasm.printer import draw, mpl_draw
 
 pytest.importorskip("matplotlib", reason="Matplotlib not installed.")
 
@@ -111,7 +110,7 @@ def test_draw_bell():
     cnot q[0], q[1];
     b = measure q;
     """
-    fig = draw(qasm3, output="mpl")
+    fig = mpl_draw(qasm3)
     return fig
 
 
@@ -134,5 +133,21 @@ def test_draw_misc_ops():
     measure q;
     reset q;
     """
-    fig = draw(qasm3, output="mpl")
+    fig = mpl_draw(qasm3)
     return fig
+
+
+def test_draw_raises_unsupported_format_error():
+    """Test that an error is raised for unsupported formats."""
+    qasm = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    h q;
+    cnot q[0], q[1];
+    measure q;
+    """
+    circ = loads(qasm)
+
+    with pytest.raises(ValueError, match=r"Unsupported output format"):
+        draw(circ, output="unsupported_format")


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->
Fixes #165 

## Summary of changes
- Internal to the `mpl_draw` function, the image is being generated during the matplotlib initialization. While I couldn't find that source, closing it with `plt.close` does not display the figure before it is returned to the notebook
- Also, in the original `draw` implementation, the `plt.show` is disabled by default due to the `plt.ioff`. So, needed a check to know if we were in interactive mode or not. 
