### PR TITLE
Feature/Implement Qubit Register Consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Types of changes:
 ### Improved / Modified
 - Added `slots=True` parameter to the data classes in `elements.py` to improve memory efficiency ([#218](https://github.com/qBraid/pyqasm/pull/218))
 - Updated the documentation to include core features in the `README` ([#219](https://github.com/qBraid/pyqasm/pull/219))
+- Added support to `device qubit` resgister consolidation.([#222](https://github.com/qBraid/pyqasm/pull/222))
 
 ### Deprecated
 

--- a/src/pyqasm/elements.py
+++ b/src/pyqasm/elements.py
@@ -89,6 +89,7 @@ class Variable:  # pylint: disable=too-many-instance-attributes
         base_size (int): Base size of the variable.
         dims (Optional[List[int]]): Dimensions of the variable.
         value (Optional[int | float | np.ndarray]): Value of the variable.
+        span (Any): Span of the variable.
         is_constant (bool): Flag indicating if the variable is constant.
         is_register (bool): Flag indicating if the variable is a register.
         readonly (bool): Flag indicating if the variable is readonly.
@@ -99,6 +100,7 @@ class Variable:  # pylint: disable=too-many-instance-attributes
     base_size: int
     dims: Optional[list[int]] = None
     value: Optional[int | float | np.ndarray] = None
+    span: Any = None
     is_constant: bool = False
     is_register: bool = False
     readonly: bool = False

--- a/src/pyqasm/entrypoint.py
+++ b/src/pyqasm/entrypoint.py
@@ -30,11 +30,15 @@ if TYPE_CHECKING:
     import openqasm3.ast
 
 
-def load(filename: str) -> QasmModule:
+def load(
+    filename: str, *, device_qubits: int | None = None, consolidate_qubits: bool = False
+) -> QasmModule:
     """Loads an OpenQASM program into a `QasmModule` object.
 
     Args:
         filename (str): The filename of the OpenQASM program to validate.
+        device_qubits (int): Number of physical qubits available on the target device.
+        consolidate_qubits (bool): If True, consolidate all quantum registers into single register.
 
     Returns:
         QasmModule: An object containing the parsed qasm representation along with
@@ -44,14 +48,21 @@ def load(filename: str) -> QasmModule:
         raise TypeError("Input 'filename' must be of type 'str'.")
     with open(filename, "r", encoding="utf-8") as file:
         program = file.read()
-    return loads(program)
+    return loads(program, device_qubits=device_qubits, consolidate_qubits=consolidate_qubits)
 
 
-def loads(program: openqasm3.ast.Program | str) -> QasmModule:
+def loads(
+    program: "openqasm3.ast.Program | str",
+    *,
+    device_qubits: int | None = None,
+    consolidate_qubits: bool = False,
+) -> QasmModule:
     """Loads an OpenQASM program into a `QasmModule` object.
 
     Args:
         program (openqasm3.ast.Program or str): The OpenQASM program to validate.
+        device_qubits (int): Number of physical qubits available on the target device.
+        consolidate_qubits (bool): If True, consolidate all quantum registers into single register.
 
     Raises:
         TypeError: If the input is not a string or an `openqasm3.ast.Program` instance.
@@ -79,7 +90,9 @@ def loads(program: openqasm3.ast.Program | str) -> QasmModule:
 
     qasm_module = Qasm3Module if program.version.startswith("3") else Qasm2Module
     module = qasm_module("main", program)
-
+    # Store device_qubits and consolidate_qubits on the module for later use
+    module._device_qubits = device_qubits
+    module._consolidate_qubits = consolidate_qubits
     return module
 
 

--- a/src/pyqasm/entrypoint.py
+++ b/src/pyqasm/entrypoint.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 
 def load(
-    filename: str, *, device_qubits: int | None = None, consolidate_qubits: bool = False
+    filename: str, device_qubits: int | None = None, consolidate_qubits: bool = False
 ) -> QasmModule:
     """Loads an OpenQASM program into a `QasmModule` object.
 
@@ -52,8 +52,7 @@ def load(
 
 
 def loads(
-    program: "openqasm3.ast.Program | str",
-    *,
+    program: openqasm3.ast.Program | str,
     device_qubits: int | None = None,
     consolidate_qubits: bool = False,
 ) -> QasmModule:

--- a/src/pyqasm/entrypoint.py
+++ b/src/pyqasm/entrypoint.py
@@ -30,15 +30,11 @@ if TYPE_CHECKING:
     import openqasm3.ast
 
 
-def load(
-    filename: str, device_qubits: int | None = None, consolidate_qubits: bool = False
-) -> QasmModule:
+def load(filename: str, **kwargs) -> QasmModule:
     """Loads an OpenQASM program into a `QasmModule` object.
 
     Args:
         filename (str): The filename of the OpenQASM program to validate.
-        device_qubits (int): Number of physical qubits available on the target device.
-        consolidate_qubits (bool): If True, consolidate all quantum registers into single register.
 
     Returns:
         QasmModule: An object containing the parsed qasm representation along with
@@ -48,20 +44,17 @@ def load(
         raise TypeError("Input 'filename' must be of type 'str'.")
     with open(filename, "r", encoding="utf-8") as file:
         program = file.read()
-    return loads(program, device_qubits=device_qubits, consolidate_qubits=consolidate_qubits)
+    return loads(program, **kwargs)
 
 
-def loads(
-    program: openqasm3.ast.Program | str,
-    device_qubits: int | None = None,
-    consolidate_qubits: bool = False,
-) -> QasmModule:
+def loads(program: openqasm3.ast.Program | str, **kwargs) -> QasmModule:
     """Loads an OpenQASM program into a `QasmModule` object.
 
     Args:
         program (openqasm3.ast.Program or str): The OpenQASM program to validate.
+
+    **kwargs: Additional arguments to pass to the loads function.
         device_qubits (int): Number of physical qubits available on the target device.
-        consolidate_qubits (bool): If True, consolidate all quantum registers into single register.
 
     Raises:
         TypeError: If the input is not a string or an `openqasm3.ast.Program` instance.
@@ -89,9 +82,9 @@ def loads(
 
     qasm_module = Qasm3Module if program.version.startswith("3") else Qasm2Module
     module = qasm_module("main", program)
-    # Store device_qubits and consolidate_qubits on the module for later use
-    module._device_qubits = device_qubits
-    module._consolidate_qubits = consolidate_qubits
+    # Store device_qubits on the module for later use
+    if dev_qbts := kwargs.get("device_qubits"):
+        module._device_qubits = dev_qbts
     return module
 
 

--- a/src/pyqasm/entrypoint.py
+++ b/src/pyqasm/entrypoint.py
@@ -53,8 +53,8 @@ def loads(program: openqasm3.ast.Program | str, **kwargs) -> QasmModule:
     Args:
         program (openqasm3.ast.Program or str): The OpenQASM program to validate.
 
-    **kwargs: Additional arguments to pass to the loads function.
-        device_qubits (int): Number of physical qubits available on the target device.
+        **kwargs: Additional arguments to pass to the loads function.
+            device_qubits (int): Number of physical qubits available on the target device.
 
     Raises:
         TypeError: If the input is not a string or an `openqasm3.ast.Program` instance.

--- a/src/pyqasm/expressions.py
+++ b/src/pyqasm/expressions.py
@@ -392,6 +392,7 @@ class Qasm3ExprEvaluator:
                 dims=[],
                 value=var_value,
                 is_constant=const_expr,
+                span=expression.span,
             )
             cast_var_value = Qasm3Validator.validate_variable_assignment_value(
                 variable, var_value, expression

--- a/src/pyqasm/modules/base.py
+++ b/src/pyqasm/modules/base.py
@@ -57,6 +57,7 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
         self._unrolled_ast = Program(statements=[])
         self._external_gates: list[str] = []
         self._decompose_native_gates: Optional[bool] = None
+        self._device_qubits: Optional[int] = 0
 
     @property
     def name(self) -> str:
@@ -551,6 +552,8 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
                 self._external_gates = ext_gates
             else:
                 self._external_gates = []
+            if device_qbts := kwargs.get("device_qubits"):
+                self._device_qubits = device_qbts
             visitor = QasmVisitor(module=self, **kwargs)
             self.accept(visitor)
         except (ValidationError, UnrollError) as err:

--- a/src/pyqasm/modules/base.py
+++ b/src/pyqasm/modules/base.py
@@ -519,19 +519,14 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
             return
         try:
             self.num_qubits, self.num_clbits = 0, 0
-            visitor = QasmVisitor(
-                self,
-                check_only=True,
-                device_qubits=self._device_qubits,
-            )
+            visitor = QasmVisitor(self, check_only=True)
             self.accept(visitor)
             # Implicit validation: check total qubits if device_qubits is set and not consolidating
             if self._device_qubits:
-                total_qubits = sum(self._qubit_registers.values())
-                if total_qubits > self._device_qubits:
+                if self.num_qubits > self._device_qubits:
                     raise ValidationError(
                         # pylint: disable-next=line-too-long
-                        f"Total qubits '{total_qubits}' exceed device qubits '{self._device_qubits}'."
+                        f"Total qubits '{self.num_qubits}' exceed device qubits '{self._device_qubits}'."
                     )
         except (ValidationError, NotImplementedError) as err:
             self.num_qubits, self.num_clbits = -1, -1
@@ -562,19 +557,13 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
         """
         if not kwargs:
             kwargs = {}
-        # Use module attributes if not overridden by kwargs
-        if "device_qubits" not in kwargs:
-            kwargs["device_qubits"] = self._device_qubits
-        if "consolidate_qubits" not in kwargs:
-            kwargs["consolidate_qubits"] = self._consolidate_qubits
+
         try:
             self.num_qubits, self.num_clbits = 0, 0
             if ext_gates := kwargs.get("external_gates"):
                 self._external_gates = ext_gates
             else:
                 self._external_gates = []
-            if device_qbts := kwargs.get("device_qubits"):
-                self._device_qubits = device_qbts
             if consolidate_qbts := kwargs.get("consolidate_qubits"):
                 self._consolidate_qubits = consolidate_qbts
             visitor = QasmVisitor(module=self, **kwargs)

--- a/src/pyqasm/subroutines.py
+++ b/src/pyqasm/subroutines.py
@@ -156,6 +156,7 @@ class Qasm3SubroutineProcessor:
             dims=None,
             value=actual_arg_value,
             is_constant=False,
+            span=fn_call.span,
         )
 
     @classmethod  # pylint: disable-next=too-many-arguments,too-many-locals,too-many-branches
@@ -346,6 +347,7 @@ class Qasm3SubroutineProcessor:
             dims=formal_dimensions,
             value=actual_array_view,  # this is the VIEW of the actual array
             readonly=readonly_arr,
+            span=fn_call.span,
         )
 
     @classmethod  # pylint: disable-next=too-many-arguments
@@ -454,4 +456,5 @@ class Qasm3SubroutineProcessor:
             dims=None,
             value=None,
             is_constant=False,
+            span=fn_call.span,
         )

--- a/src/pyqasm/transformer.py
+++ b/src/pyqasm/transformer.py
@@ -29,7 +29,6 @@ from openqasm3.ast import (
     FloatLiteral,
     Identifier,
     IndexedIdentifier,
-    IndexElement,
     IndexExpression,
     IntegerLiteral,
 )
@@ -556,21 +555,16 @@ class Qasm3Transformer:
                 for stmt in unrolled_stmts:
                     stmt_qubits: list[IndexedIdentifier] = []
                     for qubit in stmt.qubits:
-                        _original_qbt_name = cast(Identifier, qubit.name)
-                        qubit_indices: list[IndexElement] = []
-                        for multi_ind in qubit.indices:  # type: ignore[union-attr]
-                            qubit_sub_ind: IndexElement = []
-                            for ind in multi_ind:
-                                pyqasm_val = _get_pyqasm_device_qubit_index(
-                                    _original_qbt_name.name,
-                                    ind.value,  # type: ignore[union-attr]
-                                    qubit_register_offsets,
-                                    global_qreg_size_map,
-                                )
-                                qubit_sub_ind.append(IntegerLiteral(pyqasm_val))
-                            qubit_indices.append(qubit_sub_ind)
+                        pyqasm_val = _get_pyqasm_device_qubit_index(
+                            qubit.name.name,
+                            qubit.indices[0][0].value,
+                            qubit_register_offsets,
+                            global_qreg_size_map,
+                        )
                         stmt_qubits.append(
-                            IndexedIdentifier(Identifier("__PYQASM_QUBITS__"), qubit_indices)
+                            IndexedIdentifier(
+                                Identifier("__PYQASM_QUBITS__"), [[IntegerLiteral(pyqasm_val)]]
+                            )
                         )
                     stmt.qubits = stmt_qubits
 

--- a/src/pyqasm/validator.py
+++ b/src/pyqasm/validator.py
@@ -335,6 +335,7 @@ class Qasm3Validator:
                     base_size,
                     None,
                     None,
+                    span=return_statement.span,
                 ),
                 return_value,
                 op_node=return_statement,

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -366,16 +366,12 @@ class QasmVisitor:
 
         self._module._add_qubit_register(register_name, register_size)
 
-        # Inline: Update offsets after adding a new register if device_qubits is set
+        # _qubit_register_offsets maps each original quantum register to its
+        # starting index in the consolidated register, enabling correct
+        # translation of qubit indices after consolidation.
         if self._consolidate_qubits:
             self._qubit_register_offsets[register_name] = self._qubit_register_max_offset
             self._qubit_register_max_offset += register_size
-            # offsets = {}
-            # offset = 0
-            # for name, n_qubits in self._global_qreg_size_map.items():
-            #     offsets[name] = offset
-            #     offset += n_qubits
-            # self._qubit_register_offsets = offsets
 
         logger.debug("Added labels for register '%s'", str(register))
 

--- a/tests/qasm3/test_device_qubits.py
+++ b/tests/qasm3/test_device_qubits.py
@@ -72,16 +72,20 @@ def test_unrolled_barrier():
     include "stdgates.inc";
     qubit[2] q;
     qreg q2[3];
+    qubit[2] q3;
     barrier q[0];
     barrier q2;
     barrier q;
+    barrier q4;
+    
     """
     expected_qasm = """OPENQASM 3.0;
     include "stdgates.inc";
     qubit[5] __PYQASM_QUBITS__;
     barrier __PYQASM_QUBITS__[0];
-    barrier __PYQASM_QUBITS__[2:];
+    barrier __PYQASM_QUBITS__[2:5];
     barrier __PYQASM_QUBITS__[:2];
+    barrier __PYQASM_QUBITS__[5:];
     """
     result = loads(qasm)
     result.unroll(unroll_barriers=False, device_qubits=5)

--- a/tests/qasm3/test_device_qubits.py
+++ b/tests/qasm3/test_device_qubits.py
@@ -1,0 +1,233 @@
+# Copyright 2025 qBraid
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Module containing unit tests for the qubit register consolidation.
+
+"""
+
+import pytest
+
+from pyqasm.entrypoint import dumps, loads
+from pyqasm.exceptions import ValidationError
+from tests.utils import check_unrolled_qasm
+
+
+def test_reset():
+    qasm = """OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    qreg q2[3];
+    reset q2;
+    reset q[1];
+    """
+    expected_qasm = """OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[5] __PYQASM_QUBITS__;
+    reset __PYQASM_QUBITS__[2];
+    reset __PYQASM_QUBITS__[3];
+    reset __PYQASM_QUBITS__[4];
+    reset __PYQASM_QUBITS__[1];
+    """
+
+    result = loads(qasm)
+    result.unroll(device_qubits=5)
+    check_unrolled_qasm(dumps(result), expected_qasm)
+
+
+def test_barrier():
+    qasm = """OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    qreg q2[3];
+    barrier q2;
+    barrier q[1];
+    """
+    expected_qasm = """OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[5] __PYQASM_QUBITS__;
+    barrier __PYQASM_QUBITS__[2];
+    barrier __PYQASM_QUBITS__[3];
+    barrier __PYQASM_QUBITS__[4];
+    barrier __PYQASM_QUBITS__[1];
+    """
+    result = loads(qasm)
+    result.unroll(device_qubits=5)
+    check_unrolled_qasm(dumps(result), expected_qasm)
+
+
+def test_unrolled_barrier():
+    qasm = """OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    qreg q2[3];
+    barrier q[0];
+    barrier q2;
+    barrier q;
+    """
+    expected_qasm = """OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[5] __PYQASM_QUBITS__;
+    barrier __PYQASM_QUBITS__[0];
+    barrier __PYQASM_QUBITS__[2:];
+    barrier __PYQASM_QUBITS__[:2];
+    """
+    result = loads(qasm)
+    result.unroll(unroll_barriers=False, device_qubits=5)
+    check_unrolled_qasm(dumps(result), expected_qasm)
+
+
+def test_measurement():
+    qasm = """OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[4] q;
+    qreg q2[3];
+    bit[3] c;
+    measure q2 -> c;
+    c[0] = measure q[0];
+    c = measure q[:3];
+    c = measure q2;
+    measure q2[1] -> c[2];
+    """
+    expected_qasm = """OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[7] __PYQASM_QUBITS__;
+    bit[3] c;
+    c[0] = measure __PYQASM_QUBITS__[4];
+    c[1] = measure __PYQASM_QUBITS__[5];
+    c[2] = measure __PYQASM_QUBITS__[6];
+    c[0] = measure __PYQASM_QUBITS__[0];
+    c[0] = measure __PYQASM_QUBITS__[0];
+    c[1] = measure __PYQASM_QUBITS__[1];
+    c[2] = measure __PYQASM_QUBITS__[2];
+    c[0] = measure __PYQASM_QUBITS__[4];
+    c[1] = measure __PYQASM_QUBITS__[5];
+    c[2] = measure __PYQASM_QUBITS__[6];
+    c[2] = measure __PYQASM_QUBITS__[5];
+    """
+    result = loads(qasm)
+    result.unroll(device_qubits=7)
+    check_unrolled_qasm(dumps(result), expected_qasm)
+
+
+def test_gates():
+    qasm = """OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[4] data;
+    qubit[2] ancilla;
+    bit[3] c;
+    x data[3];
+    cx data[0], ancilla[1];
+    crx (0.1) ancilla[0], data[2];
+    gate custom_rccx a, b, c{
+    rccx a, b, c;
+    }
+    custom_rccx ancilla[0], data[1], data[0];
+    if(c[0]){
+       x data[0];
+       cx data[1], ancilla[1];
+    }
+    if(c[1] == 1){
+       cx ancilla[0], data[2];
+    }
+    """
+    expected_qasm = """OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[6] __PYQASM_QUBITS__;
+    bit[3] c;
+    x __PYQASM_QUBITS__[3];
+    cx __PYQASM_QUBITS__[0], __PYQASM_QUBITS__[5];
+    rz(1.5707963267948966) __PYQASM_QUBITS__[2];
+    rx(1.5707963267948966) __PYQASM_QUBITS__[2];
+    rz(3.141592653589793) __PYQASM_QUBITS__[2];
+    rx(1.5707963267948966) __PYQASM_QUBITS__[2];
+    rz(3.141592653589793) __PYQASM_QUBITS__[2];
+    cx __PYQASM_QUBITS__[4], __PYQASM_QUBITS__[2];
+    rz(0) __PYQASM_QUBITS__[2];
+    rx(1.5707963267948966) __PYQASM_QUBITS__[2];
+    rz(3.0915926535897933) __PYQASM_QUBITS__[2];
+    rx(1.5707963267948966) __PYQASM_QUBITS__[2];
+    rz(3.141592653589793) __PYQASM_QUBITS__[2];
+    cx __PYQASM_QUBITS__[4], __PYQASM_QUBITS__[2];
+    rz(0) __PYQASM_QUBITS__[2];
+    rx(1.5707963267948966) __PYQASM_QUBITS__[2];
+    rz(3.191592653589793) __PYQASM_QUBITS__[2];
+    rx(1.5707963267948966) __PYQASM_QUBITS__[2];
+    rz(1.5707963267948966) __PYQASM_QUBITS__[2];
+    rz(3.141592653589793) __PYQASM_QUBITS__[0];
+    rx(1.5707963267948966) __PYQASM_QUBITS__[0];
+    rz(4.71238898038469) __PYQASM_QUBITS__[0];
+    rx(1.5707963267948966) __PYQASM_QUBITS__[0];
+    rz(3.141592653589793) __PYQASM_QUBITS__[0];
+    h __PYQASM_QUBITS__[0];
+    rx(0.7853981633974483) __PYQASM_QUBITS__[0];
+    h __PYQASM_QUBITS__[0];
+    cx __PYQASM_QUBITS__[1], __PYQASM_QUBITS__[0];
+    h __PYQASM_QUBITS__[0];
+    rx(-0.7853981633974483) __PYQASM_QUBITS__[0];
+    h __PYQASM_QUBITS__[0];
+    cx __PYQASM_QUBITS__[4], __PYQASM_QUBITS__[0];
+    h __PYQASM_QUBITS__[0];
+    rx(0.7853981633974483) __PYQASM_QUBITS__[0];
+    h __PYQASM_QUBITS__[0];
+    cx __PYQASM_QUBITS__[1], __PYQASM_QUBITS__[0];
+    h __PYQASM_QUBITS__[0];
+    rx(-0.7853981633974483) __PYQASM_QUBITS__[0];
+    h __PYQASM_QUBITS__[0];
+    rz(3.141592653589793) __PYQASM_QUBITS__[0];
+    rx(1.5707963267948966) __PYQASM_QUBITS__[0];
+    rz(4.71238898038469) __PYQASM_QUBITS__[0];
+    rx(1.5707963267948966) __PYQASM_QUBITS__[0];
+    rz(3.141592653589793) __PYQASM_QUBITS__[0];
+    if (c[0] == true) {
+        x __PYQASM_QUBITS__[0];
+        cx __PYQASM_QUBITS__[1], __PYQASM_QUBITS__[5];
+    }
+    if (c[1] == true) {
+        cx __PYQASM_QUBITS__[4], __PYQASM_QUBITS__[2];
+    }
+    """
+    result = loads(qasm)
+    result.unroll(device_qubits=6)
+    check_unrolled_qasm(dumps(result), expected_qasm)
+
+
+@pytest.mark.parametrize(
+    "qasm_code,error_message",
+    [
+        (
+            """
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            qubit[4] data;
+            qubit[3] ancilla;
+            """,
+            r"Total qubits '(7)' exceed device qubits '(6)'.",
+        ),
+        (
+            """
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            qubit[4] data;
+            qubit[2] __PYQASM_QUBITS__;
+            """,
+            r"Original QASM program already declares reserved register '__PYQASM_QUBITS__'.",
+        ),
+    ],
+)  # pylint: disable-next= too-many-arguments
+def test_incorrect_qubit_reg_consolidation(qasm_code, error_message, caplog):
+    with pytest.raises(ValidationError) as err:
+        with caplog.at_level("ERROR"):
+            loads(qasm_code).unroll(device_qubits=6)
+    assert error_message in str(err.value)

--- a/tests/qasm3/test_device_qubits.py
+++ b/tests/qasm3/test_device_qubits.py
@@ -76,7 +76,7 @@ def test_unrolled_barrier():
     barrier q[0];
     barrier q2;
     barrier q;
-    barrier q4;
+    barrier q3;
     
     """
     expected_qasm = """OPENQASM 3.0;
@@ -88,7 +88,7 @@ def test_unrolled_barrier():
     barrier __PYQASM_QUBITS__[5:];
     """
     result = loads(qasm)
-    result.unroll(unroll_barriers=False, device_qubits=5)
+    result.unroll(unroll_barriers=False, device_qubits=7)
     check_unrolled_qasm(dumps(result), expected_qasm)
 
 

--- a/tests/qasm3/test_device_qubits.py
+++ b/tests/qasm3/test_device_qubits.py
@@ -77,11 +77,10 @@ def test_unrolled_barrier():
     barrier q2;
     barrier q;
     barrier q3;
-    
     """
     expected_qasm = """OPENQASM 3.0;
     include "stdgates.inc";
-    qubit[5] __PYQASM_QUBITS__;
+    qubit[7] __PYQASM_QUBITS__;
     barrier __PYQASM_QUBITS__[0];
     barrier __PYQASM_QUBITS__[2:5];
     barrier __PYQASM_QUBITS__[:2];


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

## Summary of changes
Implement device qubit(`__PYQASM_QUBITS__`) support in QasmVisitor and QasmModule

- Added a new parameter `device_qubits` to `QasmVisitor` and `QasmModule` to manage qubit consolidation.
- Introduced `_get_pyqasm_device_qubit_index`  method for qubit index mapping and `_qubit_register_consolidation` to ensure compatibility with device constraints.
- Updated measurement, barrier, and gate operations to utilize the new device qubit logic.
- Added unit tests to validate the functionality of qubit consolidation and error handling for exceeding device qubit limits.
enhance a little bit wihtout changing anuthing

Closes #187
