### PR TITLE
Improve error reporting for pyqasm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,98 @@ barrier q1, q2, q3;
 barrier q2[:3];
 barrier q3[0];
 ```
+- Introduced a new environment variable called `PYQASM_EXPAND_TRACEBACK`. This variable can be set to `true` / `false` to enable / disable the expansion of traceback information in the error messages. The default is set as `false`. ([#171](https://github.com/qBraid/pyqasm/issues/171)) Eg. - 
+
+**Script** - 
+```python
+import pyqasm
+
+qasm = """
+    OPENQASM 3;
+    include "stdgates.inc";
+    qubit[2] q1;
+    rx(a) q1;
+    """
+
+program = pyqasm.loads(qasm)
+program.unroll()
+``` 
+
+**Execution** - 
+```bash
+>>> python3 test-traceback.py
+```
+
+```bash
+ERROR:pyqasm: Error at line 5, column 7 in QASM file
+
+ >>>>>> a
+
+ERROR:pyqasm: Error at line 5, column 4 in QASM file
+
+ >>>>>> rx(a) q1[0], q1[1];
+
+
+pyqasm.exceptions.ValidationError: Undefined identifier 'a' in expression
+
+The above exception was the direct cause of the following exception:
+
+pyqasm.exceptions.ValidationError: Invalid parameter 'a' for gate 'rx'
+```
+```bash
+>>> export PYQASM_EXPAND_TRACEBACK=true
+```
+
+```bash
+>>> python3 test-traceback.py
+```
+
+```bash
+ERROR:pyqasm: Error at line 5, column 7 in QASM file
+
+ >>>>>> a
+
+ERROR:pyqasm: Error at line 5, column 4 in QASM file
+
+ >>>>>> rx(a) q1[0], q1[1];
+
+
+Traceback (most recent call last):
+  .....
+
+  File "/Users/thegupta/Desktop/qBraid/repos/pyqasm/src/pyqasm/expressions.py", line 69, in _check_var_in_scope
+    raise_qasm3_error(
+  File "/Users/thegupta/Desktop/qBraid/repos/pyqasm/src/pyqasm/exceptions.py", line 103, in raise_qasm3_error
+    raise err_type(message)
+
+pyqasm.exceptions.ValidationError: Undefined identifier 'a' in expression
+
+The above exception was the direct cause of the following exception:
+
+
+Traceback (most recent call last):
+  .....
+
+  File "/Users/thegupta/Desktop/qBraid/repos/pyqasm/src/pyqasm/visitor.py", line 2208, in visit_basic_block
+    result.extend(self.visit_statement(stmt))
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/thegupta/Desktop/qBraid/repos/pyqasm/src/pyqasm/visitor.py", line 2188, in visit_statement
+    result.extend(visitor_function(statement))  # type: ignore[operator]
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/thegupta/Desktop/qBraid/repos/pyqasm/src/pyqasm/visitor.py", line 1201, in _visit_generic_gate_operation
+    result.extend(self._visit_basic_gate_operation(operation, inverse_value, ctrls))
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/thegupta/Desktop/qBraid/repos/pyqasm/src/pyqasm/visitor.py", line 820, in _visit_basic_gate_operation
+    op_parameters = self._get_op_parameters(operation)
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/thegupta/Desktop/qBraid/repos/pyqasm/src/pyqasm/visitor.py", line 660, in _get_op_parameters
+    raise_qasm3_error(
+  File "/Users/thegupta/Desktop/qBraid/repos/pyqasm/src/pyqasm/exceptions.py", line 102, in raise_qasm3_error
+    raise err_type(message) from raised_from
+
+pyqasm.exceptions.ValidationError: Invalid parameter 'a' for gate 'rx'
+```
+
 
 ### Improved / Modified
 - Improved the error messages for the parameter mismatch errors in basic quantum gates ([#169](https://github.com/qBraid/pyqasm/issues/169)). Following error is raised on parameter count mismatch - 
@@ -67,6 +159,41 @@ In [1]: import pyqasm
 ......
 ValidationError: Expected 1 parameter for gate 'rx', but got 2  
 ```
+
+- Enhanced the verbosity and clarity of `pyqasm` validation error messages. The new error format logs the line and column number of the error, the line where the error occurred, and the specific error message, making it easier to identify and fix issues in the QASM code. ([#171](https://github.com/qBraid/pyqasm/issues/171)) Eg. - 
+
+```python
+import pyqasm
+
+qasm = """
+    OPENQASM 3;
+    include "stdgates.inc";
+    qubit[2] q1;
+    rx(a) q1;
+    """
+
+program = pyqasm.loads(qasm)
+program.unroll()
+``` 
+
+```bash
+ERROR:pyqasm: Error at line 5, column 7 in QASM file
+
+ >>>>>> a
+
+ERROR:pyqasm: Error at line 5, column 4 in QASM file
+
+ >>>>>> rx(a) q1[0], q1[1];
+
+
+pyqasm.exceptions.ValidationError: Undefined identifier 'a' in expression
+
+The above exception was the direct cause of the following exception:
+
+pyqasm.exceptions.ValidationError: Invalid parameter 'a' for gate 'rx'
+```
+
+
 ### Deprecated
 
 ### Removed

--- a/src/pyqasm/_logging.py
+++ b/src/pyqasm/_logging.py
@@ -1,16 +1,16 @@
-# # Copyright 2025 qBraid
-# #
-# # Licensed under the Apache License, Version 2.0 (the "License");
-# # you may not use this file except in compliance with the License.
-# # You may obtain a copy of the License at
-# #
-# #     http://www.apache.org/licenses/LICENSE-2.0
-# #
-# # Unless required by applicable law or agreed to in writing, software
-# # distributed under the License is distributed on an "AS IS" BASIS,
-# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# # See the License for the specific language governing permissions and
-# # limitations under the License.
+# Copyright 2025 qBraid
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Module defining logging configuration for PyQASM.

--- a/src/pyqasm/_logging.py
+++ b/src/pyqasm/_logging.py
@@ -1,0 +1,33 @@
+# # Copyright 2025 qBraid
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #     http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
+
+"""
+Module defining logging configuration for PyQASM.
+This module sets up a logger for the PyQASM library, allowing for
+
+"""
+import logging
+
+# Define a custom logger for the module
+handler = logging.StreamHandler()
+handler.setFormatter(logging.Formatter("%(levelname)s:%(name)s: %(message)s"))
+
+logger = logging.getLogger("pyqasm")
+logger.addHandler(handler)
+logger.setLevel(logging.ERROR)
+
+# disable propagation to avoid double logging
+# messages to the root logger in case the root logging
+# level changes
+logger.propagate = False

--- a/src/pyqasm/analyzer.py
+++ b/src/pyqasm/analyzer.py
@@ -53,7 +53,7 @@ class Qasm3Analyzer:
         """Validate the indices for a classical variable.
 
         Args:
-            indices (list[list[Any]]): The indices to validate.
+            indices (list[Any]): The indices to validate.
             var (Variable): The variable to verify
 
         Raises:
@@ -70,6 +70,7 @@ class Qasm3Analyzer:
             raise_qasm3_error(
                 message=f"Indexing error. Variable {var.name} is not an array",
                 err_type=ValidationError,
+                error_node=indices[0],
                 span=indices[0].span,
             )
         if isinstance(indices, DiscreteSet):
@@ -80,6 +81,7 @@ class Qasm3Analyzer:
                 message=f"Invalid number of indices for variable {var.name}. "
                 f"Expected {len(var_dimensions)} but got {len(indices)}",  # type: ignore[arg-type]
                 err_type=ValidationError,
+                error_node=indices[0],
                 span=indices[0].span,
             )
 
@@ -89,6 +91,7 @@ class Qasm3Analyzer:
                     message=f"Index {index} out of bounds for dimension {dim_num} "
                     f"of variable '{var_name}'. Expected index in range [0, {dimension-1}]",
                     err_type=ValidationError,
+                    error_node=index,
                     span=span,
                 )
 
@@ -99,6 +102,7 @@ class Qasm3Analyzer:
                     message=f"Index {start_id} is {direction} {end_id} but step"
                     f" is {'negative' if step < 0 else 'positive'}",
                     err_type=ValidationError,
+                    error_node=indices,
                     span=span,
                 )
 
@@ -108,6 +112,7 @@ class Qasm3Analyzer:
                     message=f"Unsupported index type '{type(index)}' for "
                     f"classical variable '{var.name}'",
                     err_type=ValidationError,
+                    error_node=index,
                     span=index.span,
                 )
 
@@ -284,5 +289,6 @@ class Qasm3Analyzer:
             qubit_name, qubit_id = duplicate_qubit
             raise_qasm3_error(
                 f"Duplicate qubit '{qubit_name}[{qubit_id}]' arg in gate {gate.name.name}",
+                error_node=gate,
                 span=span,
             )

--- a/src/pyqasm/analyzer.py
+++ b/src/pyqasm/analyzer.py
@@ -87,7 +87,7 @@ class Qasm3Analyzer:
             if index < 0 or index >= dimension:
                 raise_qasm3_error(
                     message=f"Index {index} out of bounds for dimension {dim_num} "
-                    f"of variable {var_name}",
+                    f"of variable '{var_name}'. Expected index in range [0, {dimension-1}]",
                     err_type=ValidationError,
                     span=span,
                 )
@@ -105,8 +105,8 @@ class Qasm3Analyzer:
         for i, index in enumerate(indices):
             if not isinstance(index, (Identifier, Expression, RangeDefinition, IntegerLiteral)):
                 raise_qasm3_error(
-                    message=f"Unsupported index type {type(index)} for "
-                    f"classical variable {var.name}",
+                    message=f"Unsupported index type '{type(index)}' for "
+                    f"classical variable '{var.name}'",
                     err_type=ValidationError,
                     span=index.span,
                 )
@@ -283,6 +283,6 @@ class Qasm3Analyzer:
         if duplicate_qubit:
             qubit_name, qubit_id = duplicate_qubit
             raise_qasm3_error(
-                f"Duplicate qubit {qubit_name}[{qubit_id}] in gate {gate.name.name}",
+                f"Duplicate qubit '{qubit_name}[{qubit_id}]' arg in gate {gate.name.name}",
                 span=span,
             )

--- a/src/pyqasm/cli/validate.py
+++ b/src/pyqasm/cli/validate.py
@@ -28,6 +28,7 @@ from pyqasm import load
 from pyqasm.exceptions import QasmParsingError, UnrollError, ValidationError
 
 logger = logging.getLogger(__name__)
+logger.propagate = False
 
 
 def validate_paths_exist(paths: Optional[list[str]]) -> Optional[list[str]]:

--- a/src/pyqasm/exceptions.py
+++ b/src/pyqasm/exceptions.py
@@ -81,10 +81,10 @@ def raise_qasm3_error(
                 error_parts.append("\n >>>>>> " + dumps(error_node, indent="    ") + "\n")
             elif isinstance(error_node, list):
                 error_parts.append(
-                    "\n >>>>>> "
-                    + " , ".join(dumps(node, indent="    ") for node in error_node + "\n")
+                    "\n >>>>>> " + " , ".join(dumps(node, indent="    ") for node in error_node)
                 )
         except Exception as _:  # pylint: disable = broad-exception-caught
+            print(_)
             error_parts.append("\n >>>>>> " + str(error_node))
 
     if error_parts:

--- a/src/pyqasm/exceptions.py
+++ b/src/pyqasm/exceptions.py
@@ -84,7 +84,13 @@ def raise_qasm3_error(
 
     if error_node:
         try:
-            error_parts.append("\n >>>>>> " + dumps(error_node, indent="    "))
+            if isinstance(error_node, QASMNode):
+                error_parts.append("\n >>>>>> " + dumps(error_node, indent="    ") + "\n")
+            elif isinstance(error_node, list):
+                error_parts.append(
+                    "\n >>>>>> "
+                    + " , ".join(dumps(node, indent="    ") for node in error_node + "\n")
+                )
         except Exception as _:  # pylint: disable = broad-exception-caught
             error_parts.append("\n >>>>>> " + str(error_node))
 

--- a/src/pyqasm/exceptions.py
+++ b/src/pyqasm/exceptions.py
@@ -17,7 +17,6 @@ Module defining base PyQASM exceptions.
 
 """
 
-import logging
 import os
 import sys
 from typing import Optional, Type
@@ -26,13 +25,7 @@ from openqasm3.ast import QASMNode, Span
 from openqasm3.parser import QASM3ParsingError
 from openqasm3.printer import dumps
 
-# Define a custom logger for the module
-handler = logging.StreamHandler()
-handler.setFormatter(logging.Formatter("%(levelname)s:%(name)s: %(message)s"))
-
-logger = logging.getLogger("pyqasm")
-logger.addHandler(handler)
-logger.setLevel(logging.WARNING)
+from ._logging import logger
 
 
 class PyQasmError(Exception):

--- a/src/pyqasm/exceptions.py
+++ b/src/pyqasm/exceptions.py
@@ -97,8 +97,12 @@ def raise_qasm3_error(
     if error_parts:
         logger.error("\n".join(error_parts))
 
-    if os.environ.get("PYQASM_EXPAND_TRACEBACK") == "false":
-        sys.tracebacklimit = 0  # Disable traceback for cleaner output
+    if os.getenv("PYQASM_EXPAND_TRACEBACK", "false") == "false":
+        # Disable traceback for cleaner output
+        sys.tracebacklimit = 0
+    else:
+        # default value
+        sys.tracebacklimit = None  # type: ignore
 
     # Extract the latest message from the traceback if raised_from is provided
     if raised_from:

--- a/src/pyqasm/exceptions.py
+++ b/src/pyqasm/exceptions.py
@@ -97,7 +97,7 @@ def raise_qasm3_error(
     if error_parts:
         logger.error("\n".join(error_parts))
 
-    if os.environ.get("PYQASM_EXPAND_TRACEBACK") == "0":
+    if os.environ.get("PYQASM_EXPAND_TRACEBACK") == "false":
         sys.tracebacklimit = 0  # Disable traceback for cleaner output
 
     # Extract the latest message from the traceback if raised_from is provided

--- a/src/pyqasm/exceptions.py
+++ b/src/pyqasm/exceptions.py
@@ -18,10 +18,21 @@ Module defining base PyQASM exceptions.
 """
 
 import logging
+import os
+import sys
 from typing import Optional, Type
 
-from openqasm3.ast import Span
+from openqasm3.ast import QASMNode, Span
 from openqasm3.parser import QASM3ParsingError
+from openqasm3.printer import dumps
+
+# Define a custom logger for the module
+handler = logging.StreamHandler()
+handler.setFormatter(logging.Formatter("%(levelname)s:%(name)s: %(message)s"))
+
+logger = logging.getLogger("pyqasm")
+logger.addHandler(handler)
+logger.setLevel(logging.WARNING)
 
 
 class PyQasmError(Exception):
@@ -48,6 +59,7 @@ class QasmParsingError(QASM3ParsingError):
 def raise_qasm3_error(
     message: Optional[str] = None,
     err_type: Type[Exception] = ValidationError,
+    error_node: Optional[QASMNode] = None,
     span: Optional[Span] = None,
     raised_from: Optional[Exception] = None,
 ) -> None:
@@ -56,17 +68,33 @@ def raise_qasm3_error(
     Args:
         message: The error message. If not provided, a default message will be used.
         err_type: The type of error to raise.
+        error_node: The QASM node that caused the error.
         span: The span (location) in the QASM file where the error occurred.
         raised_from: Optional exception from which this error was raised (chaining).
 
     Raises:
         err_type: The error type initialized with the specified message and chained exception.
     """
+    error_parts = []
+
     if span:
-        logging.error(
-            "Error at line %s, column %s in QASM file", span.start_line, span.start_column
+        error_parts.append(
+            f"Error at line {span.start_line}, column {span.start_column} in QASM file"
         )
 
+    if error_node:
+        try:
+            error_parts.append("\n >>>>>> " + dumps(error_node, indent="    "))
+        except Exception as _:  # pylint: disable = broad-exception-caught
+            error_parts.append("\n >>>>>> " + str(error_node))
+
+    if error_parts:
+        logger.error("\n".join(error_parts))
+
+    if os.environ.get("PYQASM_EXPAND_TRACEBACK") == "0":
+        sys.tracebacklimit = 0  # Disable traceback for cleaner output
+
+    # Extract the latest message from the traceback if raised_from is provided
     if raised_from:
         raise err_type(message) from raised_from
     raise err_type(message)

--- a/src/pyqasm/expressions.py
+++ b/src/pyqasm/expressions.py
@@ -68,8 +68,9 @@ class Qasm3ExprEvaluator:
         if not cls.visitor_obj._check_in_scope(var_name):
             raise_qasm3_error(
                 f"Undefined identifier '{var_name}' in expression",
-                ValidationError,
-                expression.span,
+                err_type=ValidationError,
+                error_node=expression,
+                span=expression.span,
             )
 
     @classmethod
@@ -89,8 +90,9 @@ class Qasm3ExprEvaluator:
         if const_expr and not const_var:
             raise_qasm3_error(
                 f"Expected variable '{var_name}' to be constant in given expression",
-                ValidationError,
-                expression.span,
+                err_type=ValidationError,
+                error_node=expression,
+                span=expression.span,
             )
 
     @classmethod
@@ -109,10 +111,11 @@ class Qasm3ExprEvaluator:
         var = cls.visitor_obj._get_from_visible_scope(var_name)
         if not Qasm3Validator.validate_variable_type(var, reqd_type):
             raise_qasm3_error(
-                f"Invalid type '{var.base_type}' of variable '{var_name}' for "
+                message=f"Invalid type '{var.base_type}' of variable '{var_name}' for "
                 f"required type {reqd_type}",
-                ValidationError,
-                expression.span,
+                err_type=ValidationError,
+                error_node=expression,
+                span=expression.span,
             )
 
     @staticmethod
@@ -130,8 +133,9 @@ class Qasm3ExprEvaluator:
         if var_value is None:
             raise_qasm3_error(
                 f"Uninitialized variable '{var_name}' in expression",
-                ValidationError,
-                expression.span,
+                err_type=ValidationError,
+                error_node=expression,
+                span=expression.span,
             )
 
     @classmethod
@@ -183,8 +187,9 @@ class Qasm3ExprEvaluator:
         if isinstance(expression, (ImaginaryLiteral, DurationLiteral)):
             raise_qasm3_error(
                 f"Unsupported expression type {type(expression)}",
-                ValidationError,
-                expression.span,
+                err_type=ValidationError,
+                error_node=expression,
+                span=expression.span,
             )
 
         def _check_and_return_value(value):
@@ -207,8 +212,9 @@ class Qasm3ExprEvaluator:
                     return _check_and_return_value(CONSTANTS_MAP[var_name])
                 raise_qasm3_error(
                     f"Constant '{var_name}' not allowed in non-float expression",
-                    ValidationError,
-                    expression.span,
+                    err_type=ValidationError,
+                    error_node=expression,
+                    span=expression.span,
                 )
             return _process_variable(var_name)
 
@@ -230,6 +236,7 @@ class Qasm3ExprEvaluator:
                 raise_qasm3_error(
                     message=f"Unsupported target type '{type(target)}' for sizeof expression",
                     err_type=ValidationError,
+                    error_node=expression,
                     span=expression.span,
                 )
 
@@ -237,6 +244,7 @@ class Qasm3ExprEvaluator:
                 raise_qasm3_error(
                     message=f"Invalid sizeof usage, variable '{var_name}' is not an array.",
                     err_type=ValidationError,
+                    error_node=expression,
                     span=expression.span,
                 )
 
@@ -251,8 +259,9 @@ class Qasm3ExprEvaluator:
                 raise_qasm3_error(
                     f"Index {index} out of bounds for array '{var_name}' with "
                     f"{len(dimensions)} dimensions",
-                    ValidationError,
-                    expression.span,
+                    err_type=ValidationError,
+                    error_node=expression,
+                    span=expression.span,
                 )
             return _check_and_return_value(dimensions[index])
 
@@ -267,8 +276,9 @@ class Qasm3ExprEvaluator:
                 raise_qasm3_error(
                     f"Invalid value {expression.value} with type {type(expression)} "
                     f"for required type {reqd_type}",
-                    ValidationError,
-                    expression.span,
+                    err_type=ValidationError,
+                    error_node=expression,
+                    span=expression.span,
                 )
             return _check_and_return_value(expression.value)
 
@@ -279,8 +289,9 @@ class Qasm3ExprEvaluator:
             if expression.op.name == "~" and not isinstance(operand, int):
                 raise_qasm3_error(
                     f"Unsupported expression type '{type(operand)}' in ~ operation",
-                    ValidationError,
-                    expression.span,
+                    err_type=ValidationError,
+                    error_node=expression,
+                    span=expression.span,
                 )
             op_name = "UMINUS" if expression.op.name == "-" else expression.op.name
             statements.extend(returned_stats)
@@ -307,7 +318,10 @@ class Qasm3ExprEvaluator:
             return _check_and_return_value(ret_value)
 
         raise_qasm3_error(
-            f"Unsupported expression type {type(expression)}", ValidationError, expression.span
+            f"Unsupported expression type {type(expression)}",
+            err_type=ValidationError,
+            error_node=expression,
+            span=expression.span,
         )
 
     @classmethod

--- a/src/pyqasm/expressions.py
+++ b/src/pyqasm/expressions.py
@@ -186,7 +186,7 @@ class Qasm3ExprEvaluator:
 
         if isinstance(expression, (ImaginaryLiteral, DurationLiteral)):
             raise_qasm3_error(
-                f"Unsupported expression type {type(expression)}",
+                f"Unsupported expression type '{type(expression)}'",
                 err_type=ValidationError,
                 error_node=expression,
                 span=expression.span,

--- a/src/pyqasm/expressions.py
+++ b/src/pyqasm/expressions.py
@@ -67,7 +67,7 @@ class Qasm3ExprEvaluator:
 
         if not cls.visitor_obj._check_in_scope(var_name):
             raise_qasm3_error(
-                f"Undefined identifier {var_name} in expression",
+                f"Undefined identifier '{var_name}' in expression",
                 ValidationError,
                 expression.span,
             )
@@ -88,7 +88,7 @@ class Qasm3ExprEvaluator:
         const_var = cls.visitor_obj._get_from_visible_scope(var_name).is_constant
         if const_expr and not const_var:
             raise_qasm3_error(
-                f"Variable '{var_name}' is not a constant in given expression",
+                f"Expected variable '{var_name}' to be constant in given expression",
                 ValidationError,
                 expression.span,
             )
@@ -106,12 +106,11 @@ class Qasm3ExprEvaluator:
         Raises:
             ValidationError: If the variable has an invalid type for the required type.
         """
-
-        if not Qasm3Validator.validate_variable_type(
-            cls.visitor_obj._get_from_visible_scope(var_name), reqd_type
-        ):
+        var = cls.visitor_obj._get_from_visible_scope(var_name)
+        if not Qasm3Validator.validate_variable_type(var, reqd_type):
             raise_qasm3_error(
-                f"Invalid type of variable {var_name} for required type {reqd_type}",
+                f"Invalid type '{var.base_type}' of variable '{var_name}' for "
+                f"required type {reqd_type}",
                 ValidationError,
                 expression.span,
             )
@@ -130,7 +129,7 @@ class Qasm3ExprEvaluator:
 
         if var_value is None:
             raise_qasm3_error(
-                f"Uninitialized variable {var_name} in expression",
+                f"Uninitialized variable '{var_name}' in expression",
                 ValidationError,
                 expression.span,
             )
@@ -207,7 +206,7 @@ class Qasm3ExprEvaluator:
                 if not reqd_type or reqd_type == Qasm3FloatType:
                     return _check_and_return_value(CONSTANTS_MAP[var_name])
                 raise_qasm3_error(
-                    f"Constant {var_name} not allowed in non-float expression",
+                    f"Constant '{var_name}' not allowed in non-float expression",
                     ValidationError,
                     expression.span,
                 )
@@ -229,14 +228,14 @@ class Qasm3ExprEvaluator:
                 ).dims
             else:
                 raise_qasm3_error(
-                    message=f"Unsupported target type {type(target)} for sizeof expression",
+                    message=f"Unsupported target type '{type(target)}' for sizeof expression",
                     err_type=ValidationError,
                     span=expression.span,
                 )
 
             if dimensions is None or len(dimensions) == 0:
                 raise_qasm3_error(
-                    message=f"Invalid sizeof usage, variable {var_name} is not an array.",
+                    message=f"Invalid sizeof usage, variable '{var_name}' is not an array.",
                     err_type=ValidationError,
                     span=expression.span,
                 )
@@ -250,7 +249,7 @@ class Qasm3ExprEvaluator:
             assert index is not None and isinstance(index, int)
             if index < 0 or index >= len(dimensions):
                 raise_qasm3_error(
-                    f"Index {index} out of bounds for array {var_name} with "
+                    f"Index {index} out of bounds for array '{var_name}' with "
                     f"{len(dimensions)} dimensions",
                     ValidationError,
                     expression.span,
@@ -279,7 +278,7 @@ class Qasm3ExprEvaluator:
             )
             if expression.op.name == "~" and not isinstance(operand, int):
                 raise_qasm3_error(
-                    f"Unsupported expression type {type(operand)} in ~ operation",
+                    f"Unsupported expression type '{type(operand)}' in ~ operation",
                     ValidationError,
                     expression.span,
                 )

--- a/src/pyqasm/maps/expressions.py
+++ b/src/pyqasm/maps/expressions.py
@@ -1,12 +1,16 @@
-# Copyright (C) 2025 qBraid
+# Copyright 2025 qBraid
 #
-# This file is part of PyQASM
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# PyQASM is free software released under the GNU General Public License v3
-# or later. You can redistribute and/or modify it under the terms of the GPL v3.
-# See the LICENSE file in the project root or <https://www.gnu.org/licenses/gpl-3.0.html>.
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# THERE IS NO WARRANTY for PyQASM, as per Section 15 of the GPL v3.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Module mapping supported QASM expressions to lower level gate operations.

--- a/src/pyqasm/maps/expressions.py
+++ b/src/pyqasm/maps/expressions.py
@@ -1,23 +1,19 @@
-# Copyright 2025 qBraid
+# Copyright (C) 2025 qBraid
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# This file is part of PyQASM
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# PyQASM is free software released under the GNU General Public License v3
+# or later. You can redistribute and/or modify it under the terms of the GPL v3.
+# See the LICENSE file in the project root or <https://www.gnu.org/licenses/gpl-3.0.html>.
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# THERE IS NO WARRANTY for PyQASM, as per Section 15 of the GPL v3.
 
 """
 Module mapping supported QASM expressions to lower level gate operations.
 
 """
 
-from typing import Callable
+from typing import Callable, Union
 
 import numpy as np
 from openqasm3.ast import AngleType, BitType, BoolType, ComplexType, FloatType, IntType, UintType
@@ -25,10 +21,10 @@ from openqasm3.ast import AngleType, BitType, BoolType, ComplexType, FloatType, 
 from pyqasm.exceptions import ValidationError
 
 # Define the type for the operator functions
-OperatorFunction = (
-    Callable[[int | float | bool], int | float | bool]
-    | Callable[[int | float | bool, int | float | bool], int | float | bool]
-)
+OperatorFunction = Union[
+    Callable[[Union[int, float, bool]], Union[int, float, bool]],
+    Callable[[Union[int, float, bool], Union[int, float, bool]], Union[int, float, bool]],
+]
 
 
 OPERATOR_MAP: dict[str, OperatorFunction] = {
@@ -56,18 +52,18 @@ OPERATOR_MAP: dict[str, OperatorFunction] = {
 }
 
 
-def qasm3_expression_op_map(op_name: str, *args) -> float | int | bool:
+def qasm3_expression_op_map(op_name: str, *args) -> Union[float, int, bool]:
     """
     Return the result of applying the given operator to the given operands.
 
     Args:
         op_name (str): The operator name.
-        *args: The operands of type int | float | bool
+        *args: The operands of type Union[int, float, bool]
                 1. For unary operators, a single operand (e.g., ~3)
                 2. For binary operators, two operands (e.g., 3 + 2)
 
     Returns:
-        (float | int | bool): The result of applying the operator to the operands.
+        (Union[float, int, bool]): The result of applying the operator to the operands.
     """
     try:
         operator = OPERATOR_MAP[op_name]

--- a/src/pyqasm/maps/expressions.py
+++ b/src/pyqasm/maps/expressions.py
@@ -17,7 +17,7 @@ Module mapping supported QASM expressions to lower level gate operations.
 
 """
 
-from typing import Callable, Union
+from typing import Callable
 
 import numpy as np
 from openqasm3.ast import AngleType, BitType, BoolType, ComplexType, FloatType, IntType, UintType
@@ -25,10 +25,10 @@ from openqasm3.ast import AngleType, BitType, BoolType, ComplexType, FloatType, 
 from pyqasm.exceptions import ValidationError
 
 # Define the type for the operator functions
-OperatorFunction = Union[
-    Callable[[Union[int, float, bool]], Union[int, float, bool]],
-    Callable[[Union[int, float, bool], Union[int, float, bool]], Union[int, float, bool]],
-]
+OperatorFunction = (
+    Callable[[int | float | bool], int | float | bool]
+    | Callable[[int | float | bool, int | float | bool], int | float | bool]
+)
 
 
 OPERATOR_MAP: dict[str, OperatorFunction] = {
@@ -56,18 +56,18 @@ OPERATOR_MAP: dict[str, OperatorFunction] = {
 }
 
 
-def qasm3_expression_op_map(op_name: str, *args) -> Union[float, int, bool]:
+def qasm3_expression_op_map(op_name: str, *args) -> float | int | bool:
     """
     Return the result of applying the given operator to the given operands.
 
     Args:
         op_name (str): The operator name.
-        *args: The operands of type Union[int, float, bool]
+        *args: The operands of type int | float | bool
                 1. For unary operators, a single operand (e.g., ~3)
                 2. For binary operators, two operands (e.g., 3 + 2)
 
     Returns:
-        (Union[float, int, bool]): The result of applying the operator to the operands.
+        (float | int | bool): The result of applying the operator to the operands.
     """
     try:
         operator = OPERATOR_MAP[op_name]

--- a/src/pyqasm/modules/base.py
+++ b/src/pyqasm/modules/base.py
@@ -16,7 +16,6 @@
 Definition of the base Qasm module
 """
 
-import os
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from typing import Optional
@@ -505,12 +504,11 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
         # 4. return the module
         return qasm_module
 
-    def validate(self, expand_traceback: Optional[bool] = False):
+    def validate(self):
         """Validate the module"""
         if self._validated_program is True:
             return
         try:
-            os.environ["PYQASM_EXPAND_TRACEBACK"] = "true" if expand_traceback else "false"
             self.num_qubits, self.num_clbits = 0, 0
             visitor = QasmVisitor(self, check_only=True)
             self.accept(visitor)
@@ -528,7 +526,6 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
                 unroll_barriers (bool): If True, barriers will be unrolled. Defaults to True.
                 check_only (bool): If True, only check the program without executing it.
                                    Defaults to False.
-                expand_traceback (bool): If True, expand the traceback for verbose error messages.
 
         Raises:
             ValidationError: If the module fails validation during unrolling.
@@ -541,10 +538,6 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
         if not kwargs:
             kwargs = {}
         try:
-            os.environ["PYQASM_EXPAND_TRACEBACK"] = (
-                "true" if kwargs.pop("expand_traceback", False) else "false"
-            )
-
             self.num_qubits, self.num_clbits = 0, 0
             visitor = QasmVisitor(module=self, **kwargs)
             self.accept(visitor)

--- a/src/pyqasm/modules/base.py
+++ b/src/pyqasm/modules/base.py
@@ -510,7 +510,7 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
         if self._validated_program is True:
             return
         try:
-            os.environ["PYQASM_EXPAND_TRACEBACK"] = "1" if expand_traceback else "0"
+            os.environ["PYQASM_EXPAND_TRACEBACK"] = "true" if expand_traceback else "false"
             self.num_qubits, self.num_clbits = 0, 0
             visitor = QasmVisitor(self, check_only=True)
             self.accept(visitor)
@@ -528,7 +528,7 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
                 unroll_barriers (bool): If True, barriers will be unrolled. Defaults to True.
                 check_only (bool): If True, only check the program without executing it.
                                    Defaults to False.
-                expand_traceback (bool): If True, expand the traceback for better error messages.
+                expand_traceback (bool): If True, expand the traceback for verbose error messages.
 
         Raises:
             ValidationError: If the module fails validation during unrolling.
@@ -542,7 +542,7 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
             kwargs = {}
         try:
             os.environ["PYQASM_EXPAND_TRACEBACK"] = (
-                "1" if kwargs.pop("expand_traceback", False) else "0"
+                "true" if kwargs.pop("expand_traceback", False) else "false"
             )
 
             self.num_qubits, self.num_clbits = 0, 0

--- a/src/pyqasm/modules/base.py
+++ b/src/pyqasm/modules/base.py
@@ -16,6 +16,7 @@
 Definition of the base Qasm module
 """
 
+import os
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from typing import Optional
@@ -504,11 +505,12 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
         # 4. return the module
         return qasm_module
 
-    def validate(self):
+    def validate(self, expand_traceback: Optional[bool] = False):
         """Validate the module"""
         if self._validated_program is True:
             return
         try:
+            os.environ["PYQASM_EXPAND_TRACEBACK"] = "1" if expand_traceback else "0"
             self.num_qubits, self.num_clbits = 0, 0
             visitor = QasmVisitor(self, check_only=True)
             self.accept(visitor)
@@ -526,6 +528,7 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
                 unroll_barriers (bool): If True, barriers will be unrolled. Defaults to True.
                 check_only (bool): If True, only check the program without executing it.
                                    Defaults to False.
+                expand_traceback (bool): If True, expand the traceback for better error messages.
 
         Raises:
             ValidationError: If the module fails validation during unrolling.
@@ -538,6 +541,10 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
         if not kwargs:
             kwargs = {}
         try:
+            os.environ["PYQASM_EXPAND_TRACEBACK"] = (
+                "1" if kwargs.pop("expand_traceback", False) else "0"
+            )
+
             self.num_qubits, self.num_clbits = 0, 0
             visitor = QasmVisitor(module=self, **kwargs)
             self.accept(visitor)

--- a/src/pyqasm/subroutines.py
+++ b/src/pyqasm/subroutines.py
@@ -122,6 +122,7 @@ class Qasm3SubroutineProcessor:
                 raise_qasm3_error(
                     f"Expecting classical argument for '{formal_arg.name.name}'. "
                     f"Qubit register '{actual_arg_name}' found for function '{fn_name}'",
+                    error_node=actual_arg,
                     span=span,
                 )
 
@@ -131,6 +132,7 @@ class Qasm3SubroutineProcessor:
                 raise_qasm3_error(
                     f"Undefined variable '{actual_arg_name}' used"
                     f" for function call '{fn_name}'",
+                    error_node=actual_arg,
                     span=span,
                 )
         actual_arg_value = Qasm3ExprEvaluator.evaluate_expression(actual_arg)[0]
@@ -183,6 +185,7 @@ class Qasm3SubroutineProcessor:
                 array_expected_type_msg
                 + f"Literal '{Qasm3ExprEvaluator.evaluate_expression(actual_arg)[0]}' "
                 + "found in function call",
+                error_node=actual_arg,
                 span=span,
             )
 
@@ -190,6 +193,7 @@ class Qasm3SubroutineProcessor:
             raise_qasm3_error(
                 array_expected_type_msg
                 + f"Qubit register '{actual_arg_name}' found for function call",
+                error_node=actual_arg,
                 span=span,
             )
 
@@ -197,6 +201,7 @@ class Qasm3SubroutineProcessor:
         if not cls.visitor_obj._check_in_scope(actual_arg_name):
             raise_qasm3_error(
                 f"Undefined variable '{actual_arg_name}' used for function call '{fn_name}'",
+                error_node=actual_arg,
                 span=span,
             )
 
@@ -208,6 +213,7 @@ class Qasm3SubroutineProcessor:
             raise_qasm3_error(
                 array_expected_type_msg
                 + f"Variable '{actual_arg_name}' has type '{actual_type_string}'.",
+                error_node=actual_arg,
                 span=span,
             )
 
@@ -219,6 +225,7 @@ class Qasm3SubroutineProcessor:
             raise_qasm3_error(
                 array_expected_type_msg
                 + f"Variable '{actual_arg_name}' has type '{actual_type_string}'.",
+                error_node=actual_arg,
                 span=span,
             )
 
@@ -241,6 +248,7 @@ class Qasm3SubroutineProcessor:
             raise_qasm3_error(
                 f"Invalid number of dimensions {num_formal_dimensions}"
                 f" for '{formal_arg.name.name}' in function '{fn_name}'",
+                error_node=formal_arg,
                 span=span,
             )
 
@@ -249,6 +257,7 @@ class Qasm3SubroutineProcessor:
                 f"Dimension mismatch for '{formal_arg.name.name}' in function '{fn_name}'. "
                 f"Expected {num_formal_dimensions} dimensions but"
                 f" variable '{actual_arg_name}' has {len(actual_dimensions)}",
+                error_node=formal_arg,
                 span=span,
             )
         formal_dimensions = []
@@ -268,6 +277,7 @@ class Qasm3SubroutineProcessor:
                     raise_qasm3_error(
                         f"Invalid dimension size {formal_dim} for '{formal_arg.name.name}'"
                         f" in function '{fn_name}'",
+                        error_node=formal_arg,
                         span=span,
                     )
                 if actual_dim < formal_dim:
@@ -275,6 +285,7 @@ class Qasm3SubroutineProcessor:
                         f"Dimension mismatch for '{formal_arg.name.name}'"
                         f" in function '{fn_name}'. Expected dimension {idx} with size"
                         f" >= {formal_dim} but got {actual_dim}",
+                        error_node=actual_arg,
                         span=span,
                     )
                 formal_dimensions.append(formal_dim)
@@ -341,6 +352,7 @@ class Qasm3SubroutineProcessor:
             raise_qasm3_error(
                 f"Invalid qubit size {formal_qubit_size} for variable '{formal_reg_name}'"
                 f" in function '{fn_name}'",
+                error_node=formal_arg,
                 span=span,
             )
         formal_qreg_size_map[formal_reg_name] = formal_qubit_size
@@ -352,6 +364,7 @@ class Qasm3SubroutineProcessor:
             raise_qasm3_error(
                 f"Expecting qubit argument for '{formal_reg_name}'. "
                 f"Qubit register '{actual_arg_name}' not found for function '{fn_name}'",
+                error_node=actual_arg,
                 span=span,
             )
         cls.visitor_obj._label_scope_level[cls.visitor_obj._curr_scope].add(formal_reg_name)
@@ -365,6 +378,7 @@ class Qasm3SubroutineProcessor:
                 f"Qubit register size mismatch for function '{fn_name}'. "
                 f"Expected {formal_qubit_size} in variable '{formal_reg_name}' "
                 f"but got {actual_qubits_size}",
+                error_node=actual_arg,
                 span=span,
             )
 
@@ -374,6 +388,7 @@ class Qasm3SubroutineProcessor:
             raise_qasm3_error(
                 f"Duplicate qubit argument for register '{actual_arg_name}' "
                 f"in function call for '{fn_name}'",
+                error_node=actual_arg,
                 span=span,
             )
 

--- a/src/pyqasm/subroutines.py
+++ b/src/pyqasm/subroutines.py
@@ -396,7 +396,7 @@ class Qasm3SubroutineProcessor:
             raise_qasm3_error(
                 f"Qubit register size mismatch for function '{fn_name}'. "
                 f"Expected {formal_qubit_size} in variable '{formal_reg_name}' "
-                f"but got {actual_qubits_size}\n",
+                f"but got {actual_qubits_size}\n"
                 f"Usage: {fn_name} ( {formal_args_desc} )\n",
                 error_node=fn_call,
                 span=fn_call.span,

--- a/src/pyqasm/subroutines.py
+++ b/src/pyqasm/subroutines.py
@@ -381,7 +381,7 @@ class Qasm3SubroutineProcessor:
             raise_qasm3_error(
                 f"Expecting qubit argument for '{formal_reg_name}'. "
                 f"{arg_desc}found for function '{fn_name}'\n"
-                f"Usage: {fn_name} ( {formal_args_desc} )\n",
+                f"\nUsage: {fn_name} ( {formal_args_desc} )\n",
                 error_node=fn_call,
                 span=fn_call.span,
             )
@@ -395,9 +395,9 @@ class Qasm3SubroutineProcessor:
             formal_args_desc = " , ".join(dumps(arg, indent="    ") for arg in fn_defn.arguments)
             raise_qasm3_error(
                 f"Qubit register size mismatch for function '{fn_name}'. "
-                f"Expected {formal_qubit_size} in variable '{formal_reg_name}' "
+                f"Expected {formal_qubit_size} qubits in variable '{formal_reg_name}' "
                 f"but got {actual_qubits_size}\n"
-                f"Usage: {fn_name} ( {formal_args_desc} )\n",
+                f"\nUsage: {fn_name} ( {formal_args_desc} )\n",
                 error_node=fn_call,
                 span=fn_call.span,
             )

--- a/src/pyqasm/subroutines.py
+++ b/src/pyqasm/subroutines.py
@@ -181,7 +181,7 @@ class Qasm3SubroutineProcessor:
         if actual_arg_name is None:
             raise_qasm3_error(
                 array_expected_type_msg
-                + f"Literal {Qasm3ExprEvaluator.evaluate_expression(actual_arg)[0]} "
+                + f"Literal '{Qasm3ExprEvaluator.evaluate_expression(actual_arg)[0]}' "
                 + "found in function call",
                 span=span,
             )

--- a/src/pyqasm/transformer.py
+++ b/src/pyqasm/transformer.py
@@ -112,6 +112,7 @@ class Qasm3Transformer:
             if not isinstance(value, IntegerLiteral):
                 raise_qasm3_error(
                     f"Unsupported discrete set value '{value}' in discrete set",
+                    error_node=discrete_set,
                     span=discrete_set.span,
                 )
             values.append(value.value)
@@ -169,6 +170,7 @@ class Qasm3Transformer:
                 raise_qasm3_error(
                     f"Indexing '{qubit.name.name}' not supported in gate definition "
                     f"for gate {gate_op.name}",
+                    error_node=gate_op,
                     span=qubit.span,
                 )
             gate_qubit_name = qubit.name
@@ -257,12 +259,14 @@ class Qasm3Transformer:
             raise_qasm3_error(
                 message="Only simple comparison supported in branching condition with "
                 "classical register",
+                error_node=condition,
                 span=condition.span,
             )
         if isinstance(condition, UnaryExpression):
             if condition.op != UnaryOperator["!"]:
                 raise_qasm3_error(
                     message="Only '!' supported in branching condition with classical register",
+                    error_node=condition,
                     span=condition.span,
                 )
             return BranchParams(
@@ -276,6 +280,7 @@ class Qasm3Transformer:
                 raise_qasm3_error(
                     message="Only {==, >=, <=, >, <} supported in branching condition "
                     "with classical register",
+                    error_node=condition,
                     span=condition.span,
                 )
 
@@ -301,12 +306,14 @@ class Qasm3Transformer:
             if isinstance(condition.index, DiscreteSet):
                 raise_qasm3_error(
                     message="DiscreteSet not supported in branching condition",
+                    error_node=condition,
                     span=condition.span,
                 )
             if isinstance(condition.index, list):
                 if isinstance(condition.index[0], RangeDefinition):
                     raise_qasm3_error(
                         message="RangeDefinition not supported in branching condition",
+                        error_node=condition,
                         span=condition.span,
                     )
                 return BranchParams(

--- a/src/pyqasm/transformer.py
+++ b/src/pyqasm/transformer.py
@@ -34,6 +34,7 @@ from openqasm3.ast import (
 )
 from openqasm3.ast import IntType as Qasm3IntType
 from openqasm3.ast import (
+    QASMNode,
     QuantumBarrier,
     QuantumGate,
     QuantumPhase,
@@ -98,7 +99,9 @@ class Qasm3Transformer:
         multi_dim_arr[slicing] = value
 
     @staticmethod
-    def extract_values_from_discrete_set(discrete_set: DiscreteSet) -> list[int]:
+    def extract_values_from_discrete_set(
+        discrete_set: DiscreteSet, op_node: Optional[QASMNode] = None
+    ) -> list[int]:
         """Extract the values from a discrete set.
 
         Args:
@@ -113,21 +116,25 @@ class Qasm3Transformer:
                 raise_qasm3_error(
                     f"Unsupported value '{Qasm3ExprEvaluator.evaluate_expression(value)[0]}' "
                     "in discrete set",
-                    error_node=discrete_set,
-                    span=discrete_set.span,
+                    error_node=op_node if op_node else discrete_set,
+                    span=op_node.span if op_node else discrete_set.span,
                 )
             values.append(value.value)
         return values
 
     @staticmethod
     def get_qubits_from_range_definition(
-        range_def: RangeDefinition, qreg_size: int, is_qubit_reg: bool
+        range_def: RangeDefinition,
+        qreg_size: int,
+        is_qubit_reg: bool,
+        op_node: Optional[QASMNode] = None,
     ) -> list[int]:
         """Get the qubits from a range definition.
         Args:
             range_def (RangeDefinition): The range definition to get qubits from.
             qreg_size (int): The size of the register.
             is_qubit_reg (bool): Whether the register is a qubit register.
+            op_node (Optional[QASMNode]): The operation node.
         Returns:
             list[int]: The list of qubit identifiers.
         """
@@ -147,10 +154,10 @@ class Qasm3Transformer:
             else Qasm3ExprEvaluator.evaluate_expression(range_def.step)[0]
         )
         Qasm3Validator.validate_register_index(
-            start_qid, qreg_size, qubit=is_qubit_reg, op_node=range_def
+            start_qid, qreg_size, qubit=is_qubit_reg, op_node=op_node
         )
         Qasm3Validator.validate_register_index(
-            end_qid - 1, qreg_size, qubit=is_qubit_reg, op_node=range_def
+            end_qid - 1, qreg_size, qubit=is_qubit_reg, op_node=op_node
         )
         return list(range(start_qid, end_qid, step))
 

--- a/src/pyqasm/transformer.py
+++ b/src/pyqasm/transformer.py
@@ -111,7 +111,7 @@ class Qasm3Transformer:
         for value in discrete_set.values:
             if not isinstance(value, IntegerLiteral):
                 raise_qasm3_error(
-                    f"Unsupported discrete set value {value} in discrete set",
+                    f"Unsupported discrete set value '{value}' in discrete set",
                     span=discrete_set.span,
                 )
             values.append(value.value)
@@ -167,7 +167,8 @@ class Qasm3Transformer:
         for i, qubit in enumerate(gate_op.qubits):
             if isinstance(qubit, IndexedIdentifier):
                 raise_qasm3_error(
-                    f"Indexing '{qubit.name.name}' not supported in gate definition",
+                    f"Indexing '{qubit.name.name}' not supported in gate definition "
+                    f"for gate {gate_op.name}",
                     span=qubit.span,
                 )
             gate_qubit_name = qubit.name

--- a/src/pyqasm/validator.py
+++ b/src/pyqasm/validator.py
@@ -320,7 +320,7 @@ class Qasm3Validator:
             if return_value is None:
                 raise_qasm3_error(
                     f"Return type mismatch for subroutine '{subroutine_def.name.name}'."
-                    f" Expected {subroutine_def.return_type} but got void",
+                    f" Expected {type(subroutine_def.return_type)} but got void",
                     error_node=return_statement,
                     span=return_statement.span,
                 )

--- a/src/pyqasm/validator.py
+++ b/src/pyqasm/validator.py
@@ -194,24 +194,30 @@ class Qasm3Validator:
         return type_casted_value
 
     @staticmethod
-    def validate_classical_type(base_type, base_size, var_name, span) -> None:
+    def validate_classical_type(base_type, base_size, var_name, op_node) -> None:
         """Validate the type and size of a classical variable.
 
         Args:
             base_type (Any): The base type of the variable.
             base_size (int): The size of the variable.
             var_name (str): The name of the variable.
-            span (Span): The span of the variable.
+            op_node (QASMNode): The operation node.
 
         Raises:
             ValidationError: If the type or size is invalid.
         """
         if not isinstance(base_size, int) or base_size <= 0:
-            raise_qasm3_error(f"Invalid base size {base_size} for variable '{var_name}'", span=span)
+            raise_qasm3_error(
+                f"Invalid base size {base_size} for variable '{var_name}'",
+                error_node=op_node,
+                span=op_node.span,
+            )
 
         if isinstance(base_type, FloatType) and base_size not in [32, 64]:
             raise_qasm3_error(
-                f"Invalid base size {base_size} for float variable '{var_name}'", span=span
+                f"Invalid base size {base_size} for float variable '{var_name}'",
+                error_node=op_node,
+                span=op_node.span,
             )
 
     @staticmethod

--- a/src/pyqasm/validator.py
+++ b/src/pyqasm/validator.py
@@ -67,7 +67,7 @@ class Qasm3Validator:
         if stmt_type in blacklisted_stmts:
             if stmt_type != ClassicalDeclaration:
                 raise_qasm3_error(
-                    f"Unsupported statement {stmt_type} in {construct} block",
+                    f"Unsupported statement '{stmt_type}' in {construct} block",
                     span=statement.span,
                 )
 
@@ -116,7 +116,9 @@ class Qasm3Validator:
         try:
             type_to_match = VARIABLE_TYPE_MAP[qasm_type]
         except KeyError as err:
-            raise ValidationError(f"Invalid type {qasm_type} for variable {variable.name}") from err
+            raise ValidationError(
+                f"Invalid type {qasm_type} for variable '{variable.name}'"
+            ) from err
 
         # For each type we will have a "castable" type set and its corresponding cast operation
         type_casted_value = qasm_variable_type_cast(qasm_type, variable.name, base_size, value)
@@ -150,14 +152,14 @@ class Qasm3Validator:
 
             if type_casted_value < left or type_casted_value > right:
                 raise_qasm3_error(
-                    f"Value {value} out of limits for variable {variable.name} with "
+                    f"Value {value} out of limits for variable '{variable.name}' with "
                     f"base size {base_size}",
                 )
         elif type_to_match == bool:
             pass
         else:
             raise_qasm3_error(
-                f"Invalid type {type_to_match} for variable {variable.name}", TypeError
+                f"Invalid type {type_to_match} for variable '{variable.name}'", TypeError
             )
 
         return type_casted_value
@@ -176,11 +178,11 @@ class Qasm3Validator:
             ValidationError: If the type or size is invalid.
         """
         if not isinstance(base_size, int) or base_size <= 0:
-            raise_qasm3_error(f"Invalid base size {base_size} for variable {var_name}", span=span)
+            raise_qasm3_error(f"Invalid base size {base_size} for variable '{var_name}'", span=span)
 
         if isinstance(base_type, FloatType) and base_size not in [32, 64]:
             raise_qasm3_error(
-                f"Invalid base size {base_size} for float variable {var_name}", span=span
+                f"Invalid base size {base_size} for float variable '{var_name}'", span=span
             )
 
     @staticmethod
@@ -200,7 +202,7 @@ class Qasm3Validator:
         # recursively check the array
         if values.shape[0] != dimensions[0]:
             raise_qasm3_error(
-                f"Invalid dimensions for array assignment to variable {variable.name}. "
+                f"Invalid dimensions for array assignment to variable '{variable.name}'. "
                 f"Expected {dimensions[0]} but got {values.shape[0]}",
             )
         for i, value in enumerate(values):
@@ -235,7 +237,7 @@ class Qasm3Validator:
         if op_num_args != gate_def_num_args:
             s = "" if gate_def_num_args == 1 else "s"
             raise_qasm3_error(
-                f"Parameter count mismatch for gate {operation.name.name}: "
+                f"Parameter count mismatch for gate '{operation.name.name}': "
                 f"expected {gate_def_num_args} argument{s}, but got {op_num_args} instead.",
                 span=operation.span,
             )
@@ -244,7 +246,7 @@ class Qasm3Validator:
         if qubits_in_op != gate_def_num_qubits:
             s = "" if gate_def_num_qubits == 1 else "s"
             raise_qasm3_error(
-                f"Qubit count mismatch for gate {operation.name.name}: "
+                f"Qubit count mismatch for gate '{operation.name.name}': "
                 f"expected {gate_def_num_qubits} qubit{s}, but got {qubits_in_op} instead.",
                 span=operation.span,
             )

--- a/src/pyqasm/validator.py
+++ b/src/pyqasm/validator.py
@@ -68,6 +68,7 @@ class Qasm3Validator:
             if stmt_type != ClassicalDeclaration:
                 raise_qasm3_error(
                     f"Unsupported statement '{stmt_type}' in {construct} block",
+                    error_node=statement,
                     span=statement.span,
                 )
 
@@ -75,6 +76,7 @@ class Qasm3Validator:
                 raise_qasm3_error(
                     f"Unsupported statement {stmt_type} with {statement.type.__class__}"
                     f" in {construct} block",
+                    error_node=statement,
                     span=statement.span,
                 )
 
@@ -138,7 +140,7 @@ class Qasm3Validator:
                 left, right = 0, 2**base_size - 1
             if type_casted_value < left or type_casted_value > right:
                 raise_qasm3_error(
-                    f"Value {value} out of limits for variable {variable.name} with "
+                    f"Value {value} out of limits for variable '{variable.name}' with "
                     f"base size {base_size}",
                 )
 
@@ -239,6 +241,7 @@ class Qasm3Validator:
             raise_qasm3_error(
                 f"Parameter count mismatch for gate '{operation.name.name}': "
                 f"expected {gate_def_num_args} argument{s}, but got {op_num_args} instead.",
+                error_node=operation,
                 span=operation.span,
             )
 
@@ -248,6 +251,7 @@ class Qasm3Validator:
             raise_qasm3_error(
                 f"Qubit count mismatch for gate '{operation.name.name}': "
                 f"expected {gate_def_num_qubits} qubit{s}, but got {qubits_in_op} instead.",
+                error_node=operation,
                 span=operation.span,
             )
 
@@ -276,6 +280,7 @@ class Qasm3Validator:
                 raise_qasm3_error(
                     f"Return type mismatch for subroutine '{subroutine_def.name.name}'."
                     f" Expected void but got {type(return_value)}",
+                    error_node=return_statement,
                     span=return_statement.span,
                 )
         else:
@@ -283,6 +288,7 @@ class Qasm3Validator:
                 raise_qasm3_error(
                     f"Return type mismatch for subroutine '{subroutine_def.name.name}'."
                     f" Expected {subroutine_def.return_type} but got void",
+                    error_node=return_statement,
                     span=return_statement.span,
                 )
             base_size = 1

--- a/src/pyqasm/validator.py
+++ b/src/pyqasm/validator.py
@@ -134,9 +134,13 @@ class Qasm3Validator:
         try:
             type_to_match = VARIABLE_TYPE_MAP[qasm_type]
         except KeyError as err:
-            raise ValidationError(
-                f"Invalid type {qasm_type} for variable '{variable.name}'"
-            ) from err
+            raise_qasm3_error(
+                f"Invalid type '{qasm_type}' for variable '{variable.name}'",
+                err_type=ValidationError,
+                raised_from=err,
+                error_node=op_node,
+                span=op_node.span if op_node else None,
+            )
 
         # For each type we will have a "castable" type set and its corresponding cast operation
         type_casted_value = qasm_variable_type_cast(qasm_type, variable.name, base_size, value)
@@ -262,8 +266,8 @@ class Qasm3Validator:
         if op_num_args != gate_def_num_args:
             s = "" if gate_def_num_args == 1 else "s"
             raise_qasm3_error(
-                f"Parameter count mismatch for gate '{operation.name.name}': "
-                f"expected {gate_def_num_args} argument{s}, but got {op_num_args} instead.",
+                f"Parameter count mismatch for gate '{operation.name.name}'. "
+                f"Expected {gate_def_num_args} argument{s}, but got {op_num_args} instead.",
                 error_node=operation,
                 span=operation.span,
             )
@@ -272,8 +276,8 @@ class Qasm3Validator:
         if qubits_in_op != gate_def_num_qubits:
             s = "" if gate_def_num_qubits == 1 else "s"
             raise_qasm3_error(
-                f"Qubit count mismatch for gate '{operation.name.name}': "
-                f"expected {gate_def_num_qubits} qubit{s}, but got {qubits_in_op} instead.",
+                f"Qubit count mismatch for gate '{operation.name.name}'. "
+                f"Expected {gate_def_num_qubits} qubit{s}, but got {qubits_in_op} instead.",
                 error_node=operation,
                 span=operation.span,
             )

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -647,7 +647,9 @@ class QasmVisitor:
         """
         gate_name = definition.name.name
         if gate_name in self._custom_gates:
-            raise_qasm3_error(f"Duplicate quantum gate definition for '{gate_name}'", span=definition.span)
+            raise_qasm3_error(
+                f"Duplicate quantum gate definition for '{gate_name}'", span=definition.span
+            )
         self._custom_gates[gate_name] = definition
 
         return []
@@ -885,7 +887,8 @@ class QasmVisitor:
                 # in case the gate is reapplied
                 if isinstance(gate_op, qasm3_ast.QuantumGate) and gate_op.name.name == gate_name:
                     raise_qasm3_error(
-                        f"Recursive definitions not allowed for gate '{gate_name}'", span=gate_op.span
+                        f"Recursive definitions not allowed for gate '{gate_name}'",
+                        span=gate_op.span,
                     )
                 Qasm3Transformer.transform_gate_params(gate_op_copy, param_map)
                 Qasm3Transformer.transform_gate_qubits(gate_op_copy, qubit_map)
@@ -899,7 +902,8 @@ class QasmVisitor:
             else:
                 # TODO: add control flow support
                 raise_qasm3_error(
-                    f"Unsupported statement in gate definition '{type(gate_op).__name__}'", span=gate_op.span
+                    f"Unsupported statement in gate definition '{type(gate_op).__name__}'",
+                    span=gate_op.span,
                 )
 
         self._restore_context()
@@ -1033,7 +1037,7 @@ class QasmVisitor:
         # if args are provided in global scope, then we should raise error
         if self._in_global_scope() and len(operation.qubits) != 0:
             raise_qasm3_error(
-                f"Qubit arguments not allowed for 'gphase' operation in global scope",
+                "Qubit arguments not allowed for 'gphase' operation in global scope",
                 span=operation.span,
             )
 
@@ -1205,7 +1209,7 @@ class QasmVisitor:
                 ]
                 if not isinstance(base_size, int) or base_size <= 0:
                     raise_qasm3_error(
-                        f"Invalid base size {base_size} for variable {var_name}",
+                        f"Invalid base size {base_size} for variable '{var_name}'",
                         span=statement.span,
                     )
 
@@ -1281,7 +1285,7 @@ class QasmVisitor:
                 )
             if len(dimensions) > MAX_ARRAY_DIMENSIONS:
                 raise_qasm3_error(
-                    f"Invalid dimensions {len(dimensions)} for array declaration for {var_name}. "
+                    f"Invalid dimensions {len(dimensions)} for array declaration for '{var_name}'. "
                     f"Max allowed dimensions is {MAX_ARRAY_DIMENSIONS}",
                     span=statement.span,
                 )
@@ -1290,7 +1294,7 @@ class QasmVisitor:
                 dim_value = Qasm3ExprEvaluator.evaluate_expression(dim, const_expr=True)[0]
                 if not isinstance(dim_value, int) or dim_value <= 0:
                     raise_qasm3_error(
-                        f"Invalid dimension size {dim_value} in array declaration for {var_name}",
+                        f"Invalid dimension size {dim_value} in array declaration for '{var_name}'",
                         span=statement.span,
                     )
                 final_dimensions.append(dim_value)

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -1650,6 +1650,7 @@ class QasmVisitor:
 
     def _visit_forin_loop(self, statement: qasm3_ast.ForInLoop) -> list[qasm3_ast.Statement]:
         # Compute loop variable values
+        irange = []
         if isinstance(statement.set_declaration, qasm3_ast.RangeDefinition):
             init_exp = statement.set_declaration.start
             startval = Qasm3ExprEvaluator.evaluate_expression(init_exp)[0]
@@ -1668,8 +1669,10 @@ class QasmVisitor:
                 for exp in statement.set_declaration.values
             ]
         else:
-            raise ValidationError(
-                f"Unexpected type {type(statement.set_declaration)} of set_declaration in loop."
+            raise_qasm3_error(
+                f"Unexpected type {type(statement.set_declaration)} of set_declaration in loop.",
+                error_node=statement,
+                span=statement.span,
             )
 
         i: Optional[Variable]  # will store iteration Variable to update to loop scope

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -45,6 +45,7 @@ from pyqasm.transformer import Qasm3Transformer
 from pyqasm.validator import Qasm3Validator
 
 logger = logging.getLogger(__name__)
+logger.propagate = False
 
 
 # pylint: disable-next=too-many-instance-attributes

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -410,10 +410,15 @@ class QasmVisitor:
 
             if isinstance(bit, qasm3_ast.IndexedIdentifier):
                 if isinstance(bit.indices[0], qasm3_ast.DiscreteSet):
-                    bit_ids = Qasm3Transformer.extract_values_from_discrete_set(bit.indices[0])
+                    bit_ids = Qasm3Transformer.extract_values_from_discrete_set(
+                        bit.indices[0], operation
+                    )
                 elif isinstance(bit.indices[0][0], qasm3_ast.RangeDefinition):
                     bit_ids = Qasm3Transformer.get_qubits_from_range_definition(
-                        bit.indices[0][0], reg_size_map[reg_name], is_qubit_reg=qubits
+                        bit.indices[0][0],
+                        reg_size_map[reg_name],
+                        is_qubit_reg=qubits,
+                        op_node=operation,
                     )
                 else:
                     bit_id = Qasm3ExprEvaluator.evaluate_expression(bit.indices[0][0])[0]
@@ -1910,7 +1915,7 @@ class QasmVisitor:
             alias_reg_size = aliased_reg_size
         elif isinstance(value, qasm3_ast.IndexExpression):
             if isinstance(value.index, qasm3_ast.DiscreteSet):  # "let alias = q[{0,1}];"
-                qids = Qasm3Transformer.extract_values_from_discrete_set(value.index)
+                qids = Qasm3Transformer.extract_values_from_discrete_set(value.index, statement)
                 for i, qid in enumerate(qids):
                     Qasm3Validator.validate_register_index(
                         qid,

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -1865,7 +1865,7 @@ class QasmVisitor:
             if isinstance(formal_arg, qasm3_ast.ClassicalArgument):
                 classical_vars.append(
                     Qasm3SubroutineProcessor.process_classical_arg(
-                        formal_arg, actual_arg, fn_name, statement.span
+                        formal_arg, actual_arg, fn_name, statement
                     )
                 )
             else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+# Copyright 2025 qBraid
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Module for configuring pytest fixtures and logging settings for tests.
+"""
+
+import pytest
+
+from src.pyqasm._logging import logger
+
+
+# Automatically applied to all tests
+@pytest.fixture(autouse=True)
+def enable_logger_propagation():
+    """Temporarily enable logger propagation for tests. This is because
+    caplog only captures logs from the root logger"""
+    original_propagate = logger.propagate
+    logger.propagate = True  # Enable propagation for tests
+    yield
+    logger.propagate = original_propagate  # Restore original behavior

--- a/tests/qasm3/declarations/test_classical.py
+++ b/tests/qasm3/declarations/test_classical.py
@@ -370,14 +370,22 @@ def test_array_range_assignment():
 
 
 @pytest.mark.parametrize("test_name", DECLARATION_TESTS.keys())
-def test_incorrect_declarations(test_name):
-    qasm_input, error_message = DECLARATION_TESTS[test_name]
+def test_incorrect_declarations(test_name, caplog):
+    qasm_input, error_message, line_num, col_num, err_line = DECLARATION_TESTS[test_name]
     with pytest.raises(ValidationError, match=error_message):
-        loads(qasm_input).validate()
+        with caplog.at_level("ERROR"):
+            loads(qasm_input).validate()
+
+    assert f"Error at line {line_num}, column {col_num}" in caplog.text
+    assert err_line in caplog.text
 
 
 @pytest.mark.parametrize("test_name", ASSIGNMENT_TESTS.keys())
-def test_incorrect_assignments(test_name):
-    qasm_input, error_message = ASSIGNMENT_TESTS[test_name]
+def test_incorrect_assignments(test_name, caplog):
+    qasm_input, error_message, line_num, col_num, err_line = ASSIGNMENT_TESTS[test_name]
     with pytest.raises(ValidationError, match=error_message):
-        loads(qasm_input).validate()
+        with caplog.at_level("ERROR"):
+            loads(qasm_input).validate()
+
+    assert f"Error at line {line_num}, column {col_num}" in caplog.text
+    assert err_line in caplog.text

--- a/tests/qasm3/declarations/test_quantum.py
+++ b/tests/qasm3/declarations/test_quantum.py
@@ -165,7 +165,7 @@ def test_clbit_redeclaration_error():
 def test_non_constant_size():
     """Test non-constant size in qubit and clbit declarations"""
     with pytest.raises(
-        ValidationError, match=r"Variable 'N' is not a constant in given expression"
+        ValidationError, match=r"Expected variable 'N' to be constant in given expression"
     ):
         qasm3_string = """
         OPENQASM 3.0;
@@ -176,7 +176,7 @@ def test_non_constant_size():
         loads(qasm3_string).validate()
 
     with pytest.raises(
-        ValidationError, match=r"Variable 'size' is not a constant in given expression"
+        ValidationError, match=r"Expected variable 'size' to be constant in given expression"
     ):
         qasm3_string = """
         OPENQASM 3.0;

--- a/tests/qasm3/declarations/test_quantum.py
+++ b/tests/qasm3/declarations/test_quantum.py
@@ -152,7 +152,7 @@ def test_invalid_qubit_name():
 
 def test_clbit_redeclaration_error():
     """Test redeclaration of clbit"""
-    with pytest.raises(ValidationError, match=r"Re-declaration of variable c1"):
+    with pytest.raises(ValidationError, match=r"Re-declaration of variable 'c1'"):
         qasm3_string = """
         OPENQASM 3.0;
         include "stdgates.inc";

--- a/tests/qasm3/declarations/test_quantum.py
+++ b/tests/qasm3/declarations/test_quantum.py
@@ -125,63 +125,75 @@ def test_qubit_clbit_declarations():
     check_unrolled_qasm(unrolled_qasm, expected_qasm)
 
 
-def test_qubit_redeclaration_error():
-    """Test redeclaration of qubit"""
-    with pytest.raises(ValidationError, match="Re-declaration of quantum register with name 'q1'"):
-        qasm3_string = """
-        OPENQASM 3.0;
-        include "stdgates.inc";
-        qubit q1;
-        qubit q1;
-        """
-        loads(qasm3_string).validate()
+@pytest.mark.parametrize(
+    "qasm_code,error_message,line_num,col_num,err_line",
+    [
+        (
+            """
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            qubit q1;
+            qubit q1;
+            """,
+            "Re-declaration of quantum register with name 'q1'",
+            5,
+            12,
+            "qubit[1] q1;",
+        ),
+        (
+            """
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            qubit pi;
+            """,
+            "Can not declare quantum register with keyword name 'pi'",
+            4,
+            12,
+            "qubit[1] pi;",
+        ),
+        (
+            """
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            bit c1;
+            bit[4] c1;
+            """,
+            r"Re-declaration of variable 'c1'",
+            5,
+            12,
+            "bit[4] c1;",
+        ),
+        (
+            """
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            int[32] N = 10;
+            qubit[N] q;
+            """,
+            r"Invalid size 'N' for quantum register 'q'",
+            5,
+            12,
+            "qubit[N] q;",
+        ),
+        (
+            """
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            int[32] size = 10;
+            bit[size] c;
+            """,
+            r"Invalid base size for variable 'c'",
+            5,
+            15,
+            "bit[size] c;",
+        ),
+    ],
+)
+def test_quantum_declarations_errors(qasm_code, error_message, line_num, col_num, err_line, caplog):
+    """Test various error cases with qubit and bit declarations"""
+    with pytest.raises(ValidationError, match=error_message):
+        with caplog.at_level("ERROR"):
+            loads(qasm_code).validate()
 
-
-def test_invalid_qubit_name():
-    """Test that qubit name can not be one of constants"""
-    with pytest.raises(
-        ValidationError, match="Can not declare quantum register with keyword name 'pi'"
-    ):
-        qasm3_string = """
-        OPENQASM 3.0;
-        include "stdgates.inc";
-        qubit pi;
-        """
-        loads(qasm3_string).validate()
-
-
-def test_clbit_redeclaration_error():
-    """Test redeclaration of clbit"""
-    with pytest.raises(ValidationError, match=r"Re-declaration of variable 'c1'"):
-        qasm3_string = """
-        OPENQASM 3.0;
-        include "stdgates.inc";
-        bit c1;
-        bit[4] c1;
-        """
-        loads(qasm3_string).validate()
-
-
-def test_non_constant_size():
-    """Test non-constant size in qubit and clbit declarations"""
-    with pytest.raises(
-        ValidationError, match=r"Expected variable 'N' to be constant in given expression"
-    ):
-        qasm3_string = """
-        OPENQASM 3.0;
-        include "stdgates.inc";
-        int[32] N = 10;
-        qubit[N] q;
-        """
-        loads(qasm3_string).validate()
-
-    with pytest.raises(
-        ValidationError, match=r"Expected variable 'size' to be constant in given expression"
-    ):
-        qasm3_string = """
-        OPENQASM 3.0;
-        include "stdgates.inc";
-        int[32] size = 10;
-        bit[size] c;
-        """
-        loads(qasm3_string).validate()
+    assert f"Error at line {line_num}, column {col_num}" in caplog.text
+    assert err_line in caplog.text

--- a/tests/qasm3/declarations/test_quantum.py
+++ b/tests/qasm3/declarations/test_quantum.py
@@ -189,6 +189,7 @@ def test_qubit_clbit_declarations():
         ),
     ],
 )
+# pylint: disable-next=too-many-arguments
 def test_quantum_declarations_errors(qasm_code, error_message, line_num, col_num, err_line, caplog):
     """Test various error cases with qubit and bit declarations"""
     with pytest.raises(ValidationError, match=error_message):

--- a/tests/qasm3/resources/gates.py
+++ b/tests/qasm3/resources/gates.py
@@ -255,7 +255,7 @@ SINGLE_QUBIT_GATE_INCORRECT_TESTS = {
         qubit[2] q1;
         h q2;  // undeclared register
         """,
-        "Missing register declaration for q2 .*",
+        "Missing qubit register declaration for 'q2' in QuantumGate",
     ),
     "undeclared_1qubit_op": (
         """
@@ -328,7 +328,7 @@ CUSTOM_GATE_INCORRECT_TESTS = {
         qubit q;
         gphase(pi) q;
         """,
-        r"Qubit arguments not allowed for phase operation",
+        r"Qubit arguments not allowed for 'gphase' operation",
     ),
     "undeclared_custom": (
         """
@@ -431,6 +431,6 @@ CUSTOM_GATE_INCORRECT_TESTS = {
         qubit[2] q1;
         custom_gate(0.5, 0.5) q1;  // duplicate definition
         """,
-        "Duplicate gate definition for custom_gate",
+        "Duplicate quantum gate definition for 'custom_gate'",
     ),
 }

--- a/tests/qasm3/resources/gates.py
+++ b/tests/qasm3/resources/gates.py
@@ -306,7 +306,7 @@ SINGLE_QUBIT_GATE_INCORRECT_TESTS = {
         qubit[2] q1;
         rx(a) q1; // unsupported parameter type
         """,
-        "Undefined identifier a in.*",
+        "Undefined identifier 'a' in.*",
     ),
     "duplicate_qubits": (
         """
@@ -316,7 +316,7 @@ SINGLE_QUBIT_GATE_INCORRECT_TESTS = {
         qubit[2] q1;
         cx q1[0] , q1[0];  // duplicate qubit
         """,
-        r"Duplicate qubit q1\[0\] in gate cx",
+        r"Duplicate qubit 'q1\[0\]' arg in gate cx",
     ),
 }
 
@@ -353,7 +353,7 @@ CUSTOM_GATE_INCORRECT_TESTS = {
         qubit[2] q1;
         custom_gate(0.5) q1;  // parameter count mismatch
         """,
-        "Parameter count mismatch for gate custom_gate: expected 2 arguments, but got 1 instead.",
+        "Parameter count mismatch for gate 'custom_gate': expected 2 arguments, but got 1 instead.",
     ),
     "parameter_mismatch_2": (
         """
@@ -382,7 +382,7 @@ CUSTOM_GATE_INCORRECT_TESTS = {
         qubit[3] q1;
         custom_gate(0.5, 0.5) q1;  // qubit count mismatch
         """,
-        "Qubit count mismatch for gate custom_gate: expected 2 qubits, but got 3 instead.",
+        "Qubit count mismatch for gate 'custom_gate': expected 2 qubits, but got 3 instead.",
     ),
     "indexing_not_supported": (
         """

--- a/tests/qasm3/resources/gates.py
+++ b/tests/qasm3/resources/gates.py
@@ -353,7 +353,7 @@ CUSTOM_GATE_INCORRECT_TESTS = {
         qubit[2] q1;
         custom_gate(0.5) q1;  // parameter count mismatch
         """,
-        "Parameter count mismatch for gate 'custom_gate': expected 2 arguments, but got 1 instead.",
+        "Parameter count mismatch for gate 'custom_gate'. Expected 2 arguments, but got 1 instead.",
     ),
     "parameter_mismatch_2": (
         """
@@ -382,7 +382,7 @@ CUSTOM_GATE_INCORRECT_TESTS = {
         qubit[3] q1;
         custom_gate(0.5, 0.5) q1;  // qubit count mismatch
         """,
-        "Qubit count mismatch for gate 'custom_gate': expected 2 qubits, but got 3 instead.",
+        "Qubit count mismatch for gate 'custom_gate'. Expected 2 qubits, but got 3 instead.",
     ),
     "indexing_not_supported": (
         """

--- a/tests/qasm3/resources/gates.py
+++ b/tests/qasm3/resources/gates.py
@@ -256,6 +256,9 @@ SINGLE_QUBIT_GATE_INCORRECT_TESTS = {
         h q2;  // undeclared register
         """,
         "Missing qubit register declaration for 'q2' in QuantumGate",
+        6,
+        8,
+        "h q2;",
     ),
     "undeclared_1qubit_op": (
         """
@@ -266,6 +269,9 @@ SINGLE_QUBIT_GATE_INCORRECT_TESTS = {
         u_abc(0.5, 0.5, 0.5) q1;  // unsupported gate
         """,
         "Unsupported / undeclared QASM operation: u_abc",
+        6,
+        8,
+        "u_abc(0.5, 0.5, 0.5) q1",
     ),
     "undeclared_1qubit_op_with_indexing": (
         """
@@ -277,6 +283,9 @@ SINGLE_QUBIT_GATE_INCORRECT_TESTS = {
         u_abc(0.5, 0.5, 0.5) q1[0], q1[1];  // unsupported gate
         """,
         "Unsupported / undeclared QASM operation: u_abc",
+        7,
+        8,
+        "u_abc(0.5, 0.5, 0.5) q1[0], q1[1];",
     ),
     "undeclared_3qubit_op": (
         """
@@ -287,6 +296,9 @@ SINGLE_QUBIT_GATE_INCORRECT_TESTS = {
         u_abc(0.5, 0.5, 0.5) q1[0], q1[1], q1[2];  // unsupported gate
         """,
         "Unsupported / undeclared QASM operation: u_abc",
+        6,
+        8,
+        "u_abc(0.5, 0.5, 0.5) q1[0], q1[1], q1[2];",
     ),
     "invalid_gate_application": (
         """
@@ -297,6 +309,9 @@ SINGLE_QUBIT_GATE_INCORRECT_TESTS = {
         cx q1;  // invalid application of gate, as we apply it to 3 qubits in blocks of 2
         """,
         "Invalid number of qubits 3 for operation cx",
+        6,
+        8,
+        "cx q1[0], q1[1], q1[2];",  # expanded line
     ),
     "unsupported_parameter_type": (
         """
@@ -304,9 +319,12 @@ SINGLE_QUBIT_GATE_INCORRECT_TESTS = {
         include "stdgates.inc";
 
         qubit[2] q1;
-        rx(a) q1; // unsupported parameter type
+        rx(a) q1;
         """,
-        "Undefined identifier 'a' in.*",
+        "Invalid parameter 'a' for .*",
+        6,
+        11,
+        "rx(a) q1[0], q1[1];",  # expanded line
     ),
     "duplicate_qubits": (
         """
@@ -317,6 +335,9 @@ SINGLE_QUBIT_GATE_INCORRECT_TESTS = {
         cx q1[0] , q1[0];  // duplicate qubit
         """,
         r"Duplicate qubit 'q1\[0\]' arg in gate cx",
+        6,
+        8,
+        "cx q1[0], q1[0];",
     ),
 }
 
@@ -329,6 +350,9 @@ CUSTOM_GATE_INCORRECT_TESTS = {
         gphase(pi) q;
         """,
         r"Qubit arguments not allowed for 'gphase' operation",
+        4,
+        8,
+        "gphase(3.141592653589793) q[0];",
     ),
     "undeclared_custom": (
         """
@@ -339,6 +363,9 @@ CUSTOM_GATE_INCORRECT_TESTS = {
         custom_gate q1;  // undeclared gate
         """,
         "Unsupported / undeclared QASM operation: custom_gate",
+        6,
+        8,
+        "custom_gate q1[0], q1[1];",  # expanded line
     ),
     "parameter_mismatch_1": (
         """
@@ -354,6 +381,9 @@ CUSTOM_GATE_INCORRECT_TESTS = {
         custom_gate(0.5) q1;  // parameter count mismatch
         """,
         "Parameter count mismatch for gate 'custom_gate'. Expected 2 arguments, but got 1 instead.",
+        11,
+        8,
+        "custom_gate(0.5) q1[0], q1[1];",  # expanded line
     ),
     "parameter_mismatch_2": (
         """
@@ -368,6 +398,9 @@ CUSTOM_GATE_INCORRECT_TESTS = {
         rz(0.5, 0.0) q[0];
         """,
         "Expected 1 parameter for gate 'rz', but got 2",
+        10,
+        8,
+        "rz(0.5, 0.0) q[0];",
     ),
     "qubit_mismatch": (
         """
@@ -383,6 +416,9 @@ CUSTOM_GATE_INCORRECT_TESTS = {
         custom_gate(0.5, 0.5) q1;  // qubit count mismatch
         """,
         "Qubit count mismatch for gate 'custom_gate'. Expected 2 qubits, but got 3 instead.",
+        11,
+        8,
+        "custom_gate(0.5, 0.5) q1[0], q1[1], q1[2];",  # expanded line
     ),
     "indexing_not_supported": (
         """
@@ -398,6 +434,9 @@ CUSTOM_GATE_INCORRECT_TESTS = {
         custom_gate(0.5, 0.5) q1;  // indexing not supported
         """,
         "Indexing .* not supported in gate definition",
+        7,
+        18,
+        "ry(0.5) q[0];",  # expanded line
     ),
     "recursive_definition": (
         """
@@ -412,6 +451,9 @@ CUSTOM_GATE_INCORRECT_TESTS = {
         custom_gate(0.5, 0.5) q1;  // recursive definition
         """,
         "Recursive definitions not allowed .*",
+        6,
+        12,
+        "custom_gate(a, b) p, q;",
     ),
     "duplicate_definition": (
         """
@@ -432,5 +474,8 @@ CUSTOM_GATE_INCORRECT_TESTS = {
         custom_gate(0.5, 0.5) q1;  // duplicate definition
         """,
         "Duplicate quantum gate definition for 'custom_gate'",
+        10,
+        8,
+        "gate custom_gate(a, b) p, q {",
     ),
 }

--- a/tests/qasm3/resources/subroutines.py
+++ b/tests/qasm3/resources/subroutines.py
@@ -55,7 +55,7 @@ SUBROUTINE_INCORRECT_TESTS = {
         qubit q;
         my_function(q);
         """,
-        "Re-declaration of variable q",
+        "Re-declaration of variable 'q'",
     ),
     "incorrect_param_count_1": (
         """

--- a/tests/qasm3/resources/subroutines.py
+++ b/tests/qasm3/resources/subroutines.py
@@ -271,7 +271,7 @@ SUBROUTINE_INCORRECT_TESTS_WITH_ARRAYS = {
         my_function(q, 5);
         """,
         r"Expecting type 'array\[int\[8\],...\]' for 'my_arr' in function 'my_function'."
-        r" Literal 5 found in function call",
+        r" Literal '5' found in function call",
     ),
     "type_mismatch_in_array": (
         """

--- a/tests/qasm3/resources/subroutines.py
+++ b/tests/qasm3/resources/subroutines.py
@@ -16,7 +16,6 @@
 Module defining subroutine tests.
 
 """
-
 SUBROUTINE_INCORRECT_TESTS = {
     "undeclared_call": (
         """
@@ -26,6 +25,9 @@ SUBROUTINE_INCORRECT_TESTS = {
         my_function(1);
         """,
         "Undefined subroutine 'my_function' was called",
+        5,  # Line number
+        8,  # Column number
+        "my_function(1)",  # Complete line
     ),
     "redefinition_raises_error": (
         """
@@ -43,6 +45,9 @@ SUBROUTINE_INCORRECT_TESTS = {
         qubit q;
         """,
         "Redefinition of subroutine 'my_function'",
+        9,
+        8,
+        "def my_function(qubit q) -> float[32]",
     ),
     "redefinition_raises_error_2": (
         """
@@ -56,6 +61,9 @@ SUBROUTINE_INCORRECT_TESTS = {
         my_function(q);
         """,
         "Re-declaration of variable 'q'",
+        5,
+        12,
+        "int[32] q = 1;",
     ),
     "incorrect_param_count_1": (
         """
@@ -70,6 +78,9 @@ SUBROUTINE_INCORRECT_TESTS = {
         my_function(q);
         """,
         "Parameter count mismatch for subroutine 'my_function'. Expected 2 but got 1 in call",
+        10,
+        8,
+        "my_function(q)",
     ),
     "incorrect_param_count_2": (
         """
@@ -84,6 +95,9 @@ SUBROUTINE_INCORRECT_TESTS = {
         my_function(q, q);
         """,
         "Parameter count mismatch for subroutine 'my_function'. Expected 1 but got 2 in call",
+        10,
+        8,
+        "my_function(q, q)",
     ),
     "return_value_mismatch": (
         """
@@ -99,6 +113,9 @@ SUBROUTINE_INCORRECT_TESTS = {
         my_function(q);
         """,
         "Return type mismatch for subroutine 'my_function'.",
+        8,
+        12,
+        "return a;",
     ),
     "return_value_mismatch_2": (
         """
@@ -114,6 +131,9 @@ SUBROUTINE_INCORRECT_TESTS = {
         my_function(q);
         """,
         "Return type mismatch for subroutine 'my_function'.",
+        8,
+        12,
+        "return;",
     ),
     "subroutine_keyword_naming": (
         """
@@ -128,6 +148,9 @@ SUBROUTINE_INCORRECT_TESTS = {
         pi(q);
         """,
         "Subroutine name 'pi' is a reserved keyword",
+        5,
+        8,
+        "def pi(qubit q) {",
     ),
     "qubit_size_arg_mismatch": (
         """
@@ -142,6 +165,9 @@ SUBROUTINE_INCORRECT_TESTS = {
         my_function(q);
         """,
         "Qubit register size mismatch for function 'my_function'.",
+        10,
+        8,
+        "my_function(q)",
     ),
     "subroutine_var_name_conflict": (
         """
@@ -156,6 +182,9 @@ SUBROUTINE_INCORRECT_TESTS = {
         a(q);
         """,
         r"Can not declare subroutine with name 'a' .*",
+        5,
+        8,
+        "def a(qubit q) {",
     ),
     "undeclared_register_usage": (
         """
@@ -171,6 +200,9 @@ SUBROUTINE_INCORRECT_TESTS = {
         my_function(b);
         """,
         "Expecting qubit argument for 'q'. Qubit register 'b' not found for function 'my_function'",
+        11,
+        8,
+        "my_function(b)",
     ),
     "test_invalid_qubit_size": (
         """
@@ -185,6 +217,9 @@ SUBROUTINE_INCORRECT_TESTS = {
         my_function(q);
         """,
         "Invalid qubit size '-3' for variable 'q' in function 'my_function'",
+        5,
+        24,
+        "qubit[-3] q",
     ),
     "test_type_mismatch_for_function": (
         """
@@ -200,6 +235,9 @@ SUBROUTINE_INCORRECT_TESTS = {
         my_function(q, b);
         """,
         "Expecting classical argument for 'a'. Qubit register 'q' found for function 'my_function'",
+        11,
+        8,
+        "my_function(q, b)",
     ),
     "test_duplicate_qubit_args": (
         """
@@ -214,6 +252,9 @@ SUBROUTINE_INCORRECT_TESTS = {
         my_function(q[0:3], q[2]);
         """,
         r"Duplicate qubit argument for register 'q' in function call for 'my_function'",
+        10,
+        8,
+        "my_function(q[0:3], q[2])",
     ),
     "undefined_variable_in_actual_arg_1": (
         """
@@ -228,6 +269,9 @@ SUBROUTINE_INCORRECT_TESTS = {
         my_function(b);
         """,
         "Undefined variable 'b' used for function call 'my_function'",
+        10,
+        8,
+        "my_function(b)",
     ),
     "undefined_array_arg_in_function_call": (
         """
@@ -240,6 +284,9 @@ SUBROUTINE_INCORRECT_TESTS = {
         my_function(b);
         """,
         "Undefined variable 'b' used for function call 'my_function'",
+        8,
+        8,
+        "my_function(b)",
     ),
 }
 
@@ -257,7 +304,10 @@ SUBROUTINE_INCORRECT_TESTS_WITH_ARRAYS = {
         my_function(q, arr);
         """,
         r"Expecting type 'array\[int\[8\],...\]' for 'my_arr' in function 'my_function'."
-        r" Variable 'arr' has type 'int\[8\]'.",
+        r" Variable 'arr' has type 'int\[8\]'",
+        10,
+        8,
+        "my_function(q, arr)",
     ),
     "literal_raises_error": (
         """
@@ -272,6 +322,9 @@ SUBROUTINE_INCORRECT_TESTS_WITH_ARRAYS = {
         """,
         r"Expecting type 'array\[int\[8\],...\]' for 'my_arr' in function 'my_function'."
         r" Literal '5' found in function call",
+        9,
+        8,
+        "my_function(q, 5)",
     ),
     "type_mismatch_in_array": (
         """
@@ -286,7 +339,10 @@ SUBROUTINE_INCORRECT_TESTS_WITH_ARRAYS = {
         my_function(q, arr);
         """,
         r"Expecting type 'array\[int\[8\],...\]' for 'my_arr' in function 'my_function'."
-        r" Variable 'arr' has type 'array\[uint\[32\], 2, 2\]'.",
+        r" Variable 'arr' has type 'array\[uint\[32\], 2, 2\]'",
+        10,
+        8,
+        "my_function(q, arr)",
     ),
     "dimension_count_mismatch_1": (
         """
@@ -300,8 +356,11 @@ SUBROUTINE_INCORRECT_TESTS_WITH_ARRAYS = {
         array[int[8], 2] arr;
         my_function(q, arr);
         """,
-        r"Dimension mismatch for 'my_arr' in function 'my_function'. Expected 2 dimensions"
-        r" but variable 'arr' has 1",
+        r"Dimension mismatch. Expected 2 dimensions but variable 'arr'"
+        r" has 1 for 'my_arr' in function 'my_function'",
+        10,
+        8,
+        "my_function(q, arr)",
     ),
     "dimension_count_mismatch_2": (
         """
@@ -315,8 +374,11 @@ SUBROUTINE_INCORRECT_TESTS_WITH_ARRAYS = {
         array[int[8], 2, 2] arr;
         my_function(q, arr);
         """,
-        r"Dimension mismatch for 'my_arr' in function 'my_function'. Expected 4 dimensions "
-        r"but variable 'arr' has 2",
+        r"Dimension mismatch. Expected 4 dimensions but variable 'arr'"
+        r" has 2 for 'my_arr' in function 'my_function'",
+        10,
+        8,
+        "my_function(q, arr)",
     ),
     "qubit_passed_as_array": (
         """
@@ -331,6 +393,9 @@ SUBROUTINE_INCORRECT_TESTS_WITH_ARRAYS = {
         """,
         r"Expecting type 'array\[int\[8\],...\]' for 'my_arr' in function 'my_function'."
         r" Qubit register 'q' found for function call",
+        9,
+        8,
+        "my_function(q)",
     ),
     "invalid_dimension_number": (
         """
@@ -345,6 +410,9 @@ SUBROUTINE_INCORRECT_TESTS_WITH_ARRAYS = {
         my_function(q, arr);
         """,
         r"Invalid number of dimensions -3 for 'my_arr' in function 'my_function'",
+        10,
+        8,
+        "my_function(q, arr)",
     ),
     "invalid_non_int_dimensions_1": (
         """
@@ -358,8 +426,10 @@ SUBROUTINE_INCORRECT_TESTS_WITH_ARRAYS = {
         array[int[8], 2, 2] arr;
         my_function(q, arr);
         """,
-        r"Invalid value 2.5 with type <class 'openqasm3.ast.FloatLiteral'> for required type "
-        r"<class 'openqasm3.ast.IntType'>",
+        r"Invalid dimension size 2.5 for 'my_arr' in function 'my_function'",
+        10,
+        8,
+        "my_function(q, arr)",
     ),
     "invalid_non_int_dimensions_2": (
         """
@@ -373,8 +443,10 @@ SUBROUTINE_INCORRECT_TESTS_WITH_ARRAYS = {
         array[int[8], 2, 2] arr;
         my_function(q, arr);
         """,
-        r"Invalid value 2.5 with type <class 'openqasm3.ast.FloatLiteral'> for required type"
-        r" <class 'openqasm3.ast.IntType'>",
+        r"Invalid dimension size 2.5 for 'my_arr' in function 'my_function'",
+        10,
+        8,
+        "my_function(q, arr)",
     ),
     "extra_dimensions_for_array": (
         """
@@ -388,8 +460,10 @@ SUBROUTINE_INCORRECT_TESTS_WITH_ARRAYS = {
         array[int[8], 2, 2] arr;
         my_function(q, arr);
         """,
-        r"Dimension mismatch for 'my_arr' in function 'my_function'. "
-        r"Expected dimension 0 with size >= 4 but got 2",
+        r"Invalid dimension size 4 for 'my_arr' in function 'my_function'",
+        10,
+        8,
+        "my_function(q, arr)",
     ),
     "invalid_array_dimensions_formal_arg": (
         """
@@ -403,6 +477,9 @@ SUBROUTINE_INCORRECT_TESTS_WITH_ARRAYS = {
         my_function(b);
         """,
         r"Invalid dimension size -1 for 'a' in function 'my_function'",
+        9,
+        8,
+        "my_function(b)",
     ),
     "invalid_array_mutation_for_readonly_arg": (
         """
@@ -417,5 +494,8 @@ SUBROUTINE_INCORRECT_TESTS_WITH_ARRAYS = {
         my_function(b);
         """,
         r"Assignment to readonly variable 'a' not allowed in function call",
+        6,
+        12,
+        "a[1][0] = 5",
     ),
 }

--- a/tests/qasm3/resources/subroutines.py
+++ b/tests/qasm3/resources/subroutines.py
@@ -184,7 +184,7 @@ SUBROUTINE_INCORRECT_TESTS = {
         qubit[4] q;
         my_function(q);
         """,
-        "Invalid qubit size -3 for variable 'q' in function 'my_function'",
+        "Invalid qubit size '-3' for variable 'q' in function 'my_function'",
     ),
     "test_type_mismatch_for_function": (
         """

--- a/tests/qasm3/resources/variables.py
+++ b/tests/qasm3/resources/variables.py
@@ -121,7 +121,7 @@ DECLARATION_TESTS = {
 
         angle x = 3.4;
         """,
-        "Invalid type <class 'openqasm3.ast.AngleType'> for variable 'x'",
+        "Invalid type '<class 'openqasm3.ast.AngleType'>' for variable 'x'",
     ),
     "imaginary_variable": (
         """

--- a/tests/qasm3/resources/variables.py
+++ b/tests/qasm3/resources/variables.py
@@ -77,7 +77,7 @@ DECLARATION_TESTS = {
         include "stdgates.inc";
         int[32.1] x;
         """,
-        "Invalid base size 32.1 for variable x",
+        "Invalid base size 32.1 for variable 'x'",
     ),
     "invalid_const_int_size": (
         """
@@ -85,7 +85,7 @@ DECLARATION_TESTS = {
         include "stdgates.inc";
         const int[32.1] x = 3;
         """,
-        "Invalid base size 32.1 for variable x",
+        "Invalid base size 32.1 for variable 'x'",
     ),
     "const_declaration_with_non_const": (
         """
@@ -94,7 +94,7 @@ DECLARATION_TESTS = {
         int[32] x = 5;
         const int[32] y = x + 5;
         """,
-        "Variable 'x' is not a constant in given expression",
+        "Expected variable 'x' to be constant in given expression",
     ),
     "const_declaration_with_non_const_size": (
         """
@@ -103,7 +103,7 @@ DECLARATION_TESTS = {
         int[32] x = 5;
         const int[x] y = 5;
         """,
-        "Variable 'x' is not a constant in given expression",
+        "Expected variable 'x' to be constant in given expression",
     ),
     "invalid_float_size": (
         """
@@ -112,7 +112,7 @@ DECLARATION_TESTS = {
 
         float[23] x;
         """,
-        "Invalid base size 23 for float variable x",
+        "Invalid base size 23 for float variable 'x'",
     ),
     "unsupported_types": (
         """
@@ -121,7 +121,7 @@ DECLARATION_TESTS = {
 
         angle x = 3.4;
         """,
-        "Invalid type <class 'openqasm3.ast.AngleType'> for variable x",
+        "Invalid type <class 'openqasm3.ast.AngleType'> for variable 'x'",
     ),
     "imaginary_variable": (
         """
@@ -139,7 +139,7 @@ DECLARATION_TESTS = {
 
         array[int[32], 1, 2.1] x;
         """,
-        "Invalid dimension size 2.1 in array declaration for x",
+        "Invalid dimension size 2.1 in array declaration for 'x'",
     ),
     "extra_array_dimensions": (
         """
@@ -148,7 +148,7 @@ DECLARATION_TESTS = {
 
         array[int[32], 1, 2, 3, 4, 5, 6, 7, 8] x;
         """,
-        "Invalid dimensions 8 for array declaration for x. Max allowed dimensions is 7",
+        "Invalid dimensions 8 for array declaration for 'x'. Max allowed dimensions is 7",
     ),
     "dimension_mismatch_1": (
         """
@@ -157,7 +157,7 @@ DECLARATION_TESTS = {
 
         array[int[32], 1, 2] x = {1,2,3};
         """,
-        "Invalid dimensions for array assignment to variable x. Expected 1 but got 3",
+        "Invalid dimensions for array assignment to variable 'x'. Expected 1 but got 3",
     ),
     "dimension_mismatch_2": (
         """
@@ -240,7 +240,7 @@ ASSIGNMENT_TESTS = {
 
         float[32] x = 123456789123456789123456789123456789123456789.1;
         """,
-        "Value .* out of limits for variable x with base size 32",
+        "Value .* out of limits for variable 'x' with base size 32",
     ),
     "indexing_non_array": (
         """
@@ -281,6 +281,6 @@ ASSIGNMENT_TESTS = {
         array[int[32], 3] x;
         x[3] = 3;
         """,
-        "Index 3 out of bounds for dimension 0 of variable x",
+        "Index 3 out of bounds for dimension 0 of variable 'x'",
     ),
 }

--- a/tests/qasm3/resources/variables.py
+++ b/tests/qasm3/resources/variables.py
@@ -42,7 +42,7 @@ DECLARATION_TESTS = {
         float y = 3.4;
         uint x;
         """,
-        "Re-declaration of variable x",
+        "Re-declaration of variable 'x'",
     ),
     "variable_redeclaration_with_qubits_1": (
         """
@@ -60,7 +60,7 @@ DECLARATION_TESTS = {
         qubit x;
         int x;
         """,
-        "Re-declaration of variable x",
+        "Re-declaration of variable 'x'",
     ),
     "const_variable_redeclaration": (
         """
@@ -69,7 +69,7 @@ DECLARATION_TESTS = {
         const int x = 3;
         const float x = 3.4;
         """,
-        "Re-declaration of variable x",
+        "Re-declaration of variable 'x'",
     ),
     "invalid_int_size": (
         """

--- a/tests/qasm3/resources/variables.py
+++ b/tests/qasm3/resources/variables.py
@@ -291,7 +291,7 @@ ASSIGNMENT_TESTS = {
 
         int[32] x = 1<<64;
         """,
-        f"Invalid initialization value for variable 'x'",
+        "Invalid initialization value for variable 'x'",
         5,
         8,
         "int[32] x = 1 << 64;",

--- a/tests/qasm3/resources/variables.py
+++ b/tests/qasm3/resources/variables.py
@@ -231,7 +231,7 @@ ASSIGNMENT_TESTS = {
 
         int[32] x = 1<<64;
         """,
-        f"Value {2**64} out of limits for variable x with base size 32",
+        f"Value {2**64} out of limits for variable 'x' with base size 32",
     ),
     "float32_out_of_range": (
         """

--- a/tests/qasm3/resources/variables.py
+++ b/tests/qasm3/resources/variables.py
@@ -16,7 +16,6 @@
 Module defining QASM3 incorrect variable tests.
 
 """
-
 DECLARATION_TESTS = {
     "keyword_redeclaration": (
         """
@@ -25,6 +24,9 @@ DECLARATION_TESTS = {
         int pi;
         """,
         "Can not declare variable with keyword name pi",
+        4,  # Line number
+        8,  # Column number
+        "int pi;",  # Complete line
     ),
     "const_keyword_redeclaration": (
         """
@@ -33,6 +35,9 @@ DECLARATION_TESTS = {
         const int pi = 3;
         """,
         "Can not declare variable with keyword name pi",
+        4,
+        8,
+        "const int pi = 3;",
     ),
     "variable_redeclaration": (
         """
@@ -43,6 +48,9 @@ DECLARATION_TESTS = {
         uint x;
         """,
         "Re-declaration of variable 'x'",
+        6,
+        8,
+        "uint x;",
     ),
     "variable_redeclaration_with_qubits_1": (
         """
@@ -52,6 +60,9 @@ DECLARATION_TESTS = {
         qubit x;
         """,
         "Re-declaration of quantum register with name 'x'",
+        5,
+        8,
+        "qubit[1] x;",
     ),
     "variable_redeclaration_with_qubits_2": (
         """
@@ -61,6 +72,9 @@ DECLARATION_TESTS = {
         int x;
         """,
         "Re-declaration of variable 'x'",
+        5,
+        8,
+        "int x;",
     ),
     "const_variable_redeclaration": (
         """
@@ -70,6 +84,9 @@ DECLARATION_TESTS = {
         const float x = 3.4;
         """,
         "Re-declaration of variable 'x'",
+        5,
+        8,
+        "const float x = 3.4;",
     ),
     "invalid_int_size": (
         """
@@ -78,6 +95,9 @@ DECLARATION_TESTS = {
         int[32.1] x;
         """,
         "Invalid base size 32.1 for variable 'x'",
+        4,
+        8,
+        "int[32.1] x;",
     ),
     "invalid_const_int_size": (
         """
@@ -85,7 +105,10 @@ DECLARATION_TESTS = {
         include "stdgates.inc";
         const int[32.1] x = 3;
         """,
-        "Invalid base size 32.1 for variable 'x'",
+        "Invalid base size for constant 'x'",
+        4,
+        8,
+        "const int[32.1] x = 3;",
     ),
     "const_declaration_with_non_const": (
         """
@@ -94,7 +117,10 @@ DECLARATION_TESTS = {
         int[32] x = 5;
         const int[32] y = x + 5;
         """,
-        "Expected variable 'x' to be constant in given expression",
+        "Invalid initialization value for constant 'y'",
+        5,
+        8,
+        "const int[32] y = x + 5;",
     ),
     "const_declaration_with_non_const_size": (
         """
@@ -103,7 +129,10 @@ DECLARATION_TESTS = {
         int[32] x = 5;
         const int[x] y = 5;
         """,
-        "Expected variable 'x' to be constant in given expression",
+        "Invalid base size for constant 'y'",
+        5,
+        8,
+        "const int[x] y = 5;",
     ),
     "invalid_float_size": (
         """
@@ -113,6 +142,9 @@ DECLARATION_TESTS = {
         float[23] x;
         """,
         "Invalid base size 23 for float variable 'x'",
+        5,
+        8,
+        "float[23] x;",
     ),
     "unsupported_types": (
         """
@@ -121,7 +153,10 @@ DECLARATION_TESTS = {
 
         angle x = 3.4;
         """,
-        "Invalid type '<class 'openqasm3.ast.AngleType'>' for variable 'x'",
+        "Invalid initialization value for variable 'x'",
+        5,
+        8,
+        "angle x = 3.4;",
     ),
     "imaginary_variable": (
         """
@@ -130,7 +165,10 @@ DECLARATION_TESTS = {
 
         int x = 1 + 3im;
         """,
-        "Unsupported expression type '<class 'openqasm3.ast.ImaginaryLiteral'>'",
+        "Invalid initialization value for variable 'x'",
+        5,
+        8,
+        "int x = 1 + 3.0im;",
     ),
     "invalid_array_dimensions": (
         """
@@ -140,6 +178,9 @@ DECLARATION_TESTS = {
         array[int[32], 1, 2.1] x;
         """,
         "Invalid dimension size 2.1 in array declaration for 'x'",
+        5,
+        8,
+        "array[int[32], 1, 2.1] x;",
     ),
     "extra_array_dimensions": (
         """
@@ -149,6 +190,9 @@ DECLARATION_TESTS = {
         array[int[32], 1, 2, 3, 4, 5, 6, 7, 8] x;
         """,
         "Invalid dimensions 8 for array declaration for 'x'. Max allowed dimensions is 7",
+        5,
+        8,
+        "array[int[32], 1, 2, 3, 4, 5, 6, 7, 8] x;",
     ),
     "dimension_mismatch_1": (
         """
@@ -157,7 +201,10 @@ DECLARATION_TESTS = {
 
         array[int[32], 1, 2] x = {1,2,3};
         """,
-        "Invalid dimensions for array assignment to variable 'x'. Expected 1 but got 3",
+        "Invalid initialization value for array 'x'",
+        5,
+        8,
+        "array[int[32], 1, 2] x = {1, 2, 3};",
     ),
     "dimension_mismatch_2": (
         """
@@ -166,7 +213,10 @@ DECLARATION_TESTS = {
 
         array[int[32], 3, 1, 2] x = {1,2,3};
         """,
-        "Invalid dimensions for array assignment to variable x. Expected 3 but got 1",
+        "Invalid initialization value for array 'x'",
+        5,
+        8,
+        "array[int[32], 3, 1, 2] x = {1, 2, 3};",
     ),
     "invalid_bit_type_array_1": (
         """
@@ -176,6 +226,9 @@ DECLARATION_TESTS = {
         array[bit, 3] x;
         """,
         "Can not declare array x with type 'bit'",
+        5,
+        8,
+        "array[bit, 3] x;",
     ),
     "invalid_bit_type_array_2": (
         """
@@ -185,9 +238,11 @@ DECLARATION_TESTS = {
         array[bit[32], 3] x;
         """,
         "Can not declare array x with type 'bit'",
+        5,
+        8,
+        "array[bit[32], 3] x;",
     ),
 }
-
 ASSIGNMENT_TESTS = {
     "undefined_variable_assignment": (
         """
@@ -200,6 +255,9 @@ ASSIGNMENT_TESTS = {
 
         """,
         "Undefined variable x in assignment",
+        7,  # Line number
+        8,  # Column number
+        "x = 3;",  # Complete line
     ),
     "assignment_to_constant": (
         """
@@ -210,6 +268,9 @@ ASSIGNMENT_TESTS = {
         x = 4;
         """,
         "Assignment to constant variable x not allowed",
+        6,
+        8,
+        "x = 4;",
     ),
     "invalid_assignment_type": (
         """
@@ -218,11 +279,10 @@ ASSIGNMENT_TESTS = {
 
         bit x = 3.3;
         """,
-        (
-            "Cannot cast <class 'float'> to <class 'openqasm3.ast.BitType'>. "
-            "Invalid assignment of type <class 'float'> to variable x of type "
-            "<class 'openqasm3.ast.BitType'>"
-        ),
+        "Invalid initialization value for variable 'x'",
+        5,
+        8,
+        "bit x = 3.3;",
     ),
     "int_out_of_range": (
         """
@@ -231,7 +291,10 @@ ASSIGNMENT_TESTS = {
 
         int[32] x = 1<<64;
         """,
-        f"Value {2**64} out of limits for variable 'x' with base size 32",
+        f"Invalid initialization value for variable 'x'",
+        5,
+        8,
+        "int[32] x = 1 << 64;",
     ),
     "float32_out_of_range": (
         """
@@ -240,7 +303,10 @@ ASSIGNMENT_TESTS = {
 
         float[32] x = 123456789123456789123456789123456789123456789.1;
         """,
-        "Value .* out of limits for variable 'x' with base size 32",
+        "Invalid initialization value for variable 'x'",
+        5,
+        8,
+        "float[32] x = 1.2345678912345679e+44;",
     ),
     "indexing_non_array": (
         """
@@ -250,7 +316,10 @@ ASSIGNMENT_TESTS = {
         int x = 3;
         x[0] = 4;
         """,
-        "Indexing error. Variable x is not an array",
+        "Invalid index for variable 'x'",
+        6,
+        8,
+        "x[0] = 4;",
     ),
     "incorrect_num_dims": (
         """
@@ -260,7 +329,10 @@ ASSIGNMENT_TESTS = {
         array[int[32], 1, 2, 3] x;
         x[0] = 3;
         """,
-        "Invalid number of indices for variable x. Expected 3 but got 1",
+        "Invalid index for variable 'x'",
+        6,
+        8,
+        "x[0] = 3;",
     ),
     "non_nnint_index": (
         """
@@ -270,8 +342,10 @@ ASSIGNMENT_TESTS = {
         array[int[32], 3] x;
         x[0.1] = 3;
         """,
-        "Invalid value 0.1 with type <class 'openqasm3.ast.FloatLiteral'> for "
-        "required type <class 'openqasm3.ast.IntType'>",
+        "Invalid index for variable 'x'",
+        6,
+        8,
+        "x[0.1] = 3;",
     ),
     "index_out_of_range": (
         """
@@ -281,6 +355,9 @@ ASSIGNMENT_TESTS = {
         array[int[32], 3] x;
         x[3] = 3;
         """,
-        "Index 3 out of bounds for dimension 0 of variable 'x'",
+        "Invalid index for variable 'x'",
+        6,
+        8,
+        "x[3] = 3;",
     ),
 }

--- a/tests/qasm3/resources/variables.py
+++ b/tests/qasm3/resources/variables.py
@@ -130,7 +130,7 @@ DECLARATION_TESTS = {
 
         int x = 1 + 3im;
         """,
-        "Unsupported expression type <class 'openqasm3.ast.ImaginaryLiteral'>",
+        "Unsupported expression type '<class 'openqasm3.ast.ImaginaryLiteral'>'",
     ),
     "invalid_array_dimensions": (
         """

--- a/tests/qasm3/subroutines/test_subroutines.py
+++ b/tests/qasm3/subroutines/test_subroutines.py
@@ -302,7 +302,7 @@ def test_function_call_from_within_fn():
 
 
 @pytest.mark.parametrize("data_type", ["int[32] a = 1;", "float[32] a = 1.0;", "bit a = 0;"])
-def test_return_value_mismatch(data_type):
+def test_return_value_mismatch(data_type, caplog):
     """Test that returning a value of incorrect type raises error."""
     qasm_str = (
         """OPENQASM 3.0;
@@ -323,11 +323,15 @@ def test_return_value_mismatch(data_type):
     with pytest.raises(
         ValidationError, match=r"Return type mismatch for subroutine 'my_function'.*"
     ):
-        loads(qasm_str).validate()
+        with caplog.at_level("ERROR"):
+            loads(qasm_str).validate()
+
+    assert "Error at line 7, column 8" in caplog.text
+    assert "return a" in caplog.text
 
 
 @pytest.mark.parametrize("keyword", ["pi", "euler", "tau"])
-def test_subroutine_keyword_naming(keyword):
+def test_subroutine_keyword_naming(keyword, caplog):
     """Test that using a keyword as a subroutine name raises error."""
     qasm_str = f"""OPENQASM 3.0;
     include "stdgates.inc";
@@ -341,11 +345,15 @@ def test_subroutine_keyword_naming(keyword):
     """
 
     with pytest.raises(ValidationError, match=f"Subroutine name '{keyword}' is a reserved keyword"):
-        loads(qasm_str).validate()
+        with caplog.at_level("ERROR"):
+            loads(qasm_str).validate()
+
+    assert "Error at line 4, column 4" in caplog.text
+    assert f"def {keyword}" in caplog.text
 
 
-@pytest.mark.parametrize("qubit_params", ["q", "q[:2]", "q[{0,1}]"])
-def test_qubit_size_arg_mismatch(qubit_params):
+@pytest.mark.parametrize("qubit_params", ["q", "q[:2]", "q[{0, 1}]"])
+def test_qubit_size_arg_mismatch(qubit_params, caplog):
     """Test that passing a qubit of different size raises error."""
     qasm_str = (
         """OPENQASM 3.0;
@@ -367,11 +375,19 @@ def test_qubit_size_arg_mismatch(qubit_params):
         match="Qubit register size mismatch for function 'my_function'. "
         "Expected 3 qubits in variable 'q' but got 2",
     ):
-        loads(qasm_str).validate()
+        with caplog.at_level("ERROR"):
+            loads(qasm_str).validate()
+
+    assert "Error at line 9, column 4" in caplog.text
+    assert f"my_function({qubit_params})" in caplog.text
 
 
 @pytest.mark.parametrize("test_name", SUBROUTINE_INCORRECT_TESTS.keys())
-def test_incorrect_custom_ops(test_name):
-    qasm_str, error_message = SUBROUTINE_INCORRECT_TESTS[test_name]
+def test_incorrect_custom_ops(test_name, caplog):
+    qasm_str, error_message, line_num, col_num, err_line = SUBROUTINE_INCORRECT_TESTS[test_name]
     with pytest.raises(ValidationError, match=error_message):
-        loads(qasm_str).validate()
+        with caplog.at_level("ERROR"):
+            loads(qasm_str).validate()
+
+    assert f"Error at line {line_num}, column {col_num}" in caplog.text
+    assert err_line in caplog.text

--- a/tests/qasm3/subroutines/test_subroutines.py
+++ b/tests/qasm3/subroutines/test_subroutines.py
@@ -365,7 +365,7 @@ def test_qubit_size_arg_mismatch(qubit_params):
     with pytest.raises(
         ValidationError,
         match="Qubit register size mismatch for function 'my_function'. "
-        "Expected 3 in variable 'q' but got 2",
+        "Expected 3 qubits in variable 'q' but got 2",
     ):
         loads(qasm_str).validate()
 

--- a/tests/qasm3/subroutines/test_subroutines_arrays.py
+++ b/tests/qasm3/subroutines/test_subroutines_arrays.py
@@ -159,7 +159,13 @@ def test_pass_multiple_arrays_to_function():
 
 
 @pytest.mark.parametrize("test_name", SUBROUTINE_INCORRECT_TESTS_WITH_ARRAYS.keys())
-def test_incorrect_custom_ops_with_arrays(test_name):
-    qasm_input, error_message = SUBROUTINE_INCORRECT_TESTS_WITH_ARRAYS[test_name]
+def test_incorrect_custom_ops_with_arrays(test_name, caplog):
+    qasm_input, error_message, line_num, col_num, err_line = SUBROUTINE_INCORRECT_TESTS_WITH_ARRAYS[
+        test_name
+    ]
     with pytest.raises(ValidationError, match=error_message):
-        loads(qasm_input).validate()
+        with caplog.at_level("ERROR"):
+            loads(qasm_input).validate()
+
+    assert f"Error at line {line_num}, column {col_num}" in caplog.text
+    assert err_line in caplog.text

--- a/tests/qasm3/test_alias.py
+++ b/tests/qasm3/test_alias.py
@@ -145,7 +145,7 @@ def test_alias_invalid_discrete_indexing():
     """Test converting OpenQASM 3 program with invalid alias discrete indexing."""
     with pytest.raises(
         ValidationError,
-        match=r"Unsupported discrete set value .*",
+        match=r"Unsupported value .*",
     ):
         qasm3_alias_program = """
         OPENQASM 3.0;

--- a/tests/qasm3/test_alias.py
+++ b/tests/qasm3/test_alias.py
@@ -283,7 +283,7 @@ def test_alias_out_of_scope():
     """Test converting OpenQASM 3 program with alias out of scope."""
     with pytest.raises(
         ValidationError,
-        match=r"Variable alias not in scope for operation .*",
+        match="Variable 'alias' not in scope for QuantumGate 'cx'",
     ):
         qasm3_alias_program = """
         OPENQASM 3;

--- a/tests/qasm3/test_barrier.py
+++ b/tests/qasm3/test_barrier.py
@@ -165,7 +165,9 @@ def test_incorrect_barrier():
     barrier q2;
     """
 
-    with pytest.raises(ValidationError, match=r"Missing register declaration for q2 .*"):
+    with pytest.raises(
+        ValidationError, match="Missing qubit register declaration for 'q2' in QuantumBarrier"
+    ):
         loads(undeclared).validate()
 
     out_of_bounds = """

--- a/tests/qasm3/test_barrier.py
+++ b/tests/qasm3/test_barrier.py
@@ -155,7 +155,7 @@ def test_unroll_barrier():
     check_unrolled_qasm(dumps(module), expected_qasm)
 
 
-def test_incorrect_barrier():
+def test_incorrect_barrier(caplog):
 
     undeclared = """
     OPENQASM 3.0;
@@ -168,7 +168,13 @@ def test_incorrect_barrier():
     with pytest.raises(
         ValidationError, match="Missing qubit register declaration for 'q2' in QuantumBarrier"
     ):
-        loads(undeclared).validate()
+        with caplog.at_level("ERROR"):
+            loads(undeclared).validate()
+
+    assert "Error at line 6, column 4" in caplog.text
+    assert "barrier q2;" in caplog.text
+
+    caplog.clear()
 
     out_of_bounds = """
     OPENQASM 3.0;
@@ -181,4 +187,8 @@ def test_incorrect_barrier():
     with pytest.raises(
         ValidationError, match="Index 3 out of range for register of size 2 in qubit"
     ):
-        loads(out_of_bounds).validate()
+        with caplog.at_level("ERROR"):
+            loads(out_of_bounds).validate()
+
+    assert "Error at line 6, column 4" in caplog.text
+    assert "barrier q1[:4];" in caplog.text

--- a/tests/qasm3/test_expressions.py
+++ b/tests/qasm3/test_expressions.py
@@ -75,7 +75,7 @@ def test_bit_in_expression():
 
 
 def test_incorrect_expressions(caplog):
-    with pytest.raises(ValidationError, match=r"Unsupported expression type .*"):
+    with pytest.raises(ValidationError, match=r"Invalid parameter .*"):
         with caplog.at_level("ERROR"):
             loads("OPENQASM 3; qubit q; rz(1 - 2 + 32im) q;").validate()
     assert "Error at line 1, column 32" in caplog.text
@@ -83,7 +83,7 @@ def test_incorrect_expressions(caplog):
 
     caplog.clear()
 
-    with pytest.raises(ValidationError, match=r"Unsupported expression type .* in ~ operation"):
+    with pytest.raises(ValidationError, match=r"Invalid parameter .*"):
         with caplog.at_level("ERROR"):
             loads("OPENQASM 3; qubit q; rx(~1.3) q;").validate()
     assert "Error at line 1" in caplog.text
@@ -91,7 +91,7 @@ def test_incorrect_expressions(caplog):
 
     caplog.clear()
 
-    with pytest.raises(ValidationError, match=r"Unsupported expression type .* in ~ operation"):
+    with pytest.raises(ValidationError, match=r"Invalid parameter .*"):
         with caplog.at_level("ERROR"):
             loads("OPENQASM 3; qubit q; rx(~1.3+5im) q;").validate()
     assert "Error at line 1" in caplog.text
@@ -99,7 +99,7 @@ def test_incorrect_expressions(caplog):
 
     caplog.clear()
 
-    with pytest.raises(ValidationError, match="Undefined identifier 'x' in expression"):
+    with pytest.raises(ValidationError, match="Invalid parameter 'x' .*"):
         with caplog.at_level("ERROR"):
             loads("OPENQASM 3; qubit q; rx(x) q;").validate()
     assert "Error at line 1" in caplog.text
@@ -107,7 +107,7 @@ def test_incorrect_expressions(caplog):
 
     caplog.clear()
 
-    with pytest.raises(ValidationError, match="Uninitialized variable 'x' in expression"):
+    with pytest.raises(ValidationError, match="Invalid parameter 'x' .*"):
         with caplog.at_level("ERROR"):
             loads("OPENQASM 3; qubit q; int x; rx(x) q;").validate()
     assert "Error at line 1" in caplog.text

--- a/tests/qasm3/test_expressions.py
+++ b/tests/qasm3/test_expressions.py
@@ -74,18 +74,41 @@ def test_bit_in_expression():
     check_measure_op(result.unrolled_ast, 1, meas_pairs)
 
 
-def test_incorrect_expressions():
+def test_incorrect_expressions(caplog):
     with pytest.raises(ValidationError, match=r"Unsupported expression type .*"):
-        loads("OPENQASM 3; qubit q; rz(1 - 2 + 32im) q;").validate()
+        with caplog.at_level("ERROR"):
+            loads("OPENQASM 3; qubit q; rz(1 - 2 + 32im) q;").validate()
+    assert "Error at line 1, column 32" in caplog.text
+    assert "32.0im" in caplog.text
+
+    caplog.clear()
 
     with pytest.raises(ValidationError, match=r"Unsupported expression type .* in ~ operation"):
-        loads("OPENQASM 3; qubit q; rx(~1.3) q;").validate()
+        with caplog.at_level("ERROR"):
+            loads("OPENQASM 3; qubit q; rx(~1.3) q;").validate()
+    assert "Error at line 1" in caplog.text
+    assert "~1.3" in caplog.text
+
+    caplog.clear()
 
     with pytest.raises(ValidationError, match=r"Unsupported expression type .* in ~ operation"):
-        loads("OPENQASM 3; qubit q; rx(~1.3+5im) q;").validate()
+        with caplog.at_level("ERROR"):
+            loads("OPENQASM 3; qubit q; rx(~1.3+5im) q;").validate()
+    assert "Error at line 1" in caplog.text
+    assert "~1.3" in caplog.text
+
+    caplog.clear()
 
     with pytest.raises(ValidationError, match="Undefined identifier 'x' in expression"):
-        loads("OPENQASM 3; qubit q; rx(x) q;").validate()
+        with caplog.at_level("ERROR"):
+            loads("OPENQASM 3; qubit q; rx(x) q;").validate()
+    assert "Error at line 1" in caplog.text
+    assert "x" in caplog.text
+
+    caplog.clear()
 
     with pytest.raises(ValidationError, match="Uninitialized variable 'x' in expression"):
-        loads("OPENQASM 3; qubit q; int x; rx(x) q;").validate()
+        with caplog.at_level("ERROR"):
+            loads("OPENQASM 3; qubit q; int x; rx(x) q;").validate()
+    assert "Error at line 1" in caplog.text
+    assert "x" in caplog.text

--- a/tests/qasm3/test_expressions.py
+++ b/tests/qasm3/test_expressions.py
@@ -84,8 +84,8 @@ def test_incorrect_expressions():
     with pytest.raises(ValidationError, match=r"Unsupported expression type .* in ~ operation"):
         loads("OPENQASM 3; qubit q; rx(~1.3+5im) q;").validate()
 
-    with pytest.raises(ValidationError, match="Undefined identifier x in expression"):
+    with pytest.raises(ValidationError, match="Undefined identifier 'x' in expression"):
         loads("OPENQASM 3; qubit q; rx(x) q;").validate()
 
-    with pytest.raises(ValidationError, match="Uninitialized variable x in expression"):
+    with pytest.raises(ValidationError, match="Uninitialized variable 'x' in expression"):
         loads("OPENQASM 3; qubit q; int x; rx(x) q;").validate()

--- a/tests/qasm3/test_if.py
+++ b/tests/qasm3/test_if.py
@@ -206,131 +206,133 @@ def test_multi_bit_if():
     check_unrolled_qasm(dumps(result), expected_qasm)
 
 
-def test_incorrect_if():
-
-    with pytest.raises(ValidationError, match=r"Missing if block"):
-        loads(
+@pytest.mark.parametrize(
+    "qasm_code,error_message,line_num,col_num,err_line",
+    [
+        (
             """
             OPENQASM 3.0;
-           include "stdgates.inc";
-           qubit[2] q;
-           bit[2] c;
-
-           h q;
-           measure q->c;
-
-           if(c[0]){
-           }
-           """
-        ).validate()
-
-    with pytest.raises(ValidationError, match=r"Undefined identifier 'c2' in expression"):
-        loads(
+            include "stdgates.inc";
+            qubit[2] q;
+            bit[2] c;
+            h q;
+            measure q->c;
+            if(c[0]){
+            }
+            """,
+            r"Missing if block",
+            8,
+            12,
+            "if (c[0]) {",
+        ),
+        (
             """
             OPENQASM 3.0;
-           include "stdgates.inc";
-           qubit[2] q;
-           bit[2] c;
-
-           h q;
-           measure q->c;
-
-           if(c2[0]){
-            cx q;
-           }
-           """
-        ).validate()
-
-    with pytest.raises(ValidationError, match=r"Only '!' supported .*"):
-        loads(
+            include "stdgates.inc";
+            qubit[2] q;
+            bit[2] c;
+            h q;
+            measure q->c;
+            if(c2[0]){
+                cx q;
+            }
+            """,
+            r"Undefined identifier 'c2' in expression",
+            8,
+            15,
+            "c2[0]",
+        ),
+        (
             """
             OPENQASM 3.0;
-           include "stdgates.inc";
-           qubit[2] q;
-           bit[2] c;
-
-           h q;
-           measure q->c;
-
-           if(~c[0]){
-            cx q;
-           }
-           """
-        ).validate()
-    with pytest.raises(
-        ValidationError,
-        match=r"Only {==, >=, <=, >, <} supported in branching condition with classical register",
-    ):
-        loads(
+            include "stdgates.inc";
+            qubit[2] q;
+            bit[2] c;
+            h q;
+            measure q->c;
+            if(~c[0]){
+                cx q;
+            }
+            """,
+            r"Only '!' supported .*",
+            8,
+            15,
+            "~c[0]",
+        ),
+        (
             """
             OPENQASM 3.0;
-           include "stdgates.inc";
-           qubit[2] q;
-           bit[2] c;
-
-           h q;
-           measure q->c;
-
-           if(c[0] >> 1){
-            cx q;
-           }
-           """
-        ).validate()
-    with pytest.raises(
-        ValidationError,
-        match=r"Only simple comparison supported .*",
-    ):
-        loads(
+            include "stdgates.inc";
+            qubit[2] q;
+            bit[2] c;
+            h q;
+            measure q->c;
+            if(c[0] >> 1){
+                cx q;
+            }
+            """,
+            r"Only {==, >=, <=, >, <} supported in branching condition with classical register",
+            8,
+            15,
+            "c[0] >> 1",
+        ),
+        (
             """
             OPENQASM 3.0;
-           include "stdgates.inc";
-           qubit[2] q;
-           bit[2] c;
-
-           h q;
-           measure q->c;
-
-           if(c){
-            cx q;
-           }
-           """
-        ).validate()
-    with pytest.raises(
-        ValidationError,
-        match=r"RangeDefinition not supported in branching condition",
-    ):
-        loads(
+            include "stdgates.inc";
+            qubit[2] q;
+            bit[2] c;
+            h q;
+            measure q->c;
+            if(c){
+                cx q;
+            }
+            """,
+            r"Only simple comparison supported .*",
+            8,
+            15,
+            "c",
+        ),
+        (
             """
             OPENQASM 3.0;
-           include "stdgates.inc";
-           qubit[2] q;
-           bit[2] c;
-
-           h q;
-           measure q->c;
-
-           if(c[0:1]){
-            cx q;
-           }
-           """
-        ).validate()
-
-    with pytest.raises(
-        ValidationError,
-        match=r"DiscreteSet not supported in branching condition",
-    ):
-        loads(
+            include "stdgates.inc";
+            qubit[2] q;
+            bit[2] c;
+            h q;
+            measure q->c;
+            if(c[0:1]){
+                cx q;
+            }
+            """,
+            r"RangeDefinition not supported in branching condition",
+            8,
+            15,
+            "c[0:1]",
+        ),
+        (
             """
             OPENQASM 3.0;
-           include "stdgates.inc";
-           qubit[2] q;
-           bit[2] c;
+            include "stdgates.inc";
+            qubit[2] q;
+            bit[2] c;
+            h q;
+            measure q->c;
+            if(c[{0,1}]){
+                cx q;
+            }
+            """,
+            r"DiscreteSet not supported in branching condition",
+            8,
+            15,
+            "c[{0, 1}]",
+        ),
+    ],
+)  # pylint: disable-next= too-many-arguments
+def test_incorrect_if(qasm_code, error_message, line_num, col_num, err_line, caplog):
+    with pytest.raises(ValidationError, match=error_message):
+        with caplog.at_level("ERROR"):
+            loads(qasm_code).validate()
 
-           h q;
-           measure q->c;
-
-           if(c[{0,1}]){
-            cx q;
-           }
-           """
-        ).validate()
+    assert f"Error at line {line_num}, column {col_num}" in caplog.text
+    assert err_line in caplog.text

--- a/tests/qasm3/test_if.py
+++ b/tests/qasm3/test_if.py
@@ -224,7 +224,7 @@ def test_incorrect_if():
            """
         ).validate()
 
-    with pytest.raises(ValidationError, match=r"Undefined identifier c2 in expression"):
+    with pytest.raises(ValidationError, match=r"Undefined identifier 'c2' in expression"):
         loads(
             """
             OPENQASM 3.0;

--- a/tests/qasm3/test_loop.py
+++ b/tests/qasm3/test_loop.py
@@ -303,7 +303,7 @@ def test_loop_in_nested_function_call():
     check_single_qubit_rotation_op(result.unrolled_ast, 3, [0, 0, 0], [0, 3, 6], "rx")
 
 
-def test_convert_qasm3_for_loop_unsupported_type():
+def test_convert_qasm3_for_loop_unsupported_type(caplog):
     """Test correct error when converting a QASM3 program that contains a for loop initialized from
     an unsupported type."""
     with pytest.raises(
@@ -313,18 +313,22 @@ def test_convert_qasm3_for_loop_unsupported_type():
             " of set_declaration in loop."
         ),
     ):
-        loads(
-            """
-            OPENQASM 3.0;
-            include "stdgates.inc";
+        with caplog.at_level("ERROR"):
+            loads(
+                """
+                OPENQASM 3.0;
+                include "stdgates.inc";
 
-            qubit[4] q;
-            bit[4] c;
+                qubit[4] q;
+                bit[4] c;
 
-            h q;
-            for bit b in "001" {
-                x q[b];
-            }
-            measure q->c;
-            """,
-        ).validate()
+                h q;
+                for bit b in "001" {
+                    x q[b];
+                }
+                measure q->c;
+                """,
+            ).validate()
+
+    assert "Error at line 9, column 16" in caplog.text
+    assert 'for bit b in "001"' in caplog.text

--- a/tests/qasm3/test_measurement.py
+++ b/tests/qasm3/test_measurement.py
@@ -189,75 +189,95 @@ def test_standalone_measurement():
     check_unrolled_qasm(dumps(module), expected_qasm)
 
 
-def test_incorrect_measure():
-    def run_test(qasm3_code, error_message):
-        with pytest.raises(ValidationError, match=error_message):
+@pytest.mark.parametrize(
+    "qasm3_code,error_message,line_num,col_num,err_line",
+    [
+        # Test for undeclared register q2
+        (
+            """
+            OPENQASM 3.0;
+            qubit[2] q1;
+            bit[2] c1;
+            c1[0] = measure q2[0];  // undeclared register
+            """,
+            r"Missing register declaration for 'q2' .*",
+            5,
+            12,
+            "c1[0] = measure q2[0];",
+        ),
+        # Test for undeclared register c2
+        (
+            """
+            OPENQASM 3.0;
+            qubit[2] q1;
+            bit[2] c1;
+            measure q1 -> c2;  // undeclared register
+            """,
+            r"Missing register declaration for 'c2' .*",
+            5,
+            12,
+            "c2 = measure q1;",
+        ),
+        # Test for size mismatch between q1 and c2
+        (
+            """
+            OPENQASM 3.0;
+            qubit[2] q1;
+            bit[2] c1;
+            bit[1] c2;
+            c2 = measure q1;  // size mismatch
+            """,
+            r"Register sizes of q1 and c2 do not match .*",
+            6,
+            12,
+            "c2 = measure q1;",
+        ),
+        # Test for size mismatch between q1 and c1 in ranges
+        (
+            """
+            OPENQASM 3.0;
+            qubit[5] q1;
+            bit[4] c1;
+            bit[1] c2;
+            c1[:3] = measure q1;  // size mismatch
+            """,
+            r"Register sizes of q1 and c1 do not match .*",
+            6,
+            12,
+            "c1[:3] = measure q1;",
+        ),
+        # Test for out of bounds index for q1
+        (
+            """
+            OPENQASM 3.0;
+            qubit[2] q1;
+            bit[2] c1;
+            measure q1[3] -> c1[0];  // out of bounds
+            """,
+            r"Index 3 out of range for register of size 2 in qubit",
+            5,
+            12,
+            "c1[0] = measure q1[3];",
+        ),
+        # Test for out of bounds index for c1
+        (
+            """
+            OPENQASM 3.0;
+            qubit[2] q1;
+            bit[2] c1;
+            measure q1 -> c1[3];  // out of bounds
+            """,
+            r"Index 3 out of range for register of size 2 in clbit",
+            5,
+            12,
+            "c1[3] = measure q1;",
+        ),
+    ],
+)  # pylint: disable-next= too-many-arguments
+def test_incorrect_measure(qasm3_code, error_message, line_num, col_num, err_line, caplog):
+    with pytest.raises(ValidationError, match=error_message):
+        with caplog.at_level(level="ERROR"):
             loads(qasm3_code).validate()
 
-    # Test for undeclared register q2
-    run_test(
-        """
-        OPENQASM 3.0;
-        qubit[2] q1;
-        bit[2] c1;
-        c1[0] = measure q2[0];  // undeclared register
-    """,
-        r"Missing register declaration for 'q2' .*",
-    )
-
-    # Test for undeclared register c2
-    run_test(
-        """
-        OPENQASM 3.0;
-        qubit[2] q1;
-        bit[2] c1;
-        measure q1 -> c2;  // undeclared register
-    """,
-        r"Missing register declaration for 'c2' .*",
-    )
-
-    # Test for size mismatch between q1 and c2
-    run_test(
-        """
-        OPENQASM 3.0;
-        qubit[2] q1;
-        bit[2] c1;
-        bit[1] c2;
-        c2 = measure q1;  // size mismatch
-    """,
-        r"Register sizes of q1 and c2 do not match .*",
-    )
-
-    # Test for size mismatch between q1 and c2 in ranges
-    run_test(
-        """
-        OPENQASM 3.0;
-        qubit[5] q1;
-        bit[4] c1;
-        bit[1] c2;
-        c1[:3] = measure q1;  // size mismatch
-    """,
-        r"Register sizes of q1 and c1 do not match .*",
-    )
-
-    # Test for out of bounds index for q1
-    run_test(
-        """
-        OPENQASM 3.0;
-        qubit[2] q1;
-        bit[2] c1;
-        measure q1[3] -> c1[0];  // out of bounds
-    """,
-        r"Index 3 out of range for register of size 2 in qubit",
-    )
-
-    # Test for out of bounds index for c1
-    run_test(
-        """
-        OPENQASM 3.0;
-        qubit[2] q1;
-        bit[2] c1;
-        measure q1 -> c1[3];  // out of bounds
-    """,
-        r"Index 3 out of range for register of size 2 in clbit",
-    )
+    assert f"Error at line {line_num}, column {col_num}" in caplog.text
+    assert err_line in caplog.text

--- a/tests/qasm3/test_measurement.py
+++ b/tests/qasm3/test_measurement.py
@@ -202,7 +202,7 @@ def test_incorrect_measure():
         bit[2] c1;
         c1[0] = measure q2[0];  // undeclared register
     """,
-        r"Missing register declaration for q2 .*",
+        r"Missing register declaration for 'q2' .*",
     )
 
     # Test for undeclared register c2
@@ -213,7 +213,7 @@ def test_incorrect_measure():
         bit[2] c1;
         measure q1 -> c2;  // undeclared register
     """,
-        r"Missing register declaration for c2 .*",
+        r"Missing register declaration for 'c2' .*",
     )
 
     # Test for size mismatch between q1 and c2

--- a/tests/qasm3/test_sizeof.py
+++ b/tests/qasm3/test_sizeof.py
@@ -79,47 +79,56 @@ def test_sizeof_multiple_types():
     check_single_qubit_rotation_op(result.unrolled_ast, 2, [1, 1], [2, 3], "rx")
 
 
-def test_unsupported_target():
+def test_unsupported_target(caplog):
     """Test sizeof over index expressions"""
     with pytest.raises(ValidationError, match=r"Unsupported target type .*"):
-        qasm3_string = """
-        OPENQASM 3;
-        include "stdgates.inc";
+        with caplog.at_level("ERROR"):
+            qasm3_string = """
+            OPENQASM 3;
+            include "stdgates.inc";
 
-        array[int[32], 3, 2] my_ints;
+            array[int[32], 3, 2] my_ints;
 
-        int[32] size1 = sizeof(my_ints[0]); // this is invalid
-        """
-        loads(qasm3_string).validate()
+            int[32] size1 = sizeof(my_ints[0]); // this is invalid
+            """
+            loads(qasm3_string).validate()
+    assert "Error at line 7, column 28" in caplog.text
+    assert "sizeof(my_ints[0])" in caplog.text
 
 
-def test_sizeof_on_non_array():
+def test_sizeof_on_non_array(caplog):
     """Test sizeof on a non-array"""
     with pytest.raises(
         ValidationError, match="Invalid sizeof usage, variable 'my_int' is not an array."
     ):
-        qasm3_string = """
-        OPENQASM 3;
-        include "stdgates.inc";
+        with caplog.at_level("ERROR"):
+            qasm3_string = """
+            OPENQASM 3;
+            include "stdgates.inc";
 
-        int[32] my_int = 3;
+            int[32] my_int = 3;
 
-        int[32] size1 = sizeof(my_int); // this is invalid
-        """
-        loads(qasm3_string).validate()
+            int[32] size1 = sizeof(my_int); // this is invalid
+            """
+            loads(qasm3_string).validate()
+    assert "Error at line 7, column 28" in caplog.text
+    assert "sizeof(my_int)" in caplog.text
 
 
-def test_out_of_bounds_reference():
+def test_out_of_bounds_reference(caplog):
     """Test sizeof on an out of bounds reference"""
     with pytest.raises(
         ValidationError, match="Index 3 out of bounds for array 'my_ints' with 2 dimensions"
     ):
-        qasm3_string = """
-        OPENQASM 3;
-        include "stdgates.inc";
+        with caplog.at_level("ERROR"):
+            qasm3_string = """
+            OPENQASM 3;
+            include "stdgates.inc";
 
-        array[int[32], 3, 2] my_ints;
+            array[int[32], 3, 2] my_ints;
 
-        int[32] size1 = sizeof(my_ints, 3); // this is invalid
-        """
-        loads(qasm3_string).validate()
+            int[32] size1 = sizeof(my_ints, 3); // this is invalid
+            """
+            loads(qasm3_string).validate()
+    assert "Error at line 7, column 28" in caplog.text
+    assert "sizeof(my_ints, 3)" in caplog.text

--- a/tests/qasm3/test_sizeof.py
+++ b/tests/qasm3/test_sizeof.py
@@ -81,7 +81,7 @@ def test_sizeof_multiple_types():
 
 def test_unsupported_target(caplog):
     """Test sizeof over index expressions"""
-    with pytest.raises(ValidationError, match=r"Unsupported target type .*"):
+    with pytest.raises(ValidationError, match=r"Invalid initialization value for variable 'size1'"):
         with caplog.at_level("ERROR"):
             qasm3_string = """
             OPENQASM 3;
@@ -98,9 +98,7 @@ def test_unsupported_target(caplog):
 
 def test_sizeof_on_non_array(caplog):
     """Test sizeof on a non-array"""
-    with pytest.raises(
-        ValidationError, match="Invalid sizeof usage, variable 'my_int' is not an array."
-    ):
+    with pytest.raises(ValidationError, match="Invalid initialization value for variable 'size1'"):
         with caplog.at_level("ERROR"):
             qasm3_string = """
             OPENQASM 3;
@@ -117,9 +115,7 @@ def test_sizeof_on_non_array(caplog):
 
 def test_out_of_bounds_reference(caplog):
     """Test sizeof on an out of bounds reference"""
-    with pytest.raises(
-        ValidationError, match="Index 3 out of bounds for array 'my_ints' with 2 dimensions"
-    ):
+    with pytest.raises(ValidationError, match="Invalid initialization value for variable 'size1'"):
         with caplog.at_level("ERROR"):
             qasm3_string = """
             OPENQASM 3;

--- a/tests/qasm3/test_sizeof.py
+++ b/tests/qasm3/test_sizeof.py
@@ -96,7 +96,7 @@ def test_unsupported_target():
 def test_sizeof_on_non_array():
     """Test sizeof on a non-array"""
     with pytest.raises(
-        ValidationError, match="Invalid sizeof usage, variable my_int is not an array."
+        ValidationError, match="Invalid sizeof usage, variable 'my_int' is not an array."
     ):
         qasm3_string = """
         OPENQASM 3;
@@ -112,7 +112,7 @@ def test_sizeof_on_non_array():
 def test_out_of_bounds_reference():
     """Test sizeof on an out of bounds reference"""
     with pytest.raises(
-        ValidationError, match="Index 3 out of bounds for array my_ints with 2 dimensions"
+        ValidationError, match="Index 3 out of bounds for array 'my_ints' with 2 dimensions"
     ):
         qasm3_string = """
         OPENQASM 3;

--- a/tests/qasm3/test_switch.py
+++ b/tests/qasm3/test_switch.py
@@ -416,7 +416,7 @@ def test_non_int_variable_expression():
     """
     with pytest.raises(
         ValidationError,
-        match=r"Invalid type of variable .* for required type <class 'openqasm3.ast.IntType'>",
+        match=r"Invalid type .* of variable 'f' for required type <class 'openqasm3.ast.IntType'>",
     ):
         qasm3_switch_program = base_invalid_program
         loads(qasm3_switch_program).validate()
@@ -443,6 +443,8 @@ def test_non_constant_expression_case():
     }
     """
 
-    with pytest.raises(ValidationError, match=r"Variable .* is not a constant in given expression"):
+    with pytest.raises(
+        ValidationError, match=r"Expected variable .* to be constant in given expression"
+    ):
         qasm3_switch_program = base_invalid_program
         loads(qasm3_switch_program).validate()


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

## Summary of changes
- Improve the error messages across the repository and reduce traceback size 
- Added a flag `expand_traceback` to `validate` and `unroll` commands. Set to `False` by default, it collapses the traceback to only display the last error msg. If set to `True`, full traceback displayed 
- Added exact lines for QASM errors, eg. - 

```python
import pyqasm
qasm = """
OPENQASM 3.0;
include "stdgates.inc";

def test(qubit[2] q2, int[32] b) -> bool{
    h q2[0];
    cx q2[0], q2[1];
    return true;
}
qubit[10] q;
bool b = test(a, 5);

"""
program = pyqasm.loads(qasm)
program.unroll(expand_traceback=0)
```
Output - 
```bash
ERROR:pyqasm: Error at line 11, column 9 in QASM file

 >>>>>> test(a, 5)

pyqasm.exceptions.ValidationError: Expecting qubit argument for 'q2'. Qubit register 'a' not found for function 'test'
Usage: test ( qubit[2] q2 , int[32] b )
```
