### PR TITLE
Fix/ Statement copying in functions and added loop limit in for loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Types of changes:
 ### Fixed
 - Fixed multiple axes error in circuit visualization of decomposable gates in `draw` method. ([#209](https://github.com/qBraid/pyqasm/pull/210))
 - Fixed depth calculation for decomposable gates by computing depth of each constituent quantum gate.([#211](https://github.com/qBraid/pyqasm/pull/211))
+- Optimized statement copying in `_visit_function_call` with shallow-copy fallback to deepcopy and added `max_loop_iters` loop‐limit check in for loops.([#223](https://github.com/qBraid/pyqasm/pull/223))
 ### Dependencies
 
 ### Other

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -2068,9 +2068,12 @@ class QasmVisitor:
         result = []
         for function_op in subroutine_def.body:
             if isinstance(function_op, qasm3_ast.ReturnStatement):
-                return_statement = copy.deepcopy(function_op)
+                return_statement = copy.copy(function_op)
                 break
-            result.extend(self.visit_statement(copy.deepcopy(function_op)))
+            try:
+                result.extend(self.visit_statement(copy.copy(function_op)))
+            except (TypeError, copy.Error):
+                result.extend(self.visit_statement(copy.deepcopy(function_op)))
 
         return_value = None
         if return_statement:

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -1927,6 +1927,7 @@ class QasmVisitor:
         # Check if the loop range exceeds the maximum allowed iterations
         if len(irange) > self._loop_limit:
             raise_qasm3_error(
+                # pylint: disable-next=line-too-long
                 f"Loop range '{len(irange)-1}' exceeded max allowed '{self._loop_limit}' iterations",
                 err_type=LoopLimitExceededError,
                 error_node=statement,

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -1927,7 +1927,7 @@ class QasmVisitor:
         # Check if the loop range exceeds the maximum allowed iterations
         if len(irange) > self._loop_limit:
             raise_qasm3_error(
-                f"Loop range'{len(irange)-1}' exceeded max allowed '{self._loop_limit}' iterations",
+                f"Loop range '{len(irange)-1}' exceeded max allowed '{self._loop_limit}' iterations",
                 err_type=LoopLimitExceededError,
                 error_node=statement,
                 span=statement.span,

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -1924,6 +1924,15 @@ class QasmVisitor:
                 span=statement.span,
             )
 
+        # Check if the loop range exceeds the maximum allowed iterations
+        if len(irange) > self._loop_limit:
+            raise_qasm3_error(
+                f"Loop range'{len(irange)-1}' exceeded max allowed '{self._loop_limit}' iterations",
+                err_type=LoopLimitExceededError,
+                error_node=statement,
+                span=statement.span,
+            )
+
         i: Optional[Variable]  # will store iteration Variable to update to loop scope
 
         result = []


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

## Summary of changes
#### Optimize statement copying in `_visit_function_call` and added `max_loop_iters` in `_visit_forin_loop`

- Optimized the handling of return statements and function operations by using shallow copies where appropriate, while maintaining fallback to deep copies in case of errors.

Closes #202
- Added a check to ensure loop ranges do not exceed the maximum allowed iterations, raising a LoopLimitExceededError if exceeded.

Closes #208