### PR TITLE
Add OpenPulseVisitor Skeleton and Initial OpenPulse AST Handling

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install -e '.[docs]'
+        python3 -m pip install -e '.[docs,pulse]'
     - name: Build docs
       run: |
         sphinx-build -W -b html docs docs/build/html

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Install and Test wheel with extras
         run: |
           pip install setuptools
-          bash bin/install_wheel_extras.sh dist --type wheel --extra test --extra cli 
+          bash bin/install_wheel_extras.sh dist --type wheel --extra test --extra cli --extra pulse
           python -m pytest --cov=pyqasm tests/ --cov-report=html --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov

--- a/bin/test_sdist.sh
+++ b/bin/test_sdist.sh
@@ -32,7 +32,7 @@ source "$TEMP_ENV_DIR/bin/activate"
 # Install the source distribution
 SCRIPT_DIR="$TARGET_PATH/bin"
 
-"$SCRIPT_DIR/install_wheel_extras.sh" "$TARGET_PATH/dist" --type sdist --extra cli --extra test
+"$SCRIPT_DIR/install_wheel_extras.sh" "$TARGET_PATH/dist" --type sdist --extra cli --extra test --extra pulse
 
 # Print the installed version
 python -c "import pyqasm; print('Installed pyqasm version:', pyqasm.__version__)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ test = ["pytest", "pytest-cov", "pytest-mpl", "pillow<11.4.0", "matplotlib"]
 lint = ["black", "isort>=6.0.0", "pylint", "mypy", "qbraid-cli>=0.10.2"]
 docs = ["sphinx>=7.3.7,<8.3.0", "sphinx-autodoc-typehints>=1.24,<3.2", "sphinx-rtd-theme>=2.0.0,<4.0.0", "docutils<0.22", "sphinx-copybutton"]
 visualization = ["pillow<11.4.0", "matplotlib"]
-pulse = ["openpulse[parser]>=1.0.1"]
+pulse = ["openpulse>=1.0.1"]
 
 [tool.setuptools.package-data]
 pyqasm = ["py.typed", "*.pyx"]

--- a/src/pyqasm/elements.py
+++ b/src/pyqasm/elements.py
@@ -106,6 +106,25 @@ class Variable:  # pylint: disable=too-many-instance-attributes
     readonly: bool = False
 
 
+@dataclass(slots=True)
+class Frame:
+    """
+    Class representing a frame in OpenQASM/OpenPulse.
+
+    Attributes:
+        port (Any): The port to which the frame is attached. Immutable after initialization.
+        frequency (float): The frequency of the frame.
+        phase (float): The phase of the frame, in radians.
+        time (float): The current time of the frame, in duration units.
+                      This is manipulated implicitly and cannot be set directly.
+    """
+
+    port: Any
+    frequency: Any
+    phase: Any
+    time: Optional[Any] = 0.0
+
+
 class BasisSet(Enum):
     """
     Enum for the different basis sets in Qasm.

--- a/src/pyqasm/elements.py
+++ b/src/pyqasm/elements.py
@@ -120,8 +120,8 @@ class Frame:
     """
 
     port: Any
-    frequency: Any
-    phase: Any
+    frequency: float
+    phase: float
     time: Optional[Any] = 0.0
 
 

