### PR TITLE
Add `ScopeManager` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,13 @@ Types of changes:
 - A new discussion template for issues in pyqasm ([#213](https://github.com/qBraid/pyqasm/pull/213))
 - A github workflow for validating `CHANGELOG` updates in a PR ([#214](https://github.com/qBraid/pyqasm/pull/214))
 - Added `unroll` command support in PYQASM CLI with options skipping files, overwriting originals files, and specifying output paths.([#224](https://github.com/qBraid/pyqasm/pull/224))
+
 ### Improved / Modified
 - Added `slots=True` parameter to the data classes in `elements.py` to improve memory efficiency ([#218](https://github.com/qBraid/pyqasm/pull/218))
 - Updated the documentation to include core features in the `README` ([#219](https://github.com/qBraid/pyqasm/pull/219))
 - Added support to `device qubit` resgister consolidation.([#222](https://github.com/qBraid/pyqasm/pull/222))
+- Updated the scoping of variables in `QasmVisitor` using a `ScopeManager`. This change is introduced to ensure that the `QasmVisitor` and the `PulseVisitor` can share the same `ScopeManager` instance, allowing for consistent variable scoping across different visitors. No change in the user API is expected. ([#232](https://github.com/qBraid/pyqasm/pull/232))
+
 
 ### Deprecated
 

--- a/src/pyqasm/__init__.py
+++ b/src/pyqasm/__init__.py
@@ -45,6 +45,7 @@ Exceptions
 .. autosummary::
    :toctree: ../stubs/
 
+   LoopLimitExceededError
    PyQasmError
    ValidationError
    QasmParsingError

--- a/src/pyqasm/elements.py
+++ b/src/pyqasm/elements.py
@@ -103,6 +103,7 @@ class Variable:  # pylint: disable=too-many-instance-attributes
     span: Any = None
     is_constant: bool = False
     is_register: bool = False
+    is_alias: bool = False
     readonly: bool = False
 
 

--- a/src/pyqasm/elements.py
+++ b/src/pyqasm/elements.py
@@ -90,8 +90,10 @@ class Variable:  # pylint: disable=too-many-instance-attributes
         dims (Optional[List[int]]): Dimensions of the variable.
         value (Optional[int | float | np.ndarray]): Value of the variable.
         span (Any): Span of the variable.
+        shadow (bool): Flag indicating if the current variable is shadowed from its parent scope.
         is_constant (bool): Flag indicating if the variable is constant.
         is_register (bool): Flag indicating if the variable is a register.
+        is_alias (bool): Flag indicating if the variable is an alias.
         readonly (bool): Flag indicating if the variable is readonly.
     """
 
@@ -101,8 +103,9 @@ class Variable:  # pylint: disable=too-many-instance-attributes
     dims: Optional[list[int]] = None
     value: Optional[int | float | np.ndarray] = None
     span: Any = None
+    shadow: bool = False
     is_constant: bool = False
-    is_register: bool = False
+    is_qubit: bool = False
     is_alias: bool = False
     readonly: bool = False
 

--- a/src/pyqasm/expressions.py
+++ b/src/pyqasm/expressions.py
@@ -260,9 +260,8 @@ class Qasm3ExprEvaluator:
             if isinstance(target, Identifier):
                 var_name = target.name
                 cls._check_var_in_scope(var_name, expression)
-                dimensions = cls.visitor_obj._scope_manager.get_from_visible_scope(  # type: ignore[union-attr]
-                    var_name
-                ).dims
+                assert cls.visitor_obj
+                dimensions = cls.visitor_obj._scope_manager.get_from_visible_scope(var_name).dims
             else:
                 raise_qasm3_error(
                     message=f"Unsupported target type '{type(target)}' for sizeof expression",

--- a/src/pyqasm/expressions.py
+++ b/src/pyqasm/expressions.py
@@ -68,7 +68,7 @@ class Qasm3ExprEvaluator:
             ValidationError: If the variable is undefined in the current scope.
         """
 
-        if not cls.visitor_obj._check_in_scope(var_name):
+        if not cls.visitor_obj._scope_manager.check_in_scope(var_name):
             raise_qasm3_error(
                 f"Undefined identifier '{var_name}' in expression",
                 err_type=ValidationError,
@@ -89,7 +89,7 @@ class Qasm3ExprEvaluator:
             ValidationError: If the variable is not a constant in the given
                                 expression.
         """
-        const_var = cls.visitor_obj._get_from_visible_scope(var_name).is_constant
+        const_var = cls.visitor_obj._scope_manager.get_from_visible_scope(var_name).is_constant
         if const_expr and not const_var:
             raise_qasm3_error(
                 f"Expected variable '{var_name}' to be constant in given expression",
@@ -111,7 +111,7 @@ class Qasm3ExprEvaluator:
         Raises:
             ValidationError: If the variable has an invalid type for the required type.
         """
-        var = cls.visitor_obj._get_from_visible_scope(var_name)
+        var = cls.visitor_obj._scope_manager.get_from_visible_scope(var_name)
         if not Qasm3Validator.validate_variable_type(var, reqd_type):
             raise_qasm3_error(
                 message=f"Invalid type '{var.base_type}' of variable '{var_name}' for "
@@ -155,13 +155,14 @@ class Qasm3ExprEvaluator:
 
         var_value = None
         if isinstance(expression, Identifier):
-            var_value = cls.visitor_obj._get_from_visible_scope(var_name).value
+            var_value = cls.visitor_obj._scope_manager.get_from_visible_scope(var_name).value
         else:
             validated_indices = Qasm3Analyzer.analyze_classical_indices(
-                indices, cls.visitor_obj._get_from_visible_scope(var_name), cls
+                indices, cls.visitor_obj._scope_manager.get_from_visible_scope(var_name), cls
             )
             var_value = Qasm3Analyzer.find_array_element(
-                cls.visitor_obj._get_from_visible_scope(var_name).value, validated_indices
+                cls.visitor_obj._scope_manager.get_from_visible_scope(var_name).value,
+                validated_indices,
             )
         return var_value
 
@@ -259,7 +260,7 @@ class Qasm3ExprEvaluator:
             if isinstance(target, Identifier):
                 var_name = target.name
                 cls._check_var_in_scope(var_name, expression)
-                dimensions = cls.visitor_obj._get_from_visible_scope(  # type: ignore[union-attr]
+                dimensions = cls.visitor_obj._scope_manager.get_from_visible_scope(  # type: ignore[union-attr]
                     var_name
                 ).dims
             else:

--- a/src/pyqasm/modules/base.py
+++ b/src/pyqasm/modules/base.py
@@ -29,7 +29,7 @@ from pyqasm.elements import ClbitDepthNode, QubitDepthNode
 from pyqasm.exceptions import UnrollError, ValidationError
 from pyqasm.maps import QUANTUM_STATEMENTS
 from pyqasm.maps.decomposition_rules import DECOMPOSITION_RULES
-from pyqasm.visitor import QasmVisitor
+from pyqasm.visitor import QasmVisitor, ScopeManager
 
 
 class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
@@ -519,7 +519,7 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
             return
         try:
             self.num_qubits, self.num_clbits = 0, 0
-            visitor = QasmVisitor(self, check_only=True)
+            visitor = QasmVisitor(self, ScopeManager(), check_only=True)
             self.accept(visitor)
             # Implicit validation: check total qubits if device_qubits is set and not consolidating
             if self._device_qubits:
@@ -566,7 +566,7 @@ class QasmModule(ABC):  # pylint: disable=too-many-instance-attributes
                 self._external_gates = []
             if consolidate_qbts := kwargs.get("consolidate_qubits"):
                 self._consolidate_qubits = consolidate_qbts
-            visitor = QasmVisitor(module=self, **kwargs)
+            visitor = QasmVisitor(module=self, scope_manager=ScopeManager(), **kwargs)
             self.accept(visitor)
         except (ValidationError, UnrollError) as err:
             # reset the unrolled ast and qasm

--- a/src/pyqasm/scope.py
+++ b/src/pyqasm/scope.py
@@ -118,13 +118,23 @@ class ScopeManager:
 
     def check_in_scope(self, var_name: str) -> bool:
         """
-        Check if a variable is visible in the current scope.
-
+        Checks if a variable is in scope.
         Args:
             var_name (str): The name of the variable to check.
-
         Returns:
             bool: True if the variable is in scope, False otherwise.
+        NOTE:
+            - According to our definition of scope, we have a NEW DICT
+            for each block scope
+            - Since all visible variables of the immediate parent are visible
+            inside block scope, we have to check till we reach the boundary
+            contexts
+            - The "boundary" for a scope is either a FUNCTION / GATE context
+            OR the GLOBAL context
+            - Why then do we need a new scope for a block?
+            - Well, if the block redeclares a variable in its scope, then the
+            variable in the parent scope is shadowed. We need to remember the
+            original value of the shadowed variable when we exit the block scope
         """
         global_scope = self.get_global_scope()
         curr_scope = self.get_curr_scope()

--- a/src/pyqasm/scope.py
+++ b/src/pyqasm/scope.py
@@ -37,7 +37,6 @@ class ScopeManager:
         self._scope: deque = deque([{}])
         self._context: deque = deque([Context.GLOBAL])
         self._scope_level: int = 0
-        self._label_scope_level: dict[int, set] = {self._scope_level: set()}
 
     def push_scope(self, scope: dict) -> None:
         """Push a new scope dictionary onto the scope stack."""
@@ -135,7 +134,7 @@ class ScopeManager:
             if var_name in curr_scope:
                 return True
             if var_name in global_scope:
-                return global_scope[var_name].is_constant
+                return global_scope[var_name].is_constant or global_scope[var_name].is_qubit
         if self.in_block_scope():
             for scope, context in zip(reversed(self._scope), reversed(self._context)):
                 if context != Context.BLOCK:

--- a/src/pyqasm/scope_manager.py
+++ b/src/pyqasm/scope_manager.py
@@ -1,0 +1,226 @@
+# Copyright 2025 qBraid
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Module defining the ScopeManager class for managing variable scopes and contexts.
+This class provides methods for pushing/popping scopes and contexts,
+checking variable visibility, and updating variable values.
+"""
+
+from collections import deque
+
+from pyqasm.elements import Context, Variable
+
+
+class ScopeManager:
+    """
+    Manages variable scopes and contexts for QasmVisitor and PulseVisitor.
+
+    This class provides methods for pushing/popping scopes and contexts,
+    checking variable visibility, and updating variable values.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the ScopeManager with a global scope and context."""
+        self._scope: deque = deque([{}])
+        self._context: deque = deque([Context.GLOBAL])
+        self._scope_level: int = 0
+        self._label_scope_level: dict[int, set] = {self._scope_level: set()}
+
+    def push_scope(self, scope: dict) -> None:
+        """Push a new scope dictionary onto the scope stack."""
+        if not isinstance(scope, dict):
+            raise TypeError("Scope must be a dictionary")
+        self._scope.append(scope)
+
+    def pop_scope(self) -> None:
+        """Pop the top scope dictionary from the scope stack."""
+        if len(self._scope) == 0:
+            raise IndexError("Scope list is empty, cannot pop")
+        self._scope.pop()
+
+    def push_context(self, context: Context) -> None:
+        """Push a new context onto the context stack."""
+        if not isinstance(context, Context):
+            raise TypeError("Context must be an instance of Context")
+        self._context.append(context)
+
+    def restore_context(self) -> None:
+        """Pop the top context from the context stack."""
+        if len(self._context) == 0:
+            raise IndexError("Context list is empty, cannot pop")
+        self._context.pop()
+
+    def get_parent_scope(self) -> dict:
+        """Get the parent scope dictionary."""
+        if len(self._scope) < 2:
+            raise IndexError("Parent scope not available")
+        return self._scope[-2]
+
+    def get_curr_scope(self) -> dict:
+        """Get the current scope dictionary."""
+        if len(self._scope) == 0:
+            raise IndexError("No scopes available to get")
+        return self._scope[-1]
+
+    def get_scope_level(self) -> int:
+        """Get the current scope level."""
+        return self._scope_level
+
+    def increment_scope_level(self) -> None:
+        """Increment the current scope level."""
+        self._scope_level += 1
+
+    def decrement_scope_level(self) -> None:
+        """Decrement the current scope level."""
+        if self._scope_level == 0:
+            raise ValueError("Cannot decrement scope level below 0")
+        self._scope_level -= 1
+
+    def get_curr_context(self) -> Context:
+        """Get the current context."""
+        if len(self._context) == 0:
+            raise IndexError("No context available to get")
+        return self._context[-1]
+
+    def get_global_scope(self) -> dict:
+        """Get the global scope dictionary."""
+        if len(self._scope) == 0:
+            raise IndexError("No scopes available to get")
+        return self._scope[0]
+
+    def in_global_scope(self) -> bool:
+        """Check if currently in the global scope."""
+        return len(self._scope) == 1 and self.get_curr_context() == Context.GLOBAL
+
+    def in_function_scope(self) -> bool:
+        """Check if currently in a function scope."""
+        return len(self._scope) > 1 and self.get_curr_context() == Context.FUNCTION
+
+    def in_gate_scope(self) -> bool:
+        """Check if currently in a gate scope."""
+        return len(self._scope) > 1 and self.get_curr_context() == Context.GATE
+
+    def in_block_scope(self) -> bool:
+        """Check if currently in a block scope (if/else/for/while)."""
+        return len(self._scope) > 1 and self.get_curr_context() == Context.BLOCK
+
+    def check_in_scope(self, var_name: str) -> bool:
+        """
+        Check if a variable is visible in the current scope.
+
+        Args:
+            var_name (str): The name of the variable to check.
+
+        Returns:
+            bool: True if the variable is in scope, False otherwise.
+        """
+        global_scope = self.get_global_scope()
+        curr_scope = self.get_curr_scope()
+        if self.in_global_scope():
+            return var_name in global_scope
+        if self.in_function_scope() or self.in_gate_scope():
+            if var_name in curr_scope:
+                return True
+            if var_name in global_scope:
+                return global_scope[var_name].is_constant
+        if self.in_block_scope():
+            for scope, context in zip(reversed(self._scope), reversed(self._context)):
+                if context != Context.BLOCK:
+                    return var_name in scope
+                if var_name in scope:
+                    return True
+        return False
+
+    def check_in_global_scope(self, var_name: str) -> bool:
+        """
+        Check if a variable is visible in the global scope.
+
+        Args:
+            var_name (str): The name of the variable to check.
+
+        Returns:
+            bool: True if the variable is in the global scope, False otherwise.
+        """
+        return var_name in self.get_global_scope()
+
+    def get_from_visible_scope(self, var_name: str) -> Variable | None:
+        """
+        Retrieve a variable from the visible scope.
+
+        Args:
+            var_name (str): The name of the variable to retrieve.
+
+        Returns:
+            Variable | None: The variable if found, None otherwise.
+        """
+        global_scope = self.get_global_scope()
+        curr_scope = self.get_curr_scope()
+        if self.in_global_scope():
+            return global_scope.get(var_name, None)
+        if self.in_function_scope() or self.in_gate_scope():
+            if var_name in curr_scope:
+                return curr_scope[var_name]
+            if var_name in global_scope and global_scope[var_name].is_constant:
+                return global_scope[var_name]
+        if self.in_block_scope():
+            for scope, context in zip(reversed(self._scope), reversed(self._context)):
+                if context != Context.BLOCK:
+                    return scope.get(var_name, None)
+                if var_name in scope:
+                    return scope[var_name]
+        return None
+
+    def add_var_in_scope(self, variable: Variable) -> None:
+        """
+        Add a variable to the current scope.
+
+        Args:
+            variable (Variable): The variable to add.
+
+        Raises:
+            ValueError: If the variable already exists in the current scope.
+        """
+        curr_scope = self.get_curr_scope()
+        if variable.name in curr_scope:
+            raise ValueError(f"Variable '{variable.name}' already exists in current scope")
+        curr_scope[variable.name] = variable
+
+    def update_var_in_scope(self, variable: Variable) -> None:
+        """
+        Update the variable in the current scope.
+
+        Args:
+            variable (Variable): The variable to be updated.
+
+        Raises:
+            ValueError: If no scope is available to update.
+        """
+        if len(self._scope) == 0:
+            raise ValueError("No scope available to update")
+        global_scope = self.get_global_scope()
+        curr_scope = self.get_curr_scope()
+        if self.in_global_scope():
+            global_scope[variable.name] = variable
+        if self.in_function_scope() or self.in_gate_scope():
+            curr_scope[variable.name] = variable
+        if self.in_block_scope():
+            for scope, context in zip(reversed(self._scope), reversed(self._context)):
+                if context != Context.BLOCK:
+                    scope[variable.name] = variable
+                    break
+                if variable.name in scope:
+                    scope[variable.name] = variable
+                    break
+                continue

--- a/src/pyqasm/subroutines.py
+++ b/src/pyqasm/subroutines.py
@@ -419,7 +419,7 @@ class Qasm3SubroutineProcessor:
                 error_node=fn_call,
                 span=fn_call.span,
             )
-        cls.visitor_obj._label_scope_level[cls.visitor_obj._curr_scope].add(formal_reg_name)
+        # cls.visitor_obj._label_scope_level[cls.visitor_obj._curr_scope].add(formal_reg_name)
 
         actual_qids, actual_qubits_size = Qasm3Transformer.get_target_qubits(
             actual_arg, cls.visitor_obj._global_qreg_size_map, actual_arg_name

--- a/src/pyqasm/subroutines.py
+++ b/src/pyqasm/subroutines.py
@@ -455,6 +455,7 @@ class Qasm3SubroutineProcessor:
             base_size=formal_qubit_size,
             dims=None,
             value=None,
+            is_qubit=True,
             is_constant=False,
             span=fn_call.span,
         )

--- a/src/pyqasm/subroutines.py
+++ b/src/pyqasm/subroutines.py
@@ -138,7 +138,7 @@ class Qasm3SubroutineProcessor:
 
             # 2. as we have pushed the scope for fn, we need to check in parent
             #    scope for argument validation
-            if not cls.visitor_obj._check_in_scope(actual_arg_name):
+            if not cls.visitor_obj._scope_manager.check_in_scope(actual_arg_name):
                 raise_qasm3_error(
                     f"Undefined variable '{actual_arg_name}' used"
                     f" for function call '{fn_name}'\n"
@@ -216,7 +216,7 @@ class Qasm3SubroutineProcessor:
             )
 
         # verify actual argument is defined in the parent scope of function call
-        if not cls.visitor_obj._check_in_scope(actual_arg_name):
+        if not cls.visitor_obj._scope_manager.check_in_scope(actual_arg_name):
             raise_qasm3_error(
                 f"Undefined variable '{actual_arg_name}' used for function call '{fn_name}'\n"
                 + f"\nUsage: {fn_name} ( {formal_args_desc} )\n",
@@ -224,7 +224,7 @@ class Qasm3SubroutineProcessor:
                 span=fn_call.span,
             )
 
-        array_reference = cls.visitor_obj._get_from_visible_scope(actual_arg_name)
+        array_reference = cls.visitor_obj._scope_manager.get_from_visible_scope(actual_arg_name)
         actual_type_string = Qasm3Transformer.get_type_string(array_reference)
 
         # ensure that actual argument is an array
@@ -419,7 +419,6 @@ class Qasm3SubroutineProcessor:
                 error_node=fn_call,
                 span=fn_call.span,
             )
-        # cls.visitor_obj._label_scope_level[cls.visitor_obj._curr_scope].add(formal_reg_name)
 
         actual_qids, actual_qubits_size = Qasm3Transformer.get_target_qubits(
             actual_arg, cls.visitor_obj._global_qreg_size_map, actual_arg_name

--- a/src/pyqasm/transformer.py
+++ b/src/pyqasm/transformer.py
@@ -343,7 +343,6 @@ class Qasm3Transformer:
     def transform_function_qubits(
         cls,
         q_op: QuantumGate | QuantumBarrier | QuantumReset | QuantumPhase,
-        formal_qreg_sizes: dict[str, int],
         qubit_map: dict[tuple, tuple],
     ) -> list[IndexedIdentifier]:
         """Transform the qubits of a function call to the actual qubits.
@@ -357,7 +356,7 @@ class Qasm3Transformer:
         Returns:
             None
         """
-        expanded_op_qubits = cls.visitor_obj._get_op_bits(q_op, formal_qreg_sizes)
+        expanded_op_qubits = cls.visitor_obj._get_op_bits(q_op)
 
         transformed_qubits = []
         for qubit in expanded_op_qubits:

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -953,6 +953,7 @@ class QasmVisitor:
         if inverse:
             gate_definition_ops.reverse()
 
+        self._scope_manager.push_scope({})
         self._scope_manager.push_context(Context.GATE)
 
         # Pause recording the depth of new gates because we are processing the
@@ -1002,6 +1003,7 @@ class QasmVisitor:
                         qubit_idx = Qasm3ExprEvaluator.evaluate_expression(qubit.indices[0][0])[0]
                         self._is_branch_qubits.add((qubit.name.name, qubit_idx))
 
+        self._scope_manager.pop_scope()
         self._scope_manager.restore_context()
 
         if self._check_only:

--- a/tests/qasm3/subroutines/test_subroutines.py
+++ b/tests/qasm3/subroutines/test_subroutines.py
@@ -301,7 +301,7 @@ def test_function_call_from_within_fn():
 
 
 @pytest.mark.skip(reason="Bug: qubit in function scope conflicts with global scope")
-def test_return_values_from_function():
+def test_qubit_renaming_in_formal_params():
     """Test that the values returned from a function are used correctly in other function."""
     qasm_str = """OPENQASM 3.0;
     include "stdgates.inc";

--- a/tests/qasm3/test_alias.py
+++ b/tests/qasm3/test_alias.py
@@ -303,7 +303,7 @@ def test_alias_out_of_scope(caplog):
     """Test converting OpenQASM 3 program with alias out of scope."""
     with pytest.raises(
         ValidationError,
-        match="Variable 'alias' not in scope for QuantumGate 'cx'",
+        match="Missing qubit register declaration for 'alias'",
     ):
         with caplog.at_level("ERROR"):
             qasm3_alias_program = """


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->
Fixes #230 

## Summary of changes

* Introduced a new `ScopeManager` class to handle variable scopes and contexts, including methods for pushing/popping scopes, checking variable visibility, and updating variable values. (`src/pyqasm/scope_manager.py`)
* Updated the `QasmVisitor` class to use the `ScopeManager` for all scope-related operations, replacing its internal scope and context management logic. (`src/pyqasm/visitor.py`) [[1]](diffhunk://#diff-802ca57af29fc92ca8eb2f536fb5217c61c874c4c35bd39b7fd82512ee0e9a84L75-L95) [[2]](diffhunk://#diff-802ca57af29fc92ca8eb2f536fb5217c61c874c4c35bd39b7fd82512ee0e9a84L110-L111) [[3]](diffhunk://#diff-802ca57af29fc92ca8eb2f536fb5217c61c874c4c35bd39b7fd82512ee0e9a84R122-R175)

- [x] Fix `alias` bug 
- [x] Refactor scoping methods 