### PR TITLE
Fix depth calculation for external gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Types of changes:
 
 ### Fixed
 
+- Fixed the way how depth is calculated when external gates are defined with unrolling a QASM module. ([#XXX](https://github.com/qBraid/pyqasm/pull/XXX))
+
 ### Dependencies
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Types of changes:
 
 ### Fixed
 
-- Fixed the way how depth is calculated when external gates are defined with unrolling a QASM module. ([#XXX](https://github.com/qBraid/pyqasm/pull/XXX))
+- Fixed the way how depth is calculated when external gates are defined with unrolling a QASM module. ([#198](https://github.com/qBraid/pyqasm/pull/198))
 
 ### Dependencies
 

--- a/src/pyqasm/modules/base.py
+++ b/src/pyqasm/modules/base.py
@@ -55,7 +55,7 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
         self._has_barriers: Optional[bool] = None
         self._validated_program = False
         self._unrolled_ast = Program(statements=[])
-        self._external_gates = []
+        self._external_gates: list[str] = []
 
     @property
     def name(self) -> str:

--- a/src/pyqasm/modules/base.py
+++ b/src/pyqasm/modules/base.py
@@ -282,7 +282,7 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
 
         # Unroll using any external gates that have been recorded for this
         # module
-        qasm_module.unroll(external_gates = self._external_gates)
+        qasm_module.unroll(external_gates=self._external_gates)
 
         max_depth = 0
         max_qubit_depth, max_clbit_depth = 0, 0

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -918,7 +918,7 @@ class QasmVisitor:
 
         # Pause recording the depth of new gates because we are processing the
         # definition of a custom gate here - handle the depth separately afterwards
-        self._recording_depth = not (operation.name.name in self._external_gates)
+        self._recording_depth = not operation.name.name in self._external_gates
         result = []
         for gate_op in gate_definition_ops:
             if isinstance(gate_op, (qasm3_ast.QuantumGate, qasm3_ast.QuantumPhase)):

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -951,12 +951,6 @@ class QasmVisitor:
         # Update the depth only once for the entire custom gate
         if not self._recording_depth:
             self._recording_depth = True
-            op_qubits: list[qasm3_ast.IndexedIdentifier] = (
-                self._get_op_bits(  # type: ignore [assignment]
-                    operation,
-                    self._global_qreg_size_map,
-                )
-            )
             self._update_qubit_depth_for_gate([op_qubits], ctrls)
 
         self._restore_context()

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -918,7 +918,7 @@ class QasmVisitor:
 
         # Pause recording the depth of new gates because we are processing the
         # definition of a custom gate here - handle the depth separately afterwards
-        self._recording_depth = not operation.name.name in self._external_gates
+        self._recording_depth = not gate_name in self._external_gates
         result = []
         for gate_op in gate_definition_ops:
             if isinstance(gate_op, (qasm3_ast.QuantumGate, qasm3_ast.QuantumPhase)):

--- a/tests/qasm3/test_depth.py
+++ b/tests/qasm3/test_depth.py
@@ -97,6 +97,10 @@ def test_gate_depth_external_function(input_qasm_str, first_depth, second_depth,
     result = loads(input_qasm_str)
     result.unroll(external_gates=["my_gate"])
     assert result.num_qubits == num_qubits
+
+    for i in range(num_qubits):
+        assert result._qubit_depths[("q", i)].num_gates == 1
+
     assert result.num_clbits == 0
     assert result.depth() == first_depth
 

--- a/tests/qasm3/test_depth.py
+++ b/tests/qasm3/test_depth.py
@@ -84,13 +84,15 @@ qubit[2] q;
 my_gate q[0], q[1];
 """
 
-@pytest.mark.parametrize(["input_qasm_str", "first_depth", "second_depth", "num_qubits"],
-                         [
-                             (QASM3_STRING_1, 1, 2, 1),
-                             (QASM3_STRING_2, 1, 3, 2),
-                             (QASM3_STRING_3, 1, 0, 2),
-                             ]
-                         )
+
+@pytest.mark.parametrize(
+    ["input_qasm_str", "first_depth", "second_depth", "num_qubits"],
+    [
+        (QASM3_STRING_1, 1, 2, 1),
+        (QASM3_STRING_2, 1, 3, 2),
+        (QASM3_STRING_3, 1, 0, 2),
+    ],
+)
 def test_gate_depth_external_function(input_qasm_str, first_depth, second_depth, num_qubits):
     result = loads(input_qasm_str)
     result.unroll(external_gates=["my_gate"])

--- a/tests/qasm3/test_depth.py
+++ b/tests/qasm3/test_depth.py
@@ -51,7 +51,7 @@ def test_gate_depth():
     assert result.depth() == 5
 
 
-qasm3_string_1 = """
+QASM3_STRING_1 = """
 OPENQASM 3;
 include "stdgates.inc";
 
@@ -64,7 +64,7 @@ qubit q;
 my_gate() q;
 """
 
-qasm3_string_2 = """
+QASM3_STRING_2 = """
 OPENQASM 3.0;
 include "stdgates.inc";
 gate my_gate q1, q2 {
@@ -76,7 +76,7 @@ qubit[2] q;
 my_gate q[0], q[1];
 """
 
-qasm3_string_3 = """
+QASM3_STRING_3 = """
 OPENQASM 3.0;
 include "stdgates.inc";
 gate my_gate q1, q2 { }
@@ -86,9 +86,9 @@ my_gate q[0], q[1];
 
 @pytest.mark.parametrize(["input_qasm_str", "first_depth", "second_depth", "num_qubits"],
                          [
-                             (qasm3_string_1, 1, 2, 1),
-                             (qasm3_string_2, 1, 3, 2),
-                             (qasm3_string_3, 1, 0, 2),
+                             (QASM3_STRING_1, 1, 2, 1),
+                             (QASM3_STRING_2, 1, 3, 2),
+                             (QASM3_STRING_3, 1, 0, 2),
                              ]
                          )
 def test_gate_depth_external_function(input_qasm_str, first_depth, second_depth, num_qubits):


### PR DESCRIPTION
## Summary of changes

This PR fixes how the depth of a QASM module is calculated when calling the `depth` method.

With the changes in this PR, a QASM module stores external gates that have been defined for it. At the moment, the main way to define external gates on a module is to pass the `external_gates` keyword argument to the `unroll` method. Calling the same `unroll` method with no such arguments being passed flushes the external gates of the module.

Storing such external gates on the module level helps the depth calculation: any external gates of the module contribute once to the overall depth of the module, instead of the definition of the external gate being considered.

Closes #77.