--- a/src/pyqasm/openpulse_visitor.py
+++ b/src/pyqasm/openpulse_visitor.py
@@ -1,0 +1,376 @@
+# Copyright 2025 qBraid
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=all
+# mypy: disable-error-code=union-attr
+"""
+Module defining OpenPulse Visitor.
+
+"""
+import logging
+from typing import Any
+
+import openpulse.ast as o_pulse_ast
+
+from pyqasm.elements import Frame
+from pyqasm.exceptions import (
+    raise_qasm3_error,
+)
+
+logger = logging.getLogger(__name__)
+logger.propagate = False
+
+
+class OpenPulseVisitor:
+    """A visitor for basic OpenPulse program elements.
+
+    This class is designed to traverse and interact with elements in an OpenPulse program.
+
+    Args:
+
+    """
+
+    def __init__(
+        self,
+        module,
+        check_only: bool = False,
+        is_def_cal: bool = False,
+    ):
+        self._module = module
+        self._check_only: bool = check_only
+        self._frames = list[Frame]
+        self._ports = list[o_pulse_ast.PortType]
+        self._waveforms = list[o_pulse_ast.WaveformType]
+        self._is_def_cal = is_def_cal
+
+    def _visit_barrier(
+        self, barrier: o_pulse_ast.QuantumBarrier
+    ) -> list[o_pulse_ast.QuantumBarrier]:
+        """Visit a barrier statement element.
+
+        Args:
+            statement (o_pulse_ast.QuantumBarrier): The barrier statement to visit.
+
+        Returns:
+            None
+        """
+        if barrier.qubits:
+            print("TODO")
+            for frm in barrier.qubits:
+                print(frm, "TODO")
+                # check frame in global scope
+
+        return []
+
+    def _visit_classical_declaration(
+        self, statement: o_pulse_ast.ClassicalDeclaration
+    ) -> list[o_pulse_ast.Statement]:
+        """Visit a classical operation element.
+
+        Args:
+            statement (ClassicalType): The classical operation to visit.
+
+        Returns:
+            None
+        """
+
+        if isinstance(statement.type, o_pulse_ast.PortType):
+            print("TODO")
+            # check if identifier already exists and not empty
+            # create a port to qubit mapping in global scope (further-use)
+
+        if isinstance(statement.type, o_pulse_ast.FrameType):
+            print("TODO")
+            # check if identifier already exists and not empty
+
+            if statement.init_expression:
+                print("TODO")
+                frame_args = statement.init_expression.arguments
+                if not 3 <= len(frame_args) <= 4:
+                    print("ERROR")
+                new_frame = statement.init_expression.name.name
+                if new_frame != "newframe":
+                    print("ERROR")
+
+                # can be moved to function
+                port_arg = frame_args[0]
+                if not isinstance(port_arg, o_pulse_ast.Identifier):
+                    print("ERROR")
+                else:
+                    print("TODO")
+                # check if identifier already exists in global scope
+
+                freq_arg = frame_args[1]
+                if isinstance(freq_arg, o_pulse_ast.Identifier):
+                    print("TODO")
+                    # evaluate expression
+                    # store as class level value using frame class
+                elif isinstance(freq_arg, float):
+                    print("TODO")
+                    # store as class level value using frame class
+                else:
+                    print("ERROR")
+
+                phase_arg = frame_args[2]
+                if isinstance(phase_arg, o_pulse_ast.Identifier):
+                    print("TODO")
+                    # evaluate expression
+                    # store as class level value using frame class
+                elif isinstance(phase_arg, o_pulse_ast.AngleType):
+                    print("TODO")
+                    # store as class level value using frame class
+                else:
+                    print("ERROR")
+
+                if len(frame_args) == 4:
+                    time_arg = frame_args[3]
+                    if isinstance(time_arg, o_pulse_ast.Identifier):
+                        print("TODO")
+                        # evaluate expression
+                        # store as class level value using frame class
+                    elif isinstance(time_arg, o_pulse_ast.DurationType):
+                        print("TODO")
+                        # store as class level value using frame class
+                    else:
+                        print("ERROR")
+
+                # all this data can access through class level frame object
+                # Frame(frame_name, freq, pulse, time)
+
+        if isinstance(statement.type, o_pulse_ast.WaveformType):
+            print("TODO")
+            if statement.init_expression:
+                id_func_name = statement.init_expression.name.name
+                if id_func_name == "gaussian":
+                    wave_form_args = statement.init_expression.arguments
+                    if len(wave_form_args) == 3:
+                        amp_arg = wave_form_args[0]
+                        if isinstance(amp_arg, o_pulse_ast.ComplexType):
+                            print("TODO")
+                        elif isinstance(amp_arg, o_pulse_ast.Identifier):
+                            print("TODO")
+                        else:
+                            print("ERROR")
+                        duration_arg = wave_form_args[1]
+                        if isinstance(duration_arg, o_pulse_ast.DurationType):
+                            print("TODO")
+                        elif isinstance(duration_arg, o_pulse_ast.Identifier):
+                            print("TODO")
+                        else:
+                            print("ERROR")
+                        std_deviation_arg = wave_form_args[2]
+                        if isinstance(std_deviation_arg, o_pulse_ast.DurationType):
+                            print("TODO")
+                        elif isinstance(std_deviation_arg, o_pulse_ast.Identifier):
+                            print("TODO")
+                        else:
+                            print("ERROR")
+                    else:
+                        print("ERROR")
+
+                if id_func_name == "sech":
+                    print("TODO")
+                if id_func_name == "gaussian_square":
+                    print("TODO")
+                if id_func_name == "drag":
+                    print("TODO")
+                if id_func_name == "constant":
+                    print("TODO")
+                if id_func_name == "sine":
+                    print("TODO")
+                if id_func_name == "mix":
+                    print("TODO")
+                if id_func_name == "sum":
+                    print("TODO")
+                if id_func_name == "phase_shift":
+                    print("TODO")
+                if id_func_name == "scale":
+                    print("TODO")
+
+                ## Add all waveforms to global scope
+
+        if self._check_only:
+            return []
+
+        return []
+
+    def _visit_function_call(
+        self, statement: o_pulse_ast.FunctionCall
+    ) -> tuple[Any, list[o_pulse_ast.Statement]]:
+        """Visit a function call element.
+
+        Args:
+            statement (o_pulse_ast.FunctionCall): The function call to visit.
+        Returns:
+            None
+
+        """
+        # evaluate expressions to get name
+        if statement.name.name == "set_phase":
+            stmt_args = statement.arguments
+            if len(stmt_args) == 2:
+                frame_arg = stmt_args[0]
+                if isinstance(frame_arg, o_pulse_ast.Identifier):
+                    print("TODO")
+                    # get frame object from global scope
+                else:
+                    print("ERROR")
+
+                angle_arg = stmt_args[1]
+                if isinstance(angle_arg, o_pulse_ast.Identifier):
+                    print("TODO")
+                    # evaluate expression to get value
+                elif isinstance(angle_arg, o_pulse_ast.AngleType):
+                    print("TODO")
+                else:
+                    print("ERROR")
+
+            # update frame.phase
+
+            else:
+                print("ERROR")
+        if statement.name.name == "get_phase":
+            print("TODO")
+        if statement.name.name == "shift_phase":
+            print("TODO")
+        if statement.name.name == "set_frequency":
+            print("TODO")
+        if statement.name.name == "get_frequency":
+            print("TODO")
+        if statement.name.name == "shift_frequency":
+            print("TODO")
+        if statement.name.name == "play":
+            print("TODO")
+            if not self._is_def_cal:
+                print("ERROR")
+            play_args = statement.arguments
+            if len(play_args) == 2:
+                frame_arg = play_args[0]
+                if isinstance(frame_arg, o_pulse_ast.Identifier):
+                    print("TODO")
+                    # check if frame declared and exists in global scope
+                else:
+                    print("ERROR")
+
+                wave_form_arg = play_args[1]
+                if isinstance(wave_form_arg, o_pulse_ast.Identifier):
+                    print("TODO")
+                    # check if frame declared and exists in global scope
+                elif isinstance(wave_form_arg, o_pulse_ast.WaveformType):
+                    print("TODO")
+                    # evaluate expression
+                else:
+                    print("ERROR")
+
+            else:
+                print("ERROR")
+
+        ## capture command update waveform
+        if statement.name.name == "capture_v0 ":
+            print("TODO")
+        if statement.name.name == "capture_v1 ":
+            print("TODO")
+        if statement.name.name == "capture_v2 ":
+            print("TODO")
+        if statement.name.name == "capture_v3 ":
+            print("TODO")
+        if statement.name.name == "capture_v4 ":
+            print("TODO")
+
+        if self._check_only:
+            return 0, []
+
+        return 0, []
+
+    def _visit_delay_instruction(
+        self, statement: o_pulse_ast.DelayInstruction
+    ) -> list[o_pulse_ast.Statement]:
+        """Visit a delay instruction statement.
+
+        Args:
+            statement (o_pulse_ast.DelayInstruction): The delay instruction statement to visit.
+        Returns:
+            None
+        """
+        if isinstance(statement.duration, o_pulse_ast.DurationLiteral):
+            print("TODO")
+            # evaluate expression
+        elif isinstance(statement.duration, o_pulse_ast.DurationType):
+            print("TODO")
+            # evaluate expression
+        else:
+            print("ERROR")
+
+        if statement.qubits:
+            print("TODO")
+            # evaluate expression
+            # check if frame exists in global scope
+        else:
+            print("ERROR")
+
+        if self._check_only:
+            return []
+
+        return []
+
+    def visit_statement(self, statement: o_pulse_ast.Statement) -> list[o_pulse_ast.Statement]:
+        """Visit a statement element.
+
+        Args:
+            statement (o_pulse_ast.Statement): The statement to visit.
+
+        Returns:
+            None
+        """
+        logger.debug("Visiting statement '%s'", str(statement))
+        result = []
+        visit_map = {
+            o_pulse_ast.QuantumBarrier: self._visit_barrier,
+            o_pulse_ast.ClassicalDeclaration: self._visit_classical_declaration,
+            o_pulse_ast.ExpressionStatement: lambda x: self._visit_function_call(x.expression),
+            o_pulse_ast.DelayInstruction: self._visit_delay_instruction,
+        }
+
+        visitor_function = visit_map.get(type(statement))
+
+        if visitor_function:
+            if isinstance(statement, o_pulse_ast.ExpressionStatement):
+                # these return a tuple of return value and list of statements
+                _, ret_stmts = visitor_function(statement)  # type: ignore[operator]
+                result.extend(ret_stmts)
+            else:
+                result.extend(visitor_function(statement))  # type: ignore[operator]
+        else:
+            raise_qasm3_error(
+                f"Unsupported statement of type {type(statement)}",
+                error_node=statement,
+                span=statement.span,
+            )
+        return result
+
+    def visit_basic_block(
+        self, stmt_list: list[o_pulse_ast.Statement]
+    ) -> list[o_pulse_ast.Statement]:
+        """Visit a basic block of statements.
+
+        Args:
+            stmt_list (list[o_pulse_ast.Statement]): The list of statements to visit.
+
+        Returns:
+            list[o_pulse_ast.Statement]: The list of unrolled statements.
+        """
+        result = []
+        for stmt in stmt_list:
+            result.extend(self.visit_statement(stmt))
+        return result

