### PR TITLE
bugfix: add proper passthrough of calibration statements

### DIFF
--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -2538,6 +2538,8 @@ class QasmVisitor:
             qasm3_ast.ContinueStatement: self._visit_continue,
             qasm3_ast.DelayInstruction: self._visit_delay_statement,
             qasm3_ast.Box: self._visit_box_statement,
+            qasm3_ast.CalibrationStatement: lambda x: [x],
+            qasm3_ast.CalibrationDefinition: lambda x: [x],
         }
 
         visitor_function = visit_map.get(type(statement))


### PR DESCRIPTION
## Summary of changes

### Added Support for OpenQASM 3.0 Pulse Calibration Statements

This PR adds support for OpenQASM 3.0 pulse calibration statements (`cal { ... }` blocks and `defcal ... { ... }` definitions) in pyqasm. Previously, circuits containing these statements would fail during the unrolling process with "Unsupported statement" errors.

### Problem

The `visit_statement()` method in `src/pyqasm/visitor.py` had a `visit_map` dictionary that was missing handlers for:
- `openqasm3.ast.CalibrationStatement` (for `cal { ... }` blocks)  
- `openqasm3.ast.CalibrationDefinition` (for `defcal ... { ... }` definitions)

When processing pulse circuits, the visitor would encounter these node types and fail with:
```
ValueError: Unsupported statement of type <class 'openqasm3.ast.CalibrationStatement'>
```

This prevented pulse circuits from being processed by pyqasm.

### Solution

Added simple pass-through handlers for both calibration statement types in the `visit_map`:

```python
qasm3_ast.CalibrationStatement: lambda x: [x],  # Pass through calibration blocks unchanged
qasm3_ast.CalibrationDefinition: lambda x: [x],  # Pass through calibration definitions unchanged
```

These handlers preserve the calibration statements exactly as they are, allowing them to flow through the processing pipeline unchanged.

### Benefits

1. **Enables pulse circuit processing**: Circuits with `cal` blocks and `defcal` definitions can now be processed by pyqasm
2. **Maintains compatibility**: All existing functionality remains unchanged
3. **Minimal impact**: Only 2 lines added, no complex logic or validation
4. **Future-proof**: Works with any calibration syntax without requiring future updates

### Testing

- Added comprehensive tests in `tests/pulse/test_calibration_statements.py` covering:
  - Basic calibration statement loading and unrolling
  - Calibration definition loading and unrolling
  - Mixed calibration scenarios
  - Empty calibration blocks
- All existing tests continue to pass (525 passed, 4 skipped)
- Verified end-to-end processing of pulse circuits through pyqasm

### Integration

This fix enables better integration with Amazon Braket's pulse control capabilities and other quantum computing frameworks that use OpenQASM 3.0 calibration statements.
