### PR TITLE
Feature/Added depth calculation for branching statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,27 @@ Types of changes:
 ### Fixed
 
 - Fixed the way how depth is calculated when external gates are defined with unrolling a QASM module. ([#198](https://github.com/qBraid/pyqasm/pull/198))
+- Added separate depth calculation for gates inside branching statements. ([#200](https://github.com/qBraid/pyqasm/pull/200)) 
+  - **Example:**
+  ```python
+  OPENQASM 3.0;
+  include "stdgates.inc";
+  qubit[4] q;
+  bit[4] c;
+  bit[4] c0;
+  if (c[0]){
+    x q[0];
+    h q[0]
+    }
+  else {
+    h q[1];
+  }
+  ```
+  ```text
+  Depth = 1
+  ```
+  - Previously, each gate inside an `if`/`else` block would advance only its own wire depth. Now, when any branching statement is encountered, all qubit‐ and clbit‐depths used inside that block are first incremented by one, then set to the maximum of those new values. This ensures the entire conditional block counts as single “depth” increment, rather than letting individual gates within the same branch float ahead independently.
+  - In the above snippet, c[0], q[0], and q[1] all jump together to a single new depth for that branch.
 
 ### Dependencies
 

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -775,7 +775,8 @@ class QasmVisitor:
                     qubit_node = self._module._qubit_depths[(qubit.name.name, qubit_id)]
                     qubit_node.depth = max_involved_depth
 
-    def _visit_basic_gate_operation(  # pylint: disable=too-many-locals
+    # pylint: disable=too-many-branches, too-many-locals
+    def _visit_basic_gate_operation(
         self,
         operation: qasm3_ast.QuantumGate,
         inverse: bool = False,

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -1698,10 +1698,6 @@ class QasmVisitor:
                 )
 
             assert isinstance(rhs_value, (bool, int))
-            # get classical registers
-            if reg_name is not None and reg_idx is not None and self._in_branching_statement:
-                op_tuple = (reg_name, reg_idx)
-                self._is_branch_clbits.add(op_tuple)
 
             if_block = self.visit_basic_block(statement.if_block)
             else_block = self.visit_basic_block(statement.else_block)
@@ -1711,6 +1707,9 @@ class QasmVisitor:
                 Qasm3Validator.validate_register_index(
                     reg_idx, self._global_creg_size_map[reg_name], qubit=False, op_node=condition
                 )
+
+                # getting creg for depth counting
+                self._is_branch_clbits.add((reg_name, reg_idx))
 
                 new_if_block = qasm3_ast.BranchingStatement(
                     condition=qasm3_ast.BinaryExpression(
@@ -1743,6 +1742,8 @@ class QasmVisitor:
                     rhs_value -= 1
 
                 size = self._global_creg_size_map[reg_name]
+                # getting cregs for depth counting
+                self._is_branch_clbits.update((reg_name, i) for i in range(size))
                 rhs_value_str = bin(int(rhs_value))[2:].zfill(size)
                 else_block = self.visit_basic_block(statement.else_block)
 

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -859,7 +859,7 @@ class QasmVisitor:
             if not self._is_branching_statement: # if gate is not in branching statement
                 self._update_qubit_depth_for_gate(unrolled_targets, ctrls)
             else:
-                for ops in unrolled_targets + ctrls : # get qubit registers in branching operations
+                for ops in unrolled_targets + [ctrls] : # get qubit registers in branching operations
                     for op in ops:
                         op_idx = Qasm3ExprEvaluator.evaluate_expression(op.indices[0][0])[0]
                         op.name.name
@@ -967,7 +967,7 @@ class QasmVisitor:
             if not self._is_branching_statement: # if custom gate is not in branching statement
                 self._update_qubit_depth_for_gate([op_qubits], ctrls)
             else:
-                for ops in [op_qubits] + ctrls: # get qubit registers in branching operations
+                for ops in [op_qubits] + [ctrls]: # get qubit registers in branching operations
                     for op in ops:
                         op_idx = Qasm3ExprEvaluator.evaluate_expression(op.indices[0][0])[0]
                         op.name.name

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -1650,9 +1650,8 @@ class QasmVisitor:
         for node in nodes:
             node.depth = max_depths
 
-        if not self._is_branching_statement:
-            self._is_branch_clbits.clear()
-            self._is_branch_qubits.clear()
+        self._is_branch_clbits.clear()
+        self._is_branch_qubits.clear()
 
     def _visit_branching_statement(
         self, statement: qasm3_ast.BranchingStatement
@@ -1781,8 +1780,7 @@ class QasmVisitor:
         self._curr_scope -= 1
         self._pop_scope()
         self._restore_context()
-        if self._is_branching_statement:
-            self._update_branching_gate_depths()
+        self._update_branching_gate_depths()
 
         if self._check_only:
             return []

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -502,7 +502,7 @@ class QasmVisitor:
                         measure=qasm3_ast.QuantumMeasurement(qubit=src_id), target=None
                     )
                 )
-                if not self._is_branching_statement: # if measurement gate is not in branching statement
+                if not self._in_branching_statement: # if measurement gate is not in branching statement
                     src_name, src_id = src_id.name.name, src_id.indices[0][0].value  # type: ignore
                     qubit_node = self._module._qubit_depths[(src_name, src_id)]
                     qubit_node.depth += 1
@@ -536,7 +536,7 @@ class QasmVisitor:
                     measure=qasm3_ast.QuantumMeasurement(qubit=src_id),
                     target=tgt_id if target else None,
                 )
-                if not self._is_branching_statement: # if measurement gate is not in branching statement
+                if not self._in_branching_statement: # if measurement gate is not in branching statement
                     src_name, src_id = src_id.name.name, src_id.indices[0][0].value  # type: ignore
                     tgt_name, tgt_id = tgt_id.name.name, tgt_id.indices[0][0].value  # type: ignore
 
@@ -856,7 +856,7 @@ class QasmVisitor:
                 self._broadcast_gate_operation(unrolled_gate_function, unrolled_targets, ctrls)
             )
 
-            if not self._is_branching_statement: # if gate is not in branching statement
+            if not self._in_branching_statement: # if gate is not in branching statement
                 self._update_qubit_depth_for_gate(unrolled_targets, ctrls)
             else:
                 for ops in unrolled_targets + [ctrls] : # get qubit registers in branching operations
@@ -964,7 +964,7 @@ class QasmVisitor:
         # Update the depth only once for the entire custom gate
         if self._recording_ext_gate_depth:
             self._recording_ext_gate_depth = False
-            if not self._is_branching_statement: # if custom gate is not in branching statement
+            if not self._in_branching_statement: # if custom gate is not in branching statement
                 self._update_qubit_depth_for_gate([op_qubits], ctrls)
             else:
                 for ops in [op_qubits] + [ctrls]: # get qubit registers in branching operations
@@ -1632,7 +1632,7 @@ class QasmVisitor:
         return np.array(init_values, dtype=ARRAY_TYPE_MAP[base_type.__class__])
     
     def _update_branching_gate_depths(self) -> None: # seperately update branching operators depth
-        self._is_branching_statement = False
+        self._in_branching_statement = False
         max_depths = 0
         nodes = []
         for qbit in self._is_branch_qubits:
@@ -1668,7 +1668,7 @@ class QasmVisitor:
         self._push_scope({})
         self._curr_scope += 1
         self._label_scope_level[self._curr_scope] = set()
-        self._is_branching_statement = True
+        self._in_branching_statement = True
 
         result = []
         condition = statement.condition
@@ -1692,7 +1692,7 @@ class QasmVisitor:
                 )
 
             assert isinstance(rhs_value, (bool, int))
-            if reg_name is not None and reg_idx is not None and self._is_branching_statement: # get classical registers 
+            if reg_name is not None and reg_idx is not None and self._in_branching_statement: # get classical registers 
                 op_tuple = (reg_name, reg_idx)
                 self._is_branch_clbits.add(op_tuple)
 

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -89,7 +89,7 @@ class QasmVisitor:
         self._curr_scope: int = 0
         self._label_scope_level: dict[int, set] = {self._curr_scope: set()}
         self._recording_ext_gate_depth = False
-        self._is_branching_statement: bool = False
+        self._in_branching_statement: bool = False
         self._is_branch_qubits: set[tuple[str, int]]  = set()
         self._is_branch_clbits: set[tuple[str, int]]  = set()
         self._init_utilities()

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -502,7 +502,8 @@ class QasmVisitor:
                         measure=qasm3_ast.QuantumMeasurement(qubit=src_id), target=None
                     )
                 )
-                if not self._in_branching_statement: # if measurement gate is not in branching statement
+                # if measurement gate is not in branching statement
+                if not self._in_branching_statement:
                     src_name, src_id = src_id.name.name, src_id.indices[0][0].value  # type: ignore
                     qubit_node = self._module._qubit_depths[(src_name, src_id)]
                     qubit_node.depth += 1
@@ -536,7 +537,8 @@ class QasmVisitor:
                     measure=qasm3_ast.QuantumMeasurement(qubit=src_id),
                     target=tgt_id if target else None,
                 )