--- a/src/pyqasm/pulse/openpulse_visitor.py
+++ b/src/pyqasm/pulse/openpulse_visitor.py
@@ -21,7 +21,7 @@ Module defining OpenPulse Visitor.
 import logging
 from typing import Any
 
-import openpulse.ast as o_pulse_ast
+import openpulse.ast as pulse_ast
 
 from pyqasm.elements import Frame
 from pyqasm.exceptions import (
@@ -38,29 +38,28 @@ class OpenPulseVisitor:
     This class is designed to traverse and interact with elements in an OpenPulse program.
 
     Args:
-
+        visitor: The QasmVisitor instance that provides scope and context information.
+        check_only: If True, only check the program without executing it. Defaults to False.
     """
 
     def __init__(
         self,
-        module,
+        qasm_visitor,
         check_only: bool = False,
-        is_def_cal: bool = False,
     ):
-        self._module = module
+        self._qasm_visitor = qasm_visitor
+        self._module = qasm_visitor._module
         self._check_only: bool = check_only
         self._frames = list[Frame]
-        self._ports = list[o_pulse_ast.PortType]
-        self._waveforms = list[o_pulse_ast.WaveformType]
-        self._is_def_cal = is_def_cal
+        self._ports = list[pulse_ast.PortType]
+        self._waveforms = list[pulse_ast.WaveformType]
+        self._is_def_cal: bool = False
 
-    def _visit_barrier(
-        self, barrier: o_pulse_ast.QuantumBarrier
-    ) -> list[o_pulse_ast.QuantumBarrier]:
+    def _visit_barrier(self, barrier: pulse_ast.QuantumBarrier) -> list[pulse_ast.QuantumBarrier]:
         """Visit a barrier statement element.
 
         Args:
-            statement (o_pulse_ast.QuantumBarrier): The barrier statement to visit.
+            statement (pulse_ast.QuantumBarrier): The barrier statement to visit.
 
         Returns:
             None
@@ -74,8 +73,8 @@ class OpenPulseVisitor:
         return []
 
     def _visit_classical_declaration(
-        self, statement: o_pulse_ast.ClassicalDeclaration
-    ) -> list[o_pulse_ast.Statement]:
+        self, statement: pulse_ast.ClassicalDeclaration
+    ) -> list[pulse_ast.Statement]:
         """Visit a classical operation element.
 
         Args:
@@ -85,12 +84,12 @@ class OpenPulseVisitor:
             None
         """
 
