### PR TITLE
Add params validation for basic gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,23 @@ barrier q3[0];
 ```
 
 ### Improved / Modified
+- Improved the error messages for the parameter mismatch errors in basic quantum gates ([#169](https://github.com/qBraid/pyqasm/issues/169)). Following error is raised on parameter count mismatch - 
 
+```python
+In [1]: import pyqasm
+   ...: 
+   ...: qasm = """
+   ...: OPENQASM 3;
+   ...: include "stdgates.inc";
+   ...: qubit[2] q;
+   ...: rx(0.5, 1) q[1];
+   ...: """
+   ...: program = pyqasm.loads(qasm)
+   ...: program.validate()
+
+......
+ValidationError: Expected 1 parameter for gate 'rx', but got 2  
+```
 ### Deprecated
 
 ### Removed

--- a/src/pyqasm/maps/gates.py
+++ b/src/pyqasm/maps/gates.py
@@ -1091,6 +1091,39 @@ FIVE_QUBIT_OP_MAP = {
     "c4x": c4x_gate,
 }
 
+PARAMS_OP_SET = {
+    1: {
+        "rx",
+        "ry",
+        "rz",
+        "phaseshift",
+        "p",
+        "gpi",
+        "gpi2",
+        "xx",
+        "rxx",
+        "yy",
+        "ryy",
+        "zz",
+        "rzz",
+        "xy",
+        "pswap",
+        "cp",
+        "cu1",
+        "crx",
+        "cry",
+        "crz",
+        "cphaseshift",
+        "cp10",
+        "cphaseshift01",
+        "cp01",
+        "cp00",
+        "cphaseshift00",
+    },
+    2: {"xx_plus_yy", "u2", "U2"},
+    3: {"ms", "cu3", "u", "U", "u3", "U3"},
+    4: {"cu"},
+}
 BASIS_GATE_MAP = {
     # default basis set is the gate set of the stdgates.inc library file
     BasisSet.DEFAULT: {
@@ -1114,6 +1147,25 @@ BASIS_GATE_MAP = {
     BasisSet.ROTATIONAL_CX: {"rx", "ry", "rz", "cx"},
     BasisSet.CLIFFORD_T: {"h", "t", "s", "cx", "tdg", "sdg"},
 }
+
+
+def map_qasm_op_num_params(op_name: str) -> int:
+    """
+    Map a basic QASM operation to the number of parameters it takes.
+
+    Args:
+        op_name (str): The QASM operation name.
+
+    Returns:
+        int: The number of parameters the operation takes.
+
+    Raises:
+        ValidationError: If the QASM operation is unsupported or undeclared.
+    """
+    for num_params, op_set in PARAMS_OP_SET.items():
+        if op_name in op_set:
+            return num_params
+    return 0
 
 
 def map_qasm_op_to_callable(op_name: str) -> tuple[Callable, int]:

--- a/tests/qasm3/resources/gates.py
+++ b/tests/qasm3/resources/gates.py
@@ -340,7 +340,7 @@ CUSTOM_GATE_INCORRECT_TESTS = {
         """,
         "Unsupported / undeclared QASM operation: custom_gate",
     ),
-    "parameter_mismatch": (
+    "parameter_mismatch_1": (
         """
         OPENQASM 3;
         include "stdgates.inc";
@@ -354,6 +354,20 @@ CUSTOM_GATE_INCORRECT_TESTS = {
         custom_gate(0.5) q1;  // parameter count mismatch
         """,
         "Parameter count mismatch for gate custom_gate: expected 2 arguments, but got 1 instead.",
+    ),
+    "parameter_mismatch_2": (
+        """
+        OPENQASM 3;
+        include "stdgates.inc";
+
+        qubit[2] q;
+
+        rx(0.5) q[1];
+
+        // too many parameters
+        rz(0.5, 0.0) q[0];
+        """,
+        "Expected 1 parameter for gate 'rz', but got 2",
     ),
     "qubit_mismatch": (
         """


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->
Fixes #109 

## Summary of changes

* [`src/pyqasm/maps/gates.py`](diffhunk://#diff-9766fa5395f18fb3a2d7e0148476cd512f11a11dd8d2bf08c948e74d0f755771R1094-R1126): Added `PARAMS_OP_SET` dictionary to define the number of parameters for each QASM operation and implemented the `map_qasm_op_num_params` function to map QASM operations to their respective parameter counts. [[1]](diffhunk://#diff-9766fa5395f18fb3a2d7e0148476cd512f11a11dd8d2bf08c948e74d0f755771R1094-R1126) [[2]](diffhunk://#diff-9766fa5395f18fb3a2d7e0148476cd512f11a11dd8d2bf08c948e74d0f755771R1152-R1170)

* [`src/pyqasm/visitor.py`](diffhunk://#diff-802ca57af29fc92ca8eb2f536fb5217c61c874c4c35bd39b7fd82512ee0e9a84R39): Integrated `map_qasm_op_num_params` into the `_visit_basic_gate_operation` method to validate the number of parameters for each QASM operation and raise an error if there is a mismatch. [[1]](diffhunk://#diff-802ca57af29fc92ca8eb2f536fb5217c61c874c4c35bd39b7fd82512ee0e9a84R39) [[2]](diffhunk://#diff-802ca57af29fc92ca8eb2f536fb5217c61c874c4c35bd39b7fd82512ee0e9a84L772-R787)