-                if not self._in_branching_statement: # if measurement gate is not in branching statement
+                # if measurement gate is not in branching statement
+                if not self._in_branching_statement:
                     src_name, src_id = src_id.name.name, src_id.indices[0][0].value  # type: ignore
                     tgt_name, tgt_id = tgt_id.name.name, tgt_id.indices[0][0].value  # type: ignore
 
@@ -855,14 +857,13 @@ class QasmVisitor:
             result.extend(
                 self._broadcast_gate_operation(unrolled_gate_function, unrolled_targets, ctrls)
             )
-
-            if not self._in_branching_statement: # if gate is not in branching statement
+            # if gate is not in branching statement
+            if not self._in_branching_statement:
                 self._update_qubit_depth_for_gate(unrolled_targets, ctrls)
             else:
-                for ops in unrolled_targets + [ctrls] : # get qubit registers in branching operations
+                for ops in unrolled_targets + [ctrls] : # get qreg in branching operations
                     for op in ops:
                         op_idx = Qasm3ExprEvaluator.evaluate_expression(op.indices[0][0])[0]
-                        op.name.name
                         op_tuple = (op.name.name,op_idx)
                         self._is_branch_qubits.add(op_tuple)
 
@@ -970,7 +971,6 @@ class QasmVisitor:
                 for ops in [op_qubits] + [ctrls]: # get qubit registers in branching operations
                     for op in ops:
                         op_idx = Qasm3ExprEvaluator.evaluate_expression(op.indices[0][0])[0]