-        if isinstance(statement.type, o_pulse_ast.PortType):
+        if isinstance(statement.type, pulse_ast.PortType):
             print("TODO")
             # check if identifier already exists and not empty
             # create a port to qubit mapping in global scope (further-use)
 
-        if isinstance(statement.type, o_pulse_ast.FrameType):
+        if isinstance(statement.type, pulse_ast.FrameType):
             print("TODO")
             # check if identifier already exists and not empty
 
@@ -105,14 +104,14 @@ class OpenPulseVisitor:
 
                 # can be moved to function
                 port_arg = frame_args[0]
-                if not isinstance(port_arg, o_pulse_ast.Identifier):
+                if not isinstance(port_arg, pulse_ast.Identifier):
                     print("ERROR")
                 else:
                     print("TODO")
                 # check if identifier already exists in global scope
 
                 freq_arg = frame_args[1]
-                if isinstance(freq_arg, o_pulse_ast.Identifier):
+                if isinstance(freq_arg, pulse_ast.Identifier):
                     print("TODO")
                     # evaluate expression
                     # store as class level value using frame class
@@ -123,11 +122,11 @@ class OpenPulseVisitor:
                     print("ERROR")
 
                 phase_arg = frame_args[2]
-                if isinstance(phase_arg, o_pulse_ast.Identifier):
+                if isinstance(phase_arg, pulse_ast.Identifier):
                     print("TODO")
                     # evaluate expression
                     # store as class level value using frame class
