### PR TITLE
Add u1 to params map

### DIFF
--- a/src/pyqasm/maps/gates.py
+++ b/src/pyqasm/maps/gates.py
@@ -1104,6 +1104,8 @@ PARAMS_OP_SET = {
         "rz",
         "phaseshift",
         "p",
+        "u1",
+        "U1",
         "gpi",
         "gpi2",
         "xx",

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -823,7 +823,7 @@ class QasmVisitor:
 
         if len(op_parameters) != actual_num_params:
             raise_qasm3_error(
-                f"Expected {op_qubit_count} parameter{'s' if op_qubit_count > 1 else ''}"
+                f"Expected {actual_num_params} parameter{'s' if op_qubit_count == 1 else ''}"
                 f" for gate '{operation.name.name}', but got {len(op_parameters)}",
                 error_node=operation,
                 span=operation.span,

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -823,7 +823,7 @@ class QasmVisitor:
 
         if len(op_parameters) != actual_num_params:
             raise_qasm3_error(
-                f"Expected {actual_num_params} parameter{'s' if op_qubit_count == 1 else ''}"
+                f"Expected {actual_num_params} parameter{'s' if actual_num_params != 1 else ''}"
                 f" for gate '{operation.name.name}', but got {len(op_parameters)}",
                 error_node=operation,
                 span=operation.span,


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

Fixes #175 

### Gate support enhancements:
* Added `u1` and `U1` gates in the `PARAMS_OP_SET`
* Fixed an error message in the `_visit_basic_gate_operation` function in `src/pyqasm/visitor.py` to correctly reference the expected number of parameters (`actual_num_params`) instead of the expected number of qubits (`op_qubit_count`). 