-                        op.name.name
                         op_tuple = (op.name.name,op_idx)
                         self._is_branch_qubits.add(op_tuple)
 
@@ -1630,8 +1630,9 @@ class QasmVisitor:
                 init_values.append(eval_value)
 
         return np.array(init_values, dtype=ARRAY_TYPE_MAP[base_type.__class__])
-    
-    def _update_branching_gate_depths(self) -> None: # seperately update branching operators depth
+
+    # seperately update branching operators depth
+    def _update_branching_gate_depths(self) -> None:
         self._in_branching_statement = False
         max_depths = 0
         nodes = []
@@ -1646,7 +1647,7 @@ class QasmVisitor:
             c_node = self._module._clbit_depths[(c_name, c_idx)]
             nodes.append(c_node)
             max_depths = max(max_depths,c_node.depth + 1)
-        
+
         for node in nodes:
             node.depth = max_depths
 
@@ -1692,7 +1693,8 @@ class QasmVisitor:
                 )
 
             assert isinstance(rhs_value, (bool, int))
-            if reg_name is not None and reg_idx is not None and self._in_branching_statement: # get classical registers 
+            # get classical registers
+            if reg_name is not None and reg_idx is not None and self._in_branching_statement:
                 op_tuple = (reg_name, reg_idx)
                 self._is_branch_clbits.add(op_tuple)
 

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -89,7 +89,7 @@ class QasmVisitor:
         self._curr_scope: int = 0
         self._label_scope_level: dict[int, set] = {self._curr_scope: set()}
         self._recording_ext_gate_depth = False
