### PR TITLE
Fixed: Duplicate qubits not detected in function call  &  Error in function call with aliased qubit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Types of changes:
 
 ### Fixed
 - Fixed Complex value initialization error. ([#253](https://github.com/qBraid/pyqasm/pull/253))
+- Fixed duplicate qubit argument check in function calls. ([#260](https://github.com/qBraid/pyqasm/pull/260))
 
 ### Dependencies
 - Bumps `@actions/checkout` from 4 to 5 ([#250](https://github.com/qBraid/pyqasm/pull/250))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,8 @@ Types of changes:
 
 ### Fixed
 - Fixed Complex value initialization error. ([#253](https://github.com/qBraid/pyqasm/pull/253))
-- Fixed duplicate qubit argument check in function calls. ([#260](https://github.com/qBraid/pyqasm/pull/260))
+- Fixed duplicate qubit argument check in function calls and  Error in function call with aliased qubit. ([#260](https://github.com/qBraid/pyqasm/pull/260))
+
 
 ### Dependencies
 - Bumps `@actions/checkout` from 4 to 5 ([#250](https://github.com/qBraid/pyqasm/pull/250))

--- a/src/pyqasm/transformer.py
+++ b/src/pyqasm/transformer.py
@@ -409,7 +409,9 @@ class Qasm3Transformer:
                         qid, qreg_size_map[target_name], qubit=True, op_node=target
                     )
                 target_qubits_size = len(target_qids)
-            elif isinstance(target.index[0], (IntegerLiteral, Identifier)):  # "(q[0]); OR (q[i]);"
+            elif isinstance(
+                target.index[0], (IntegerLiteral, Identifier, BinaryExpression)
+            ):  # "(q[0]); OR (q[i]); OR (q[i+1]);"
                 target_qids = [Qasm3ExprEvaluator.evaluate_expression(target.index[0])[0]]
                 Qasm3Validator.validate_register_index(
                     target_qids[0], qreg_size_map[target_name], qubit=True, op_node=target

--- a/src/pyqasm/validator.py
+++ b/src/pyqasm/validator.py
@@ -340,24 +340,3 @@ class Qasm3Validator:
                 return_value,
                 op_node=return_statement,
             )
-
-    @staticmethod
-    def validate_unique_qubits(qubit_map: dict, reg_name: str, indices: list) -> bool:
-        """
-        Validates that the qubits in the given register are unique.
-
-        Args:
-            qubit_map (dict): Dictionary of qubits.
-            reg_name (str): The name of the register.
-            indices (list): A list of indices representing the qubits.
-
-        Returns:
-            bool: True if the qubits are unique, False otherwise.
-        """
-        if reg_name not in qubit_map:
-            qubit_map[reg_name] = set(indices)
-        else:
-            for idx in indices:
-                if idx in qubit_map[reg_name]:
-                    return False
-        return True

--- a/tests/qasm3/resources/subroutines.py
+++ b/tests/qasm3/resources/subroutines.py
@@ -46,6 +46,23 @@ SUBROUTINE_INCORRECT_TESTS = {
         8,
         "my_function(q[0], q[0])",
     ),
+    "test_duplicate_qubit_args_singletons_2": (
+        """
+        OPENQASM 3;
+        include "stdgates.inc";
+
+        def my_function(qubit[2] p) {
+            h p;
+            return;
+        }
+        qubit[3] q;
+        my_function(q[{0, 0}]);
+        """,
+        r"Duplicate qubit argument for register 'q' in function call for 'my_function'",
+        10,
+        8,
+        "my_function(q[{0, 0}])",
+    ),
     "redefinition_raises_error": (
         """
         OPENQASM 3;

--- a/tests/qasm3/resources/subroutines.py
+++ b/tests/qasm3/resources/subroutines.py
@@ -29,6 +29,23 @@ SUBROUTINE_INCORRECT_TESTS = {
         8,  # Column number
         "my_function(1)",  # Complete line
     ),
+    "test_duplicate_qubit_args_singletons": (
+        """
+        OPENQASM 3;
+        include "stdgates.inc";
+
+        def my_function(qubit a, qubit b) {
+            h b;
+            return;
+        }
+        qubit[2] q;
+        my_function(q[0], q[0]);
+        """,
+        r"Duplicate qubit argument for register 'q' in function call for 'my_function'",
+        10,
+        8,
+        "my_function(q[0], q[0])",
+    ),
     "redefinition_raises_error": (
         """
         OPENQASM 3;

--- a/tests/qasm3/subroutines/test_subroutines.py
+++ b/tests/qasm3/subroutines/test_subroutines.py
@@ -198,6 +198,36 @@ def test_multiple_function_calls():
     check_single_qubit_rotation_op(result.unrolled_ast, 3, [2, 1, 0], [2, 1, 0], "rx")
 
 
+def test_alias_arg_from_loop_validates():
+    """Alias of a dynamic indexed qubit used as function argument should validate."""
+    qasm_str = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+
+    qubit[4] q;
+
+    def dummy(qubit[1] q_arg) -> bool { 
+        h q_arg;
+        return true;
+    }
+
+    for int i in [0:2]
+    {
+       let new_q = q[i];
+       dummy(new_q);
+    }
+    for int i in [0:2]
+    {
+       let new_q = q[i+1];
+       dummy(new_q);
+    }
+    """
+
+    result = loads(qasm_str)
+    # Should not raise ValidationError
+    result.unroll()
+
+
 def test_function_call_with_return():
     """Test that a function call with a return value is correctly parsed."""
     qasm_str = """OPENQASM 3.0;


### PR DESCRIPTION
…ocessor

<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/pyqasm/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the PyQASM CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

## Summary of changes

Enhance QASM validation by moving unique qubit check to subroutine processor

* Add `validate_unique_qubits` method to `Qasm3SubroutineProcessor` for improved qubit uniqueness validation across function calls.
* Remove the previous implementation from `Qasm3Validator`.

Enhance `alias` handling in QASM by including alias register sizes for target qubit resolution and improving duplicate qubit validation for aliased arguments. 
Add a test case to validate dynamic indexed qubit aliases as function arguments.

Closes #80 
Closes #108 