### PR TITLE
Feature/Added explicit casting support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ Types of changes:
   ```
   - Previously, each gate inside an `if`/`else` block would advance only its own wire depth. Now, when any branching statement is encountered, all qubit‐ and clbit‐depths used inside that block are first incremented by one, then set to the maximum of those new values. This ensures the entire conditional block counts as single “depth” increment, rather than letting individual gates within the same branch float ahead independently.
   - In the above snippet, c[0], q[0], and q[1] all jump together to a single new depth for that branch.
-
+- Added initial support to explicit casting by converting the declarations into implicit casting logic. ([#205](https://github.com/qBraid/pyqasm/pull/205))
 ### Dependencies
 
 ### Other

--- a/src/README.md
+++ b/src/README.md
@@ -26,6 +26,7 @@ Source code for OpenQASM 3 program validator and semantic analyzer
 | ForLoops                       | ✅          | Completed              |
 | RangeDefinition                | ✅          | Completed              |
 | QuantumGate                    | ✅          | Completed              |
+| Cast                           | ✅          | Completed              |
 | QuantumGateModifier (ctrl)     | 📋          | Planned                |
 | WhileLoop                      | 📋          | Planned                |
 | IODeclaration                  | 📋          | Planned                |

--- a/src/pyqasm/expressions.py
+++ b/src/pyqasm/expressions.py
@@ -232,7 +232,7 @@ class Qasm3ExprEvaluator:
                         f"Invalid base size '{base_size}' for {var_format} '{var_name}'",
                         error_node=expression,
                         span=expression.span,
-                        )
+                    )
             return base_size
 
         if isinstance(expression, Identifier):
@@ -384,9 +384,7 @@ class Qasm3ExprEvaluator:
                 var_name = f"{var_value}"
                 var_format = "value"
 
-            cast_type_size = _check_type_size(
-                expression, var_name, var_format, expression.type
-            )
+            cast_type_size = _check_type_size(expression, var_name, var_format, expression.type)
             variable = Variable(
                 name=var_name,
                 base_type=expression.type,

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -482,9 +482,7 @@ class QasmVisitor:
                 base_size = (
                     initial_size
                     if not hasattr(base_type, "size") or base_type.size is None
-                    else Qasm3ExprEvaluator.evaluate_expression(
-                        base_type.size, const_expr=True
-                    )[0]
+                    else Qasm3ExprEvaluator.evaluate_expression(base_type.size, const_expr=True)[0]
                 )
             except ValidationError as err:
                 raise_qasm3_error(
@@ -530,9 +528,7 @@ class QasmVisitor:
         if is_const:
             var_format = "constant"
 
-        val_type_size = self._check_variable_type_size(
-            statement, var_name, var_format, val_type
-        )
+        val_type_size = self._check_variable_type_size(statement, var_name, var_format, val_type)
         if not isinstance(val_type, type(base_type)) or val_type_size != base_size:
             raise_qasm3_error(
                 f"Declaration type: "
@@ -1370,15 +1366,11 @@ class QasmVisitor:
         statements.extend(stmts)
 
         base_type = statement.type
-        base_size = self._check_variable_type_size(
-            statement, var_name, "constant", base_type
-        )
+        base_size = self._check_variable_type_size(statement, var_name, "constant", base_type)
         val_type, _ = Qasm3ExprEvaluator.evaluate_expression(
             statement.init_expression, validate_only=True
         )
-        self._check_variable_cast_type(
-            statement, val_type, var_name, base_type, base_size, True
-        )
+        self._check_variable_cast_type(statement, val_type, var_name, base_type, base_size, True)
         variable = Variable(var_name, base_type, base_size, [], init_value, is_constant=True)
 
         # cast + validation
@@ -1436,9 +1428,7 @@ class QasmVisitor:
             dimensions = base_type.dimensions
             base_type = base_type.base_type
 
-        base_size = self._check_variable_type_size(
-            statement, var_name, "variable", base_type
-        )
+        base_size = self._check_variable_type_size(statement, var_name, "variable", base_type)
         Qasm3Validator.validate_classical_type(base_type, base_size, var_name, statement)
 
         # initialize the bit register

--- a/tests/qasm3/resources/variables.py
+++ b/tests/qasm3/resources/variables.py
@@ -94,7 +94,7 @@ DECLARATION_TESTS = {
         include "stdgates.inc";
         int[32.1] x;
         """,
-        "Invalid base size 32.1 for variable 'x'",
+        "Invalid base size '32.1' for variable 'x'",
         4,
         8,
         "int[32.1] x;",
@@ -105,7 +105,7 @@ DECLARATION_TESTS = {
         include "stdgates.inc";
         const int[32.1] x = 3;
         """,
-        "Invalid base size for constant 'x'",
+        "Invalid base size '32.1' for constant 'x'",
         4,
         8,
         "const int[32.1] x = 3;",
@@ -363,7 +363,7 @@ ASSIGNMENT_TESTS = {
 }
 
 CASTING_TESTS = {
-    "General test": (
+    "General_test": (
         """
         OPENQASM 3.0;
         include "stdgates.inc";
@@ -372,9 +372,12 @@ CASTING_TESTS = {
         int[32] i2 = 2 * int[32](float[64](int[16](f1)));
         const int[8] i1 = int[8](f1); 
         const uint u1 = 2 * uint(f1);
+        int ccf1 = float(runtime_u) * int(f1);
+        uint ul1 = uint(float[64](int[16](f1))) * 2;
+        const int un = -int(u1);
         """
     ),
-    "Bool test": (
+    "Bool_test": (
         """
         OPENQASM 3.0;
         include "stdgates.inc";
@@ -394,7 +397,7 @@ CASTING_TESTS = {
         bool b_nested = bool(float[32](uint[8](int[8](bit[8](bool(true))))));
         """
     ),
-    "Int test": (
+    "Int_test": (
         """
         OPENQASM 3.0;
         include "stdgates.inc";
@@ -406,7 +409,7 @@ CASTING_TESTS = {
         bit[4] bits = bit[4](x);
         """
     ),
-    "Unsigned Int test": (
+    "Unsigned_Int_test": (
         """
         OPENQASM 3.0;
         include "stdgates.inc";
@@ -418,7 +421,7 @@ CASTING_TESTS = {
         bit[4] bits = bit[4](x);
         """
     ),
-    "Float test": (
+    "Float_test": (
         """
         OPENQASM 3.0;
         include "stdgates.inc";
@@ -431,7 +434,7 @@ CASTING_TESTS = {
         // angle[8] a = angle[8](f);
         """
     ),
-    "Bit test": (
+    "Bit_test": (
         """
         OPENQASM 3.0;
         include "stdgates.inc";
@@ -447,7 +450,7 @@ CASTING_TESTS = {
 }
 
 FAIL_CASTING_TESTS = {
-    "Float to Bit test": (
+    "Float_to_Bit_test": (
         """
         OPENQASM 3.0;
         include "stdgates.inc";
@@ -460,7 +463,7 @@ FAIL_CASTING_TESTS = {
         8,
         "const bit[2] b1 = bit[2](f1);",
     ),
-    "Const to non-Const test": (
+    "Const_to_non-Const_test": (
         """
         OPENQASM 3.0;
         include "stdgates.inc";
@@ -472,7 +475,7 @@ FAIL_CASTING_TESTS = {
         35,
         "const int[16] i2 = int[16](runtime_u);",
     ),
-    "Declaration vs Cast": (
+    "Declaration_vs_Cast": (
         """
         OPENQASM 3.0;
         include "stdgates.inc";
@@ -483,5 +486,40 @@ FAIL_CASTING_TESTS = {
         5,
         8,
         "int[32] i = uint[32](v);",
+    ),
+    "Incorrect_base_size_for_cast_variable": (
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        const float[64] f1 = 2.5;
+        const int[32] i1 = int[32.5](f1);
+        """,
+        "Invalid base size '32.5' for variable 'f1'",
+        5,
+        27,
+        "int[32.5](f1);",
+    ),
+    "Unsupported_expression": (
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+
+        duration d1 = 1ns;
+        """,
+        "Unsupported expression type '<class 'openqasm3.ast.DurationLiteral'>'",
+        5,
+        22,
+        "1.0ns",
+    ),
+    "Incorrect_base_size_for_direct_value_in_cast": (
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        const uint[32] iu = uint[12.2](24);
+        """,
+        "Invalid base size '12.2' for value '24'",
+        4,
+        28,
+        "uint[12.2](24);",
     ),
 }

--- a/tests/qasm3/resources/variables.py
+++ b/tests/qasm3/resources/variables.py
@@ -361,3 +361,127 @@ ASSIGNMENT_TESTS = {
         "x[3] = 3;",
     ),
 }
+
+CASTING_TESTS = {
+    "General test": (
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        const float[64] f1 = 2.5;
+        uint[8] runtime_u = 7;
+        int[32] i2 = 2 * int[32](float[64](int[16](f1)));
+        const int[8] i1 = int[8](f1); 
+        const uint u1 = 2 * uint(f1);
+        """
+    ),
+    "Bool test": (
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        
+        bool b_false = false;
+        bool b_true  = true;
+        
+        int i1 = int(b_false);
+        uint[16] u1 = uint[16](b_true);
+        float[32] f0 = float[32](b_false);
+        
+        bit  b;
+        b = b_true;
+        
+        bit[4] bits_from_true  = bit[4](b_true);
+        
+        bool b_nested = bool(float[32](uint[8](int[8](bit[8](bool(true))))));
+        """
+    ),
+    "Int test": (
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        
+        int[4] x = -3;
+        bool b = bool(x);
+        uint[8] ux = uint[8](x);
+        float[32] f = float[32](x);
+        bit[4] bits = bit[4](x);
+        """
+    ),
+    "Unsigned Int test": (
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        
+        uint[8] x = 3;
+        bool b = bool(x);
+        int[8] i = int[8](x);
+        float[32] f = float[32](x);
+        bit[4] bits = bit[4](x);
+        """
+    ),
+    "Float test": (
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+
+        const float[64] two_pi = 6.283185307179586;
+        float[64] f = two_pi * (127. / 512.);
+        bool b = bool(f);
+        int i = int(f);
+        uint u = uint(f);
+        // angle[8] a = angle[8](f);
+        """
+    ),
+    "Bit test": (
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        
+        int v = 15;
+        bit[4] x = v;
+        bool b = bool(x);
+        int[32] i = int[32](x);
+        uint[32] u = uint[32](x);
+        // angle[4] a = angle[4](x);
+        """
+    ),
+}
+
+FAIL_CASTING_TESTS = {
+    "Float to Bit test": (
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        const float[64] f1 = 2.5;
+        const bit[2] b1 = bit[2](f1);
+        """,
+        "Cannot cast <class 'float'> to <class 'openqasm3.ast.BitType'>. Invalid assignment "
+        "of type <class 'float'> to variable f1 of type <class 'openqasm3.ast.BitType'>",
+        5,
+        8,
+        "const bit[2] b1 = bit[2](f1);",
+    ),
+    "Const to non-Const test": (
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        uint[8] runtime_u = 7;
+        const int[16] i2 = int[16](runtime_u);
+        """,
+        "Expected variable 'runtime_u' to be constant in given expression",
+        5,
+        35,
+        "const int[16] i2 = int[16](runtime_u);",
+    ),
+    "Declaration vs Cast": (
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        int v = 15;
+        int[32] i = uint[32](v);
+        """,
+        "Declaration type: 'Int[32]' and Cast type: 'Uint[32]', should be same for 'i'",
+        5,
+        8,
+        "int[32] i = uint[32](v);",
+    ),
+}


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

## Summary of changes

This PR adds initial support for **Explicit Casting** in both `QasmVisitor` and `Qasm3ExprEvaluator`, in accordance with the [OpenQASM 3 casting rules](https://openqasm.com/language/types.html#casting-specifics).

With this change, we introduce logic to:

- Convert values by reusing the existing implicit‐casting mechanism, then return the correctly cast result.
- Validate declaration vs. explicit cast, ensuring that the target type and size exactly match the variable’s original declaration; otherwise emits a `ValidationError`.
- Extended the test suite to cover all newly legal explicit‐cast scenarios as well as illegal‐cast error cases. 

Closes #10 