-                elif isinstance(phase_arg, o_pulse_ast.AngleType):
+                elif isinstance(phase_arg, pulse_ast.AngleType):
                     print("TODO")
                     # store as class level value using frame class
                 else:
@@ -135,11 +134,11 @@ class OpenPulseVisitor:
 
                 if len(frame_args) == 4:
                     time_arg = frame_args[3]
-                    if isinstance(time_arg, o_pulse_ast.Identifier):
+                    if isinstance(time_arg, pulse_ast.Identifier):
                         print("TODO")
                         # evaluate expression
                         # store as class level value using frame class
-                    elif isinstance(time_arg, o_pulse_ast.DurationType):
+                    elif isinstance(time_arg, pulse_ast.DurationType):
                         print("TODO")
                         # store as class level value using frame class
                     else:
@@ -148,7 +147,7 @@ class OpenPulseVisitor:
                 # all this data can access through class level frame object
                 # Frame(frame_name, freq, pulse, time)
 
-        if isinstance(statement.type, o_pulse_ast.WaveformType):
+        if isinstance(statement.type, pulse_ast.WaveformType):
             print("TODO")
             if statement.init_expression:
                 id_func_name = statement.init_expression.name.name
@@ -156,23 +155,23 @@ class OpenPulseVisitor:
                     wave_form_args = statement.init_expression.arguments
                     if len(wave_form_args) == 3:
                         amp_arg = wave_form_args[0]
-                        if isinstance(amp_arg, o_pulse_ast.ComplexType):
+                        if isinstance(amp_arg, pulse_ast.ComplexType):
                             print("TODO")
-                        elif isinstance(amp_arg, o_pulse_ast.Identifier):
+                        elif isinstance(amp_arg, pulse_ast.Identifier):
                             print("TODO")
                         else:
                             print("ERROR")
                         duration_arg = wave_form_args[1]
-                        if isinstance(duration_arg, o_pulse_ast.DurationType):
+                        if isinstance(duration_arg, pulse_ast.DurationType):
                             print("TODO")
-                        elif isinstance(duration_arg, o_pulse_ast.Identifier):
+                        elif isinstance(duration_arg, pulse_ast.Identifier):
                             print("TODO")
                         else:
                             print("ERROR")
                         std_deviation_arg = wave_form_args[2]
-                        if isinstance(std_deviation_arg, o_pulse_ast.DurationType):
+                        if isinstance(std_deviation_arg, pulse_ast.DurationType):
                             print("TODO")
-                        elif isinstance(std_deviation_arg, o_pulse_ast.Identifier):
+                        elif isinstance(std_deviation_arg, pulse_ast.Identifier):
                             print("TODO")
                         else:
                             print("ERROR")
