### PR TITLE
Enhance function call handling to support nested functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,27 @@ Types of changes:
 - A new discussion template for issues in pyqasm ([#213](https://github.com/qBraid/pyqasm/pull/213))
 - A github workflow for validating `CHANGELOG` updates in a PR ([#214](https://github.com/qBraid/pyqasm/pull/214))
 - Added `unroll` command support in PYQASM CLI with options skipping files, overwriting originals files, and specifying output paths.([#224](https://github.com/qBraid/pyqasm/pull/224))
+- Added `Duration`,`Stretch` type, `Delay` and `Box` support for `OPENQASM3` code in pyqasm. ([#231](https://github.com/qBraid/pyqasm/pull/231))
+  ###### Example:
+  ```qasm
+  OPENQASM 3.0;
+  include "stdgates.inc";
+  qubit[3] q;
+  duration t1 = 200dt;
+  duration t2 = 300ns;
+  stretch s1;
+  delay[t1] q[0];
+  delay[t2] q[1];
+  delay[s1] q[0], q[2];
+  box [t2] {
+    h q[0];
+    cx q[0], q[1];
+    delay[100ns] q[2];
+  }
+  ```
+- Added a new `QasmModule.compare` method to compare two QASM modules, providing a detailed report of differences in gates, qubits, and measurements. This method is useful for comparing two identifying differences in QASM programs, their structure and operations. ([#233](https://github.com/qBraid/pyqasm/pull/233)) 
 - Added `.github/copilot-instructions.md` to the repository to document coding standards and design principles for pyqasm. This file provides detailed guidance on documentation, static typing, formatting, error handling, and adherence to the QASM specification for all code contributions. ([#234](https://github.com/qBraid/pyqasm/pull/234))
+- Added support for custom include statements in `OPENQASM3` code in pyqasm. This allows users to include custom files or libraries in their QASM programs, enhancing modularity and reusability of code. ([#236](https://github.com/qBraid/pyqasm/pull/236))
 - Added support for `Angle`,`extern` and `Complex` type in `OPENQASM3` code in pyqasm. ([#239](https://github.com/qBraid/pyqasm/pull/239))
   ###### Example:
   ```qasm
@@ -43,31 +63,12 @@ Types of changes:
   extern func6(bit[4]) -> bit[4];
   bit[4] be1 = func6(bd);
   ```
-- Added a new `QasmModule.compare` method to compare two QASM modules, providing a detailed report of differences in gates, qubits, and measurements. This method is useful for comparing two identifying differences in QASM programs, their structure and operations. ([#233](https://github.com/qBraid/pyqasm/pull/233)) 
 
 ### Improved / Modified
 - Added `slots=True` parameter to the data classes in `elements.py` to improve memory efficiency ([#218](https://github.com/qBraid/pyqasm/pull/218))
 - Updated the documentation to include core features in the `README` ([#219](https://github.com/qBraid/pyqasm/pull/219))
 - Added support to `device qubit` resgister consolidation.([#222](https://github.com/qBraid/pyqasm/pull/222))
 - Updated the scoping of variables in `QasmVisitor` using a `ScopeManager`. This change is introduced to ensure that the `QasmVisitor` and the `PulseVisitor` can share the same `ScopeManager` instance, allowing for consistent variable scoping across different visitors. No change in the user API is expected. ([#232](https://github.com/qBraid/pyqasm/pull/232))
-- Added `Duration`,`Stretch` type, `Delay` and `Box` support for `OPENQASM3` code in pyqasm. ([#231](https://github.com/qBraid/pyqasm/pull/231))
-  ###### Example:
-  ```qasm
-  OPENQASM 3.0;
-  include "stdgates.inc";
-  qubit[3] q;
-  duration t1 = 200dt;
-  duration t2 = 300ns;
-  stretch s1;
-  delay[t1] q[0];
-  delay[t2] q[1];
-  delay[s1] q[0], q[2];
-  box [t2] {
-    h q[0];
-    cx q[0], q[1];
-    delay[100ns] q[2];
-  }
-  ```
 - Enhance function call handling by adding support for nested functions. This change allows for more complex function definitions and calls, enabling better modularity and reusability of code within QASM programs. ([#245](https://github.com/qBraid/pyqasm/pull/245))
 
 ### Deprecated
@@ -83,7 +84,8 @@ Types of changes:
 ### Dependencies
 - Add `pillow<11.3.0` dependency for test and visualization to avoid CI errors in Linux builds ([#226](https://github.com/qBraid/pyqasm/pull/226))
 - Added `tabulate` to the testing dependencies to support new comparison table tests. ([#216](https://github.com/qBraid/pyqasm/pull/216))
-
+- Update `docutils` requirement from <0.22 to <0.23 ([#241](https://github.com/qBraid/pyqasm/pull/241))
+- Bumps `actions/download-artifact` version from 4 to 5 ([#243](https://github.com/qBraid/pyqasm/pull/243))
 ### Other
 
 ## Past Release Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Types of changes:
     delay[100ns] q[2];
   }
   ```
+- Enhance function call handling by adding support for nested functions. This change allows for more complex function definitions and calls, enabling better modularity and reusability of code within QASM programs. ([#243](https://github.com/qBraid/pyqasm/pull/243))
 
 ### Deprecated
 
@@ -77,6 +78,7 @@ Types of changes:
 - Fixed multiple axes error in circuit visualization of decomposable gates in `draw` method. ([#209](https://github.com/qBraid/pyqasm/pull/210))
 - Fixed depth calculation for decomposable gates by computing depth of each constituent quantum gate.([#211](https://github.com/qBraid/pyqasm/pull/211))
 - Optimized statement copying in `_visit_function_call` with shallow-copy fallback to deepcopy and added `max_loop_iters` loop‐limit check in for loops.([#223](https://github.com/qBraid/pyqasm/pull/223))
+
 
 ### Dependencies
 - Add `pillow<11.3.0` dependency for test and visualization to avoid CI errors in Linux builds ([#226](https://github.com/qBraid/pyqasm/pull/226))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ Types of changes:
     delay[100ns] q[2];
   }
   ```
-- Enhance function call handling by adding support for nested functions. This change allows for more complex function definitions and calls, enabling better modularity and reusability of code within QASM programs. ([#243](https://github.com/qBraid/pyqasm/pull/243))
+- Enhance function call handling by adding support for nested functions. This change allows for more complex function definitions and calls, enabling better modularity and reusability of code within QASM programs. ([#245](https://github.com/qBraid/pyqasm/pull/245))
 
 ### Deprecated
 

--- a/src/pyqasm/subroutines.py
+++ b/src/pyqasm/subroutines.py
@@ -456,6 +456,7 @@ class Qasm3SubroutineProcessor:
         cls,
         formal_arg,
         actual_arg,
+        actual_qreg_size_map,
         formal_qreg_size_map,
         duplicate_qubit_map,
         qubit_transform_map,
@@ -468,6 +469,7 @@ class Qasm3SubroutineProcessor:
         Args:
             formal_arg (Qasm3Expression): The formal argument in the function signature.
             actual_arg (Qasm3Expression): The actual argument passed to the function.
+            actual_qreg_size_map (dict): The map of actual quantum register sizes.
             formal_qreg_size_map (dict): The map of formal quantum register sizes.
             duplicate_qubit_map (dict): The map of duplicate qubit registers.
             qubit_transform_map (dict): The map of qubit register transformations.
@@ -504,7 +506,9 @@ class Qasm3SubroutineProcessor:
         # we expect that actual arg is qubit type only
         # note that we ONLY check in global scope as
         # we always map the qubit arguments to the global scope
-        if actual_arg_name not in cls.visitor_obj._global_qreg_size_map:
+        actual_arg_var = cls.visitor_obj._scope_manager.get_from_visible_scope(actual_arg_name)
+
+        if actual_arg_var is None or not actual_arg_var.is_qubit:
             # Check if the actual argument is a qubit register
             is_literal = actual_arg_name is None
             arg_desc = (
@@ -522,7 +526,7 @@ class Qasm3SubroutineProcessor:
             )
 
         actual_qids, actual_qubits_size = Qasm3Transformer.get_target_qubits(
-            actual_arg, cls.visitor_obj._global_qreg_size_map, actual_arg_name
+            actual_arg, actual_qreg_size_map, actual_arg_name
         )
 
         if formal_qubit_size != actual_qubits_size:

--- a/src/pyqasm/transformer.py
+++ b/src/pyqasm/transformer.py
@@ -343,7 +343,8 @@ class Qasm3Transformer:
     def transform_function_qubits(
         cls,
         q_op: QuantumGate | QuantumBarrier | QuantumReset | QuantumPhase,
-        qubit_map: dict[tuple, tuple],
+        qubit_transform_map: dict[tuple, tuple],
+        qubit_sizes: dict[str, int],
     ) -> list[IndexedIdentifier]:
         """Transform the qubits of a function call to the actual qubits.
 
@@ -356,7 +357,7 @@ class Qasm3Transformer:
         Returns:
             None
         """
-        expanded_op_qubits = cls.visitor_obj._get_op_bits(q_op)
+        expanded_op_qubits = cls.visitor_obj._get_op_bits(q_op, function_qubit_sizes=qubit_sizes)
 
         transformed_qubits = []
         for qubit in expanded_op_qubits:
@@ -364,7 +365,9 @@ class Qasm3Transformer:
             formal_qreg_idx = qubit.indices[0][0].value
 
             # replace the formal qubit with the actual qubit
-            actual_qreg_name, actual_qreg_idx = qubit_map[(formal_qreg_name, formal_qreg_idx)]
+            actual_qreg_name, actual_qreg_idx = qubit_transform_map[
+                (formal_qreg_name, formal_qreg_idx)
+            ]
             transformed_qubits.append(
                 IndexedIdentifier(
                     Identifier(actual_qreg_name),

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -218,7 +218,10 @@ class QasmVisitor:
 
     # pylint: disable-next=too-many-locals,too-many-branches
     def _get_op_bits(
-        self, operation: Any, qubits: bool = True
+        self,
+        operation: Any,
+        qubits: bool = True,
+        function_qubit_sizes: Optional[dict[str, int]] = None,
     ) -> list[qasm3_ast.IndexedIdentifier]:
         """Get the quantum / classical bits for the operation.
 
@@ -258,19 +261,28 @@ class QasmVisitor:
             else:
                 reg_name = bit.name
 
+            max_register_size = 0
             reg_var = self._scope_manager.get_from_visible_scope(reg_name)
             if reg_var is None:
-                err_msg = (
-                    f"Missing {'qubit' if qubits else 'clbit'} register declaration "
-                    f"for '{reg_name}' in {type(operation).__name__}"
-                )
-                raise_qasm3_error(
-                    err_msg,
-                    error_node=operation,
-                    span=operation.span,
-                )
-            assert isinstance(reg_var, Variable)
-            max_register_size = reg_var.base_size
+                if function_qubit_sizes is None:
+                    err_msg = (
+                        f"Missing {'qubit' if qubits else 'clbit'} register declaration "
+                        f"for '{reg_name}' in {type(operation).__name__}"
+                    )
+                    raise_qasm3_error(
+                        err_msg,
+                        error_node=operation,
+                        span=operation.span,
+                    )
+                # we are trying to replace the qubits inside a nested function
+                assert function_qubit_sizes is not None
+                reg_size = function_qubit_sizes.get(reg_name, None)
+                if reg_size is not None:
+                    max_register_size = reg_size
+
+            if reg_var:
+                assert isinstance(reg_var, Variable)
+                max_register_size = reg_var.base_size
 
             if isinstance(bit, qasm3_ast.IndexedIdentifier):
                 if isinstance(bit.indices[0], qasm3_ast.DiscreteSet):
@@ -293,7 +305,7 @@ class QasmVisitor:
             else:
                 bit_ids = list(range(max_register_size))
 
-            if reg_var.is_alias:
+            if reg_var and reg_var.is_alias:
                 original_reg_name, _ = self._alias_qubit_labels[(reg_name, bit_ids[0])]
                 bit_ids = [
                     self._alias_qubit_labels[(reg_name, bit_id)][1]  # gives (original_reg, index)
@@ -596,14 +608,19 @@ class QasmVisitor:
         """
         logger.debug("Visiting reset statement '%s'", str(statement))
         if len(self._function_qreg_size_map) > 0:  # atleast in SOME function scope
-            # transform qubits to use the global qreg identifiers
-            statement.qubits = (
-                Qasm3Transformer.transform_function_qubits(  # type: ignore[assignment]
-                    statement,
-                    self._function_qreg_transform_map[-1],
+            # since we may have multiple function scopes, we need to transform the qubits
+            # to use the global qreg identifiers
+            for transform_map, size_map in zip(
+                reversed(self._function_qreg_transform_map), reversed(self._function_qreg_size_map)
+            ):
+                statement.qubits = (
+                    Qasm3Transformer.transform_function_qubits(  # type: ignore[assignment]
+                        statement,
+                        transform_map,
+                        size_map,
+                    )
                 )
-            )
-        qubit_ids = self._get_op_bits(statement, True)
+        qubit_ids = self._get_op_bits(statement, qubits=True)
 
         unrolled_resets = []
         for qid in qubit_ids:
@@ -648,17 +665,22 @@ class QasmVisitor:
         """
         # if barrier is applied to ALL qubits at once, we are fine
         if len(self._function_qreg_size_map) > 0:  # atleast in SOME function scope
-            # transform qubits to use the global qreg identifiers
+            # we have multiple function scopes, so we need to transform the qubits
+            # to use the global qreg identifiers
 
             # since we are changing the qubits to IndexedIdentifiers, we need to supress the
             # error for the type checker
-            barrier.qubits = (
-                Qasm3Transformer.transform_function_qubits(  # type: ignore [assignment]
-                    barrier,
-                    self._function_qreg_transform_map[-1],
+            for transform_map, size_map in zip(
+                reversed(self._function_qreg_transform_map), reversed(self._function_qreg_size_map)
+            ):
+                barrier.qubits = (
+                    Qasm3Transformer.transform_function_qubits(  # type: ignore [assignment]
+                        barrier,
+                        transform_map,
+                        size_map,
+                    )
                 )
-            )
-        barrier_qubits = self._get_op_bits(barrier)
+        barrier_qubits = self._get_op_bits(barrier, qubits=True)
         unrolled_barriers = []
         max_involved_depth = 0
         for qubit in barrier_qubits:
@@ -763,7 +785,7 @@ class QasmVisitor:
         Returns:
             The list of all targets that the unrolled gate should act on.
         """
-        op_qubits = self._get_op_bits(operation)
+        op_qubits = self._get_op_bits(operation, qubits=True)
         if len(op_qubits) <= 0 or len(op_qubits) % gate_qubit_count != 0:
             raise_qasm3_error(
                 f"Invalid number of qubits {len(op_qubits)} for operation {operation.name.name}",
@@ -981,7 +1003,7 @@ class QasmVisitor:
         gate_name: str = operation.name.name
         gate_definition: qasm3_ast.QuantumGateDefinition = self._custom_gates[gate_name]
         op_qubits: list[qasm3_ast.IndexedIdentifier] = self._get_op_bits(
-            operation
+            operation, qubits=True
         )  # type: ignore [assignment]
 
         Qasm3Validator.validate_gate_call(operation, gate_definition, len(op_qubits))
@@ -1223,12 +1245,14 @@ class QasmVisitor:
         ):
             # we are in SOME function scope
             # transform qubits to use the global qreg identifiers
-            operation.qubits = (
-                Qasm3Transformer.transform_function_qubits(  # type: ignore [assignment]
-                    operation,
-                    self._function_qreg_transform_map[-1],
+            for transform_map, size_map in zip(
+                reversed(self._function_qreg_transform_map), reversed(self._function_qreg_size_map)
+            ):
+                operation.qubits = (
+                    Qasm3Transformer.transform_function_qubits(  # type: ignore [assignment]
+                        operation, transform_map, size_map
+                    )
                 )
-            )
 
         operation.qubits = self._get_op_bits(operation, qubits=True)  # type: ignore
 
@@ -2176,6 +2200,11 @@ class QasmVisitor:
         duplicate_qubit_detect_map: dict = {}
         qubit_transform_map: dict = {}  # {(formal arg, idx) : (actual arg, idx)}
         formal_qreg_size_map: dict = {}
+        actual_qreg_size_map: dict = (
+            self._function_qreg_size_map[-1]
+            if self._function_qreg_size_map
+            else self._global_qreg_size_map
+        )
 
         quantum_vars, classical_vars = [], []
         for actual_arg, formal_arg in zip(statement.arguments, subroutine_def.arguments):
@@ -2190,6 +2219,7 @@ class QasmVisitor:
                     Qasm3SubroutineProcessor.process_quantum_arg(
                         formal_arg,
                         actual_arg,
+                        actual_qreg_size_map,
                         formal_qreg_size_map,
                         duplicate_qubit_detect_map,
                         qubit_transform_map,


### PR DESCRIPTION

<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->
Fixes #9 

## Summary of changes
Added support for nested functions by using qubit transformation for the whole stack of functions. Previously, we were only updating the qubit variables for the latest function call.

### Function Call and Argument Handling Improvements

* Added support for nested function calls, allowing functions to call other functions with quantum and classical arguments, including passing quantum registers and parameters through multiple layers of function calls. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR71) [[2]](diffhunk://#diff-fbc643fb18c7f2cf92b72eb33c35fac600888fc31c025b39bd503138c11d824dL280-R314)
* Refactored quantum argument processing by introducing `actual_qreg_size_map` to accurately track the sizes of actual quantum registers passed to functions, ensuring correct mapping and transformation of qubit arguments. [[1]](diffhunk://#diff-6989ec830e9b2d4aaa0908762ed05c239022a6221feb3f0ca517107d7d2b09c2R459) [[2]](diffhunk://#diff-6989ec830e9b2d4aaa0908762ed05c239022a6221feb3f0ca517107d7d2b09c2R472) [[3]](diffhunk://#diff-6989ec830e9b2d4aaa0908762ed05c239022a6221feb3f0ca517107d7d2b09c2L507-R511) [[4]](diffhunk://#diff-6989ec830e9b2d4aaa0908762ed05c239022a6221feb3f0ca517107d7d2b09c2L525-R529) [[5]](diffhunk://#diff-802ca57af29fc92ca8eb2f536fb5217c61c874c4c35bd39b7fd82512ee0e9a84R2203-R2207) [[6]](diffhunk://#diff-802ca57af29fc92ca8eb2f536fb5217c61c874c4c35bd39b7fd82512ee0e9a84R2222)

### Quantum Register Transformation

* Updated the quantum register transformation logic in `transform_function_qubits` and related visitor methods to use both transformation maps and size maps, enabling correct qubit mapping across nested function scopes and supporting more complex function hierarchies. [[1]](diffhunk://#diff-e93dd1416b23d36940012c80c1eb25bec16997b6c275c38c2af09e4bb6c8d53eL346-R347) [[2]](diffhunk://#diff-e93dd1416b23d36940012c80c1eb25bec16997b6c275c38c2af09e4bb6c8d53eL359-R370) [[3]](diffhunk://#diff-802ca57af29fc92ca8eb2f536fb5217c61c874c4c35bd39b7fd82512ee0e9a84L221-R224) [[4]](diffhunk://#diff-802ca57af29fc92ca8eb2f536fb5217c61c874c4c35bd39b7fd82512ee0e9a84R264-R267) [[5]](diffhunk://#diff-802ca57af29fc92ca8eb2f536fb5217c61c874c4c35bd39b7fd82512ee0e9a84R277-R283) [[6]](diffhunk://#diff-802ca57af29fc92ca8eb2f536fb5217c61c874c4c35bd39b7fd82512ee0e9a84L296-R308) [[7]](diffhunk://#diff-802ca57af29fc92ca8eb2f536fb5217c61c874c4c35bd39b7fd82512ee0e9a84L599-R623) [[8]](diffhunk://#diff-802ca57af29fc92ca8eb2f536fb5217c61c874c4c35bd39b7fd82512ee0e9a84L651-R683) [[9]](diffhunk://#diff-802ca57af29fc92ca8eb2f536fb5217c61c874c4c35bd39b7fd82512ee0e9a84L766-R788) [[10]](diffhunk://#diff-802ca57af29fc92ca8eb2f536fb5217c61c874c4c35bd39b7fd82512ee0e9a84L984-R1006) [[11]](diffhunk://#diff-802ca57af29fc92ca8eb2f536fb5217c61c874c4c35bd39b7fd82512ee0e9a84R1248-R1253)
