### PR TITLE
Remove deepcopy in `_visit_generic_gate_operation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Types of changes:
 
 ### Improved / Modified
 
+- Optimized `_visit_generic_gate_operation` in `QasmVisitor` class by using shallow copy instead of deep copy for better performance when processing gate operations. ([#180](https://github.com/qBraid/pyqasm/pull/180))
+
 ### Deprecated
 
 ### Removed

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -1098,7 +1098,6 @@ class QasmVisitor:
         Returns:
             None
         """
-        operation, ctrls = copy.deepcopy(operation), copy.deepcopy(ctrls)
         negctrls = []
         if ctrls is None:
             ctrls = []

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -1098,6 +1098,7 @@ class QasmVisitor:
         Returns:
             None
         """
+        operation, ctrls = copy.copy(operation), copy.copy(ctrls)
         negctrls = []
         if ctrls is None:
             ctrls = []


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->
Reference : [#962 | qBraid](https://github.com/qBraid/qBraid/issues/962)

## Summary of changes
The change changes the deep copy of the `operation` and `ctrls` variables into a shallow copy, likely to improve performance and reduce unnecessary memory usage.