-        self._in_branching_statement: bool = False
+        self._in_branching_statement: int = 0
         self._is_branch_qubits: set[tuple[str, int]] = set()
         self._is_branch_clbits: set[tuple[str, int]] = set()
         self._init_utilities()
@@ -1674,7 +1674,7 @@ class QasmVisitor:
         self._push_scope({})
         self._curr_scope += 1
         self._label_scope_level[self._curr_scope] = set()
-        self._in_branching_statement = True
+        self._in_branching_statement += 1
 
         result = []
         condition = statement.condition
@@ -1787,7 +1787,9 @@ class QasmVisitor:
         self._curr_scope -= 1
         self._pop_scope()
         self._restore_context()
-        self._update_branching_gate_depths()
+        self._in_branching_statement -= 1
+        if not self._in_branching_statement:
+            self._update_branching_gate_depths()
 
         if self._check_only:
             return []

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -864,6 +864,8 @@ class QasmVisitor:
             else:
                 for ops in unrolled_targets + [ctrls]:  # get qreg in branching operations
                     for op in ops:
+                        assert isinstance(op.indices, list) and len(op.indices) > 0
+                        assert isinstance(op.indices[0], list) and len(op.indices[0]) > 0
                         op_idx = Qasm3ExprEvaluator.evaluate_expression(op.indices[0][0])[0]
                         op_tuple = (op.name.name, op_idx)
                         self._is_branch_qubits.add(op_tuple)
@@ -971,6 +973,8 @@ class QasmVisitor:
             else:
                 for ops in [op_qubits] + [ctrls]:  # get qubit registers in branching operations
                     for op in ops:
+                        assert isinstance(op.indices, list) and len(op.indices) > 0
+                        assert isinstance(op.indices[0], list) and len(op.indices[0]) > 0
                         op_idx = Qasm3ExprEvaluator.evaluate_expression(op.indices[0][0])[0]
                         op_tuple = (op.name.name, op_idx)
                         self._is_branch_qubits.add(op_tuple)

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -90,8 +90,8 @@ class QasmVisitor:
         self._label_scope_level: dict[int, set] = {self._curr_scope: set()}
         self._recording_ext_gate_depth = False
         self._in_branching_statement: bool = False
-        self._is_branch_qubits: set[tuple[str, int]]  = set()
-        self._is_branch_clbits: set[tuple[str, int]]  = set()
+        self._is_branch_qubits: set[tuple[str, int]] = set()
+        self._is_branch_clbits: set[tuple[str, int]] = set()
         self._init_utilities()
 
     def _init_utilities(self):
@@ -543,8 +543,8 @@ class QasmVisitor:
                     tgt_name, tgt_id = tgt_id.name.name, tgt_id.indices[0][0].value  # type: ignore
 
                     qubit_node, clbit_node = (
-                       self._module._qubit_depths[(src_name, src_id)],
-                       self._module._clbit_depths[(tgt_name, tgt_id)],
+                        self._module._qubit_depths[(src_name, src_id)],
+                        self._module._clbit_depths[(tgt_name, tgt_id)],
                     )
                     qubit_node.depth += 1
                     qubit_node.num_measurements += 1
@@ -862,10 +862,10 @@ class QasmVisitor:
             if not self._in_branching_statement:
                 self._update_qubit_depth_for_gate(unrolled_targets, ctrls)
             else:
-                for ops in unrolled_targets + [ctrls] : # get qreg in branching operations
+                for ops in unrolled_targets + [ctrls]:  # get qreg in branching operations
                     for op in ops:
                         op_idx = Qasm3ExprEvaluator.evaluate_expression(op.indices[0][0])[0]
-                        op_tuple = (op.name.name,op_idx)
+                        op_tuple = (op.name.name, op_idx)
                         self._is_branch_qubits.add(op_tuple)
 
         # check for duplicate bits
@@ -966,13 +966,13 @@ class QasmVisitor:
         # Update the depth only once for the entire custom gate
         if self._recording_ext_gate_depth:
             self._recording_ext_gate_depth = False
-            if not self._in_branching_statement: # if custom gate is not in branching statement
+            if not self._in_branching_statement:  # if custom gate is not in branching statement
                 self._update_qubit_depth_for_gate([op_qubits], ctrls)
             else:
-                for ops in [op_qubits] + [ctrls]: # get qubit registers in branching operations
+                for ops in [op_qubits] + [ctrls]:  # get qubit registers in branching operations
                     for op in ops:
                         op_idx = Qasm3ExprEvaluator.evaluate_expression(op.indices[0][0])[0]
-                        op_tuple = (op.name.name,op_idx)
+                        op_tuple = (op.name.name, op_idx)
                         self._is_branch_qubits.add(op_tuple)
 
         self._restore_context()
@@ -1641,13 +1641,13 @@ class QasmVisitor:
             q_name, q_idx = qbit
             q_node = self._module._qubit_depths[(q_name, q_idx)]
             nodes.append(q_node)
-            max_depths = max(max_depths,q_node.depth + 1)
+            max_depths = max(max_depths, q_node.depth + 1)
 
         for cbit in self._is_branch_clbits:
             c_name, c_idx = cbit
             c_node = self._module._clbit_depths[(c_name, c_idx)]
             nodes.append(c_node)
-            max_depths = max(max_depths,c_node.depth + 1)
+            max_depths = max(max_depths, c_node.depth + 1)
 
         for node in nodes:
             node.depth = max_depths

--- a/tests/qasm3/test_depth.py
+++ b/tests/qasm3/test_depth.py
@@ -460,8 +460,9 @@ cx q[0], q[1];
 measure q[0] -> c[0];
 
 if (c==1) measure q[1] -> c[1];
+if (c==3) measure q[1] -> c[1];
 """,
-            4,
+            5,
         ),
         (
             """
@@ -487,6 +488,99 @@ if(c1==3) x q2[1];
 measure q2 -> c2;
 """,
             8,
+        ),
+        (
+            """
+OPENQASM 3.0;
+include "stdgates.inc";
+gate custom a, b{
+    cx a, b;
+    h a;
+}
+qubit[4] q;
+bit[4] c;
+bit[4] c0;
+h q;
+measure q -> c0;
+if(c0[0]){
+    x q[0];
+    cx q[0], q[1];
+    if (c0[1]){
+        cx q[1], q[2];
+    }
+}
+if (c[0]){
+    custom q[2], q[3];
+}
+array[int[32], 8] arr;
+arr[0] = 1;
+if(arr[0] >= 1){
+    h q[0];
+    h q[1];
+}
+""",
+            4,
+        ),
+        (
+            """
+OPENQASM 3.0;
+include "stdgates.inc";
+qubit[1] q;
+bit[4] c;
+if(c == 3){
+    h q[0];
+}
+if(c >= 3){
+    h q[0];
+} else {
+    x q[0];
+}
+if(c <= 3){
+    h q[0];
+} else {
+    x q[0];
+}
+if(c[0] < 4){
+    h q[0];
+} else {
+    x q[0];
+}
+""",
+            4,
+        ),
+        (
+            """
+OPENQASM 3.0;
+include "stdgates.inc";
+qubit[2] q;
+bit[2] c;
+h q[0];
+cx q[0], q[1];
+c[0] = measure q[0];
+c[1] = measure q[1];
+if (c[0] == false) {
+  if (c[1] == true) {
+    x q[0];
+  }
+  else {
+    if (c[1] == false){
+      x q[1];
+    }
+    else {
+      z q[0];
+    }
+  }
+}
+
+if (c == 0) {
+    x q[0];
+}
+else {
+    y q[1];
+}
+x q[0];
+""",
+            6,
         ),
     ],
 )

--- a/tests/qasm3/test_depth.py
+++ b/tests/qasm3/test_depth.py
@@ -426,7 +426,7 @@ def test_qasm3_depth_no_branching(program, expected_depth):
     assert result.depth() == expected_depth
 
 
-@pytest.mark.skip(reason="Not implemented branching conditions depth")
+# @pytest.mark.skip(reason="Not implemented branching conditions depth")
 @pytest.mark.parametrize(
     "program, expected_depth",
     [
@@ -494,4 +494,5 @@ def test_qasm3_depth_branching(program, expected_depth):
     """Test calculating depth of qasm3 circuit with branching conditions"""
     result = loads(program)
     result.unroll()
+    result.remove_barriers()
     assert result.depth() == expected_depth

--- a/tests/qasm3/test_depth.py
+++ b/tests/qasm3/test_depth.py
@@ -589,3 +589,38 @@ def test_qasm3_depth_branching(program, expected_depth):
     result.unroll()
     result.remove_barriers()
     assert result.depth() == expected_depth
+
+
+def test_qasm3_depth_branching_for_external_gates():
+    """Test calculating depth of qasm3 circuit with external gates inside branching conditions"""
+    qasm3_string = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    bit[2] c;
+    gate my_gate q1, q2 {
+       h q1;
+       cx q1, q2;
+       h q2;
+    }
+    gate my_gate_two q1, q2 {
+       cx q1, q2;
+    }
+
+    qubit[2] q;
+    if (c == 0){
+       measure q -> c;
+       my_gate q[0], q[1];
+    }
+    else {
+       if (c[0] == false) {
+          my_gate q[1], q[0];
+       }
+       else{
+          measure q -> c;
+       }
+    }
+    my_gate_two q[0], q[1];
+    """
+    result = loads(qasm3_string)
+    result._external_gates = ["my_gate", "my_gate_two"]
+    assert result.depth() == 2

--- a/tests/qasm3/test_depth.py
+++ b/tests/qasm3/test_depth.py
@@ -426,7 +426,6 @@ def test_qasm3_depth_no_branching(program, expected_depth):
     assert result.depth() == expected_depth
 
 
-# @pytest.mark.skip(reason="Not implemented branching conditions depth")
 @pytest.mark.parametrize(
     "program, expected_depth",
     [


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

## Summary of changes
This PR addresses an issue in `QasmVisitor` where depth calculations for `Gate` and `Measurement` operations inside branching statements were being treated the same as `non-conditional` operations. As a result, both quantum and classical registers were not reflecting the correct depth, leading to inaccurate `circuit-depth`. <br>

With this change, we introduce logic to:

- Detect when we are inside a branching statement `(e.g., if or else)`: we set a flag at the start of `QasmVisitor`.
- Suspend immediate depth updates for all basic gates, custom gates, and measurements while inside the branch. Instead, we collect (and deduplicate) a set of all affected depth nodes (both quantum‐ and classical‐bit nodes) during the entire recursive traversal of that branch.
- Treat the entire branching block as a single depth increase.
- After exiting the branching block, take the maximum depth among all collected nodes and raise each one to “one step above” that maximum. In effect, this synchronizes every `qubit` and `clbit` participating in the conditional arguments to the correct final depth.

Closes #53 
