### PR TITLE
Fix: depth calculations for decompose gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Types of changes:
 
 ### Fixed
 - Fixed multiple axes error in circuit visualization of decomposable gates in `draw` method. ([#209](https://github.com/qBraid/pyqasm/pull/210))
+- Fixed depth calculation for decomposable gates by computing depth of each constituent quantum gate.([#211](https://github.com/qBraid/pyqasm/pull/211))
 ### Dependencies
 
 ### Other

--- a/src/pyqasm/modules/base.py
+++ b/src/pyqasm/modules/base.py
@@ -56,7 +56,7 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
         self._validated_program = False
         self._unrolled_ast = Program(statements=[])
         self._external_gates: list[str] = []
-        self._decompose_gates: Optional[bool] = None
+        self._decompose_native_gates: Optional[bool] = None
 
     @property
     def name(self) -> str:
@@ -282,7 +282,7 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
         qasm_module = self.copy()
         qasm_module._qubit_depths = {}
         qasm_module._clbit_depths = {}
-        qasm_module._decompose_gates = decompose_gates
+        qasm_module._decompose_native_gates = decompose_gates
         # Unroll using any external gates that have been recorded for this
         # module
         qasm_module.unroll(external_gates=self._external_gates)

--- a/src/pyqasm/modules/base.py
+++ b/src/pyqasm/modules/base.py
@@ -260,11 +260,11 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
 
         return curr_module
 
-    def depth(self, decompose_gates=True):
+    def depth(self, decompose_native_gates=True):
         """Calculate the depth of the unrolled openqasm program.
 
         Args:
-        decompose_gates (bool): If True, calculate depth after decomposing gates.
+        decompose_native_gates (bool): If True, calculate depth after decomposing gates.
                                 If False, treat all decompsable gates as a single gate operation.
                                 Defaults to True.
 
@@ -282,7 +282,7 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
         qasm_module = self.copy()
         qasm_module._qubit_depths = {}
         qasm_module._clbit_depths = {}
-        qasm_module._decompose_native_gates = decompose_gates
+        qasm_module._decompose_native_gates = decompose_native_gates
         # Unroll using any external gates that have been recorded for this
         # module
         qasm_module.unroll(external_gates=self._external_gates)

--- a/src/pyqasm/modules/base.py
+++ b/src/pyqasm/modules/base.py
@@ -56,6 +56,7 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
         self._validated_program = False
         self._unrolled_ast = Program(statements=[])
         self._external_gates: list[str] = []
+        self._decompose_gates: Optional[bool] = None
 
     @property
     def name(self) -> str:
@@ -259,11 +260,13 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
 
         return curr_module
 
-    def depth(self):
+    def depth(self, decompose_gates=True):
         """Calculate the depth of the unrolled openqasm program.
 
         Args:
-            None
+        decompose_gates (bool): If True, calculate depth after decomposing gates.
+                                If False, treat all decompsable gates as a single gate operation.
+                                Defaults to True.
 
         Returns:
             int: The depth of the current "unrolled" openqasm program
@@ -279,7 +282,7 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
         qasm_module = self.copy()
         qasm_module._qubit_depths = {}
         qasm_module._clbit_depths = {}
-
+        qasm_module._decompose_gates = decompose_gates
         # Unroll using any external gates that have been recorded for this
         # module
         qasm_module.unroll(external_gates=self._external_gates)

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -962,7 +962,7 @@ class QasmVisitor:
             result.extend(
                 self._broadcast_gate_operation(unrolled_gate_function, unrolled_targets, ctrls)
             )
-            if self._module._decompose_gates and len(result) > 1:
+            if self._module._decompose_native_gates and len(result) > 1:
                 for gate in result:
                     if isinstance(gate, qasm3_ast.QuantumGate):
                         self._visit_basic_gate_operation(gate)
@@ -1087,20 +1087,27 @@ class QasmVisitor:
                     error_node=gate_op,
                     span=gate_op.span,
                 )
-
-        # Update the depth only once for the entire custom gate
-        if self._recording_ext_gate_depth:
+        if self._module._decompose_native_gates and len(result) > 1:
             self._recording_ext_gate_depth = False
-            if not self._in_branching_statement:  # if custom gate is not in branching statement
-                self._update_qubit_depth_for_gate([op_qubits], ctrls)
-            else:
-                # get qubit registers in branching operations
-                for qubit_subset in [op_qubits] + [ctrls]:
-                    for qubit in qubit_subset:
-                        assert isinstance(qubit.indices, list) and len(qubit.indices) > 0
-                        assert isinstance(qubit.indices[0], list) and len(qubit.indices[0]) > 0
-                        qubit_idx = Qasm3ExprEvaluator.evaluate_expression(qubit.indices[0][0])[0]
-                        self._is_branch_qubits.add((qubit.name.name, qubit_idx))
+            for gate in result:
+                if isinstance(gate, qasm3_ast.QuantumGate):
+                    self._visit_basic_gate_operation(gate)
+        else:
+            # Update the depth only once for the entire custom gate
+            if self._recording_ext_gate_depth:
+                self._recording_ext_gate_depth = False
+                if not self._in_branching_statement:  # if custom gate is not in branching statement
+                    self._update_qubit_depth_for_gate([op_qubits], ctrls)
+                else:
+                    # get qubit registers in branching operations
+                    for qubit_subset in [op_qubits] + [ctrls]:
+                        for qubit in qubit_subset:
+                            assert isinstance(qubit.indices, list) and len(qubit.indices) > 0
+                            assert isinstance(qubit.indices[0], list) and len(qubit.indices[0]) > 0
+                            qubit_idx = Qasm3ExprEvaluator.evaluate_expression(qubit.indices[0][0])[
+                                0
+                            ]
+                            self._is_branch_qubits.add((qubit.name.name, qubit_idx))
 
         self._restore_context()
 

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -1087,27 +1087,20 @@ class QasmVisitor:
                     error_node=gate_op,
                     span=gate_op.span,
                 )
-        if self._module._decompose_native_gates and len(result) > 1:
+
+        # Update the depth only once for the entire custom gate
+        if self._recording_ext_gate_depth:
             self._recording_ext_gate_depth = False
-            for gate in result:
-                if isinstance(gate, qasm3_ast.QuantumGate):
-                    self._visit_basic_gate_operation(gate)
-        else:
-            # Update the depth only once for the entire custom gate
-            if self._recording_ext_gate_depth:
-                self._recording_ext_gate_depth = False
-                if not self._in_branching_statement:  # if custom gate is not in branching statement
-                    self._update_qubit_depth_for_gate([op_qubits], ctrls)
-                else:
-                    # get qubit registers in branching operations
-                    for qubit_subset in [op_qubits] + [ctrls]:
-                        for qubit in qubit_subset:
-                            assert isinstance(qubit.indices, list) and len(qubit.indices) > 0
-                            assert isinstance(qubit.indices[0], list) and len(qubit.indices[0]) > 0
-                            qubit_idx = Qasm3ExprEvaluator.evaluate_expression(qubit.indices[0][0])[
-                                0
-                            ]
-                            self._is_branch_qubits.add((qubit.name.name, qubit_idx))
+            if not self._in_branching_statement:  # if custom gate is not in branching statement
+                self._update_qubit_depth_for_gate([op_qubits], ctrls)
+            else:
+                # get qubit registers in branching operations
+                for qubit_subset in [op_qubits] + [ctrls]:
+                    for qubit in qubit_subset:
+                        assert isinstance(qubit.indices, list) and len(qubit.indices) > 0
+                        assert isinstance(qubit.indices[0], list) and len(qubit.indices[0]) > 0
+                        qubit_idx = Qasm3ExprEvaluator.evaluate_expression(qubit.indices[0][0])[0]
+                        self._is_branch_qubits.add((qubit.name.name, qubit_idx))
 
         self._restore_context()
 

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -690,10 +690,12 @@ class QasmVisitor:
             unrolled_reset = qasm3_ast.QuantumReset(qubits=qid)
 
             qubit_name, qubit_id = qid.name.name, qid.indices[0][0].value  # type: ignore
-            qubit_node = self._module._qubit_depths[(qubit_name, qubit_id)]
-
-            qubit_node.depth += 1
-            qubit_node.num_resets += 1
+            if not self._in_branching_statement:
+                qubit_node = self._module._qubit_depths[(qubit_name, qubit_id)]
+                qubit_node.depth += 1
+                qubit_node.num_resets += 1
+            else:
+                self._is_branch_qubits.add((qubit_name, qubit_id))
 
             unrolled_resets.append(unrolled_reset)
 

--- a/tests/qasm2/test_depth.py
+++ b/tests/qasm2/test_depth.py
@@ -44,7 +44,7 @@ def test_gate_depth():
     result.unroll()
     assert result.num_qubits == 1
     assert result.num_clbits == 0
-    assert result.depth(decompose_gates=False) == 5
+    assert result.depth(decompose_native_gates=False) == 5
 
 
 def test_qubit_depth_with_unrelated_measure_op():

--- a/tests/qasm2/test_depth.py
+++ b/tests/qasm2/test_depth.py
@@ -44,7 +44,7 @@ def test_gate_depth():
     result.unroll()
     assert result.num_qubits == 1
     assert result.num_clbits == 0
-    assert result.depth() == 5
+    assert result.depth(decompose_gates=False) == 5
 
 
 def test_qubit_depth_with_unrelated_measure_op():

--- a/tests/qasm3/test_depth.py
+++ b/tests/qasm3/test_depth.py
@@ -624,3 +624,26 @@ def test_qasm3_depth_branching_for_external_gates():
     result = loads(qasm3_string)
     result._external_gates = ["my_gate", "my_gate_two"]
     assert result.depth() == 2
+
+
+QASM3_DECOMPOSE_GATE_DEPTH_1 = """
+OPENQASM 3.0;
+qubit[2] q1;
+qreg q[3];
+creg c[3];
+crx (0.1) q[0], q[2];
+rccx q[0], q[1], q1[0];
+"""
+
+
+@pytest.mark.parametrize(
+    ["input_qasm_str", "before_decompose", "after_decompose"],
+    [
+        (QASM3_DECOMPOSE_GATE_DEPTH_1, 2, 25),
+    ],
+)
+def test_gate_depth_decomposable_gates(input_qasm_str, before_decompose, after_decompose):
+    result = loads(input_qasm_str)
+    assert result.depth(decompose_gates=False) == before_decompose
+    # by default its true
+    assert result.depth() == after_decompose

--- a/tests/qasm3/test_depth.py
+++ b/tests/qasm3/test_depth.py
@@ -417,6 +417,23 @@ h q[1];
 """,
             6,
         ),
+        (
+            """
+OPENQASM 3.0;
+include "stdgates.inc";
+qubit[3] q;
+bit[2] mid;
+bit[3] out;
+measure q[0] -> mid[0];
+measure q[1] -> mid[1]; 
+if (mid[0]) {
+reset q[0];
+reset q[1];
+} 
+out = measure q;
+""",
+            3,
+        ),
     ],
 )
 def test_qasm3_depth_no_branching(program, expected_depth):

--- a/tests/qasm3/test_depth.py
+++ b/tests/qasm3/test_depth.py
@@ -48,7 +48,7 @@ def test_gate_depth():
     result.unroll()
     assert result.num_qubits == 1
     assert result.num_clbits == 0
-    assert result.depth() == 5
+    assert result.depth(decompose_gates=False) == 5
 
 
 QASM3_STRING_1 = """
@@ -102,12 +102,12 @@ def test_gate_depth_external_function(input_qasm_str, first_depth, second_depth,
         assert result._qubit_depths[("q", i)].num_gates == 1
 
     assert result.num_clbits == 0
-    assert result.depth() == first_depth
+    assert result.depth(decompose_gates=False) == first_depth
 
     # Check that unrolling with no external_gates flushes the internally stored
     # external gates and influences the depth calculation
     result.unroll()
-    assert result.depth() == second_depth
+    assert result.depth(decompose_gates=False) == second_depth
 
 
 def test_pow_gate_depth():
@@ -309,7 +309,7 @@ def test_qasm3_depth_sparse_operations():
     result = loads(qasm_string)
     result.unroll()
 
-    assert result.depth() == 8
+    assert result.depth(decompose_gates=False) == 8
 
 
 def test_qasm3_depth_measurement_direct():
@@ -328,7 +328,7 @@ b[1] = measure q[1];
     result = loads(qasm_string)
     result.unroll()
 
-    assert result.depth() == 8
+    assert result.depth(decompose_gates=False) == 8
 
 
 def test_qasm3_depth_measurement_indirect():
@@ -605,7 +605,7 @@ def test_qasm3_depth_branching(program, expected_depth):
     result = loads(program)
     result.unroll()
     result.remove_barriers()
-    assert result.depth() == expected_depth
+    assert result.depth(decompose_gates=False) == expected_depth
 
 
 def test_qasm3_depth_branching_for_external_gates():
@@ -640,7 +640,7 @@ def test_qasm3_depth_branching_for_external_gates():
     """
     result = loads(qasm3_string)
     result._external_gates = ["my_gate", "my_gate_two"]
-    assert result.depth() == 2
+    assert result.depth(decompose_gates=False) == 2
 
 
 QASM3_DECOMPOSE_GATE_DEPTH_1 = """
@@ -661,6 +661,34 @@ rccx q[0], q[1], q1[0];
 )
 def test_gate_depth_decomposable_gates(input_qasm_str, before_decompose, after_decompose):
     result = loads(input_qasm_str)
+    assert result.depth(decompose_gates=False) == before_decompose
+    # by default its true
+    assert result.depth() == after_decompose
+
+
+QASM3_DECOMPOSE_CUSTOM_GATE_DEPTH_1 = """
+OPENQASM 3.0;
+include "stdgates.inc";
+gate custom_crx a, b, {
+    crx (0.1) a, b;
+}
+gate custom_rccx a, b, c{
+    rccx a, b, c;
+}
+qubit[2] q1;
+qreg q[3];
+custom_crx q[0], q[2];
+custom_rccx q[0], q[1], q1[0];
+"""
+
+
+@pytest.mark.parametrize(
+    ["input_qasm_str", "before_decompose", "after_decompose"],
+    [(QASM3_DECOMPOSE_CUSTOM_GATE_DEPTH_1, 2, 25)],
+)
+def test_gate_depth_decomposable_custom_gates(input_qasm_str, before_decompose, after_decompose):
+    result = loads(input_qasm_str)
+    result._external_gates = ["custom_crx", "custom_rccx"]
     assert result.depth(decompose_gates=False) == before_decompose
     # by default its true
     assert result.depth() == after_decompose


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->
Fixes #201
## Summary of changes
#### Added special handling for depth calculation for decompose gates
- A new property `decompose_gates` was added to the `QasmModule` class to control whether gates should be decomposed during depth calculations.
- This allows for more flexible depth calculations where users can choose whether to consider decomposed gates or not.