@@ -206,12 +205,12 @@ class OpenPulseVisitor:
         return []
 
     def _visit_function_call(
-        self, statement: o_pulse_ast.FunctionCall
-    ) -> tuple[Any, list[o_pulse_ast.Statement]]:
+        self, statement: pulse_ast.FunctionCall
+    ) -> tuple[Any, list[pulse_ast.Statement]]:
         """Visit a function call element.
 
         Args:
-            statement (o_pulse_ast.FunctionCall): The function call to visit.
+            statement (pulse_ast.FunctionCall): The function call to visit.
         Returns:
             None
 
@@ -221,17 +220,17 @@ class OpenPulseVisitor:
             stmt_args = statement.arguments
             if len(stmt_args) == 2:
                 frame_arg = stmt_args[0]
-                if isinstance(frame_arg, o_pulse_ast.Identifier):
+                if isinstance(frame_arg, pulse_ast.Identifier):
                     print("TODO")
                     # get frame object from global scope
                 else:
                     print("ERROR")
 
                 angle_arg = stmt_args[1]
-                if isinstance(angle_arg, o_pulse_ast.Identifier):
+                if isinstance(angle_arg, pulse_ast.Identifier):
                     print("TODO")
                     # evaluate expression to get value
-                elif isinstance(angle_arg, o_pulse_ast.AngleType):
+                elif isinstance(angle_arg, pulse_ast.AngleType):
                     print("TODO")
                 else:
                     print("ERROR")
@@ -257,17 +256,17 @@ class OpenPulseVisitor:
             play_args = statement.arguments
             if len(play_args) == 2:
                 frame_arg = play_args[0]
-                if isinstance(frame_arg, o_pulse_ast.Identifier):
+                if isinstance(frame_arg, pulse_ast.Identifier):
                     print("TODO")
                     # check if frame declared and exists in global scope
                 else:
                     print("ERROR")
 
                 wave_form_arg = play_args[1]
-                if isinstance(wave_form_arg, o_pulse_ast.Identifier):
+                if isinstance(wave_form_arg, pulse_ast.Identifier):
                     print("TODO")
                     # check if frame declared and exists in global scope
-                elif isinstance(wave_form_arg, o_pulse_ast.WaveformType):
+                elif isinstance(wave_form_arg, pulse_ast.WaveformType):
                     print("TODO")
                     # evaluate expression
                 else:
@@ -294,19 +293,19 @@ class OpenPulseVisitor:
         return 0, []
 
     def _visit_delay_instruction(
-        self, statement: o_pulse_ast.DelayInstruction
-    ) -> list[o_pulse_ast.Statement]:
+        self, statement: pulse_ast.DelayInstruction
+    ) -> list[pulse_ast.Statement]:
         """Visit a delay instruction statement.
 
         Args:
-            statement (o_pulse_ast.DelayInstruction): The delay instruction statement to visit.
+            statement (pulse_ast.DelayInstruction): The delay instruction statement to visit.
         Returns:
             None
         """
-        if isinstance(statement.duration, o_pulse_ast.DurationLiteral):
+        if isinstance(statement.duration, pulse_ast.DurationLiteral):
             print("TODO")
             # evaluate expression
-        elif isinstance(statement.duration, o_pulse_ast.DurationType):
+        elif isinstance(statement.duration, pulse_ast.DurationType):
             print("TODO")
             # evaluate expression
         else:
@@ -324,11 +323,11 @@ class OpenPulseVisitor:
 
         return []
 
-    def visit_statement(self, statement: o_pulse_ast.Statement) -> list[o_pulse_ast.Statement]:
+    def visit_statement(self, statement: pulse_ast.Statement) -> list[pulse_ast.Statement]:
         """Visit a statement element.
 
         Args:
-            statement (o_pulse_ast.Statement): The statement to visit.
+            statement (pulse_ast.Statement): The statement to visit.
 
         Returns:
             None
@@ -336,16 +335,16 @@ class OpenPulseVisitor:
         logger.debug("Visiting statement '%s'", str(statement))
         result = []
         visit_map = {
-            o_pulse_ast.QuantumBarrier: self._visit_barrier,
-            o_pulse_ast.ClassicalDeclaration: self._visit_classical_declaration,
-            o_pulse_ast.ExpressionStatement: lambda x: self._visit_function_call(x.expression),
-            o_pulse_ast.DelayInstruction: self._visit_delay_instruction,
+            pulse_ast.QuantumBarrier: self._visit_barrier,
+            pulse_ast.ClassicalDeclaration: self._visit_classical_declaration,
+            pulse_ast.ExpressionStatement: lambda x: self._visit_function_call(x.expression),
+            pulse_ast.DelayInstruction: self._visit_delay_instruction,
         }
 
         visitor_function = visit_map.get(type(statement))
 
         if visitor_function:
-            if isinstance(statement, o_pulse_ast.ExpressionStatement):
+            if isinstance(statement, pulse_ast.ExpressionStatement):
                 # these return a tuple of return value and list of statements
                 _, ret_stmts = visitor_function(statement)  # type: ignore[operator]
                 result.extend(ret_stmts)
@@ -360,17 +359,21 @@ class OpenPulseVisitor:
         return result
 
     def visit_basic_block(
-        self, stmt_list: list[o_pulse_ast.Statement]
-    ) -> list[o_pulse_ast.Statement]:
+        self,
+        stmt_list: list[pulse_ast.Statement],
+        is_def_cal: bool,
+    ) -> list[pulse_ast.Statement]:
         """Visit a basic block of statements.
 
         Args:
-            stmt_list (list[o_pulse_ast.Statement]): The list of statements to visit.
+            stmt_list (list[pulse_ast.Statement]): The list of statements to visit.
+            is_def_cal (bool): is the given statements from def_cal block.
 
         Returns:
-            list[o_pulse_ast.Statement]: The list of unrolled statements.
+            list[pulse_ast.Statement]: The list of unrolled statements.
         """
         result = []
+        self._is_def_cal = is_def_cal
         for stmt in stmt_list:
             result.extend(self.visit_statement(stmt))
         return result

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -59,7 +59,7 @@ from pyqasm.maps.gates import (
     map_qasm_op_num_params,
     map_qasm_op_to_callable,
 )
-from pyqasm.openpulse_visitor import OpenPulseVisitor
+from pyqasm.pulse.openpulse_visitor import OpenPulseVisitor
 from pyqasm.subroutines import Qasm3SubroutineProcessor
 from pyqasm.transformer import Qasm3Transformer
 from pyqasm.validator import Qasm3Validator
@@ -124,6 +124,7 @@ class QasmVisitor:
         self._in_generic_gate_op_scope: int = 0
         self._qubit_register_offsets: OrderedDict = OrderedDict()
         self._qubit_register_max_offset = 0
+        self._pulse_visitor = OpenPulseVisitor(qasm_visitor=self, check_only=check_only)
 
     def _init_utilities(self):
         """Initialize the utilities for the visitor."""
@@ -2527,9 +2528,7 @@ class QasmVisitor:
 
         result = []
         calibration_stmts: list[openpulse_ast.Statement] = block_body.body
-        pulse_visitor = OpenPulseVisitor(module=self, is_def_cal=True)
-
-        result.extend(pulse_visitor.visit_basic_block(calibration_stmts))
+        result.extend(self._pulse_visitor.visit_basic_block(calibration_stmts, is_def_cal=True))
 
         return result
 
@@ -2550,9 +2549,7 @@ class QasmVisitor:
 
         result = []
         calibration_stmts: list[openpulse_ast.Statement] = block_body.body
-        pulse_visitor = OpenPulseVisitor(module=self)
-
-        result.extend(pulse_visitor.visit_basic_block(calibration_stmts))
+        result.extend(self._pulse_visitor.visit_basic_block(calibration_stmts, is_def_cal=False))
 
         return result
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
 skip_missing_interpreter = true
 
 [testenv]
-commands_pre = python -m pip install '.[visualization]'
+commands_pre = python -m pip install '.[visualization, pulse]'
 basepython = python3
 
 [testenv:unit-tests]


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

## Summary of changes

This PR introduces the initial implementation of the `OpenPulseVisitor`. This visitor is designed to traverse and interact with elements in an `OpenPulse` program, providing a foundation for OpenPulse AST handling within the pyqasm framework.
This foundational work sets up the structure for `OpenPulse` support in pyqasm, enabling future development of OpenPulse parsing, validation, and transformation features. The current implementation provides scaffolding and type checks, with detailed TODOs for each OpenPulse construct.
- Implement the detailed logic for each visitor method (frame/port/waveform management, function call evaluation, etc.).
- Integrate with the rest of the pyqasm pipeline for end-to-end OpenPulse support.

Fixes #183 