### PR TITLE
Add delay support in openqasm 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,64 +15,33 @@ Types of changes:
 ## Unreleased
 
 ### Added
-
-- Added support to `OPENPULSE` code in pyqasm. ([#246](https://github.com/qBraid/pyqasm/pull/246))
-  ###### Example:
-  ```qasm
-  OPENQASM 3.0;
-  defcalgrammar "openpulse";
-    
-  complex[float[32]] amp = 1.0 + 2.0im;
-  cal {
-      port d0;
-      frame driveframe = newframe(d0, 5.0e9, 0.0);
-      waveform wf = gaussian(amp, 16ns, 4ns);
-  }
-    
-  const float frequency_start = 4.5e9;
-  const float frequency_step = 1e6;
-  const int frequency_num_steps = 3;
-  
-  defcal saturation_pulse $0 {
-      play(driveframe, constant(amp, 100e-6s));
-  }
-    
-  cal {
-      set_frequency(driveframe, frequency_start);
-  }
-    
-  for int i in [1:frequency_num_steps] {
-      cal {
-          shift_frequency(driveframe, frequency_step);
-      }
-      saturation_pulse $0;
-  }
-  ```
-- Added a workflow to track changes in the `docs/_static/logo.png` file to prevent unnecessary modifications. ([#257](https://github.com/qBraid/pyqasm/pull/257))
-- Added decomposition details for all gates in the `docs/gate_decompositions.md` file. ([#237](https://github.com/qBraid/pyqasm/pull/237))
-
+- Direct support for `delay` instructions in OpenQASM 2 parsing. ([#275](https://github.com/qBraid/pyqasm/pull/275)) Eg. - 
+```python
+from pyqasm import loads
+qasm_str = """
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[1];
+delay[100ns] q[0];
+"""
+program = loads(qasm_str)
+program.unroll()
+print(program)
+```
 
 ### Improved / Modified
-- Modified if statement validation to now include empty blocks as well. See [Issue #246](https://github.com/qBraid/pyqasm/issues/246) for details. ([#251](https://github.com/qBraid/pyqasm/pull/251))
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
-- Fixed Complex value initialization error. ([#253](https://github.com/qBraid/pyqasm/pull/253))
-- Fixed duplicate qubit argument check in function calls and  Error in function call with aliased qubit. ([#260](https://github.com/qBraid/pyqasm/pull/260))
-- Fixed Gate ordering across registers in `pyqasm.draw()` function. ([#268](https://github.com/qBraid/pyqasm/pull/268))
-=======
 
 
 ### Dependencies
-- Bumps `@actions/checkout` from 4 to 5 ([#250](https://github.com/qBraid/pyqasm/pull/250))
-- Bump `@codecov/codecov-action` from 5.4.3 to 5.5.0 ([#254](https://github.com/qBraid/pyqasm/pull/254))
-- Bump `@actions/upload-pages-artifact` from 3 to 4 ([#255](https://github.com/qBraid/pyqasm/pull/255))
-- Bump `@actions/setup-python` from 5 to 6 ([#262](https://github.com/qBraid/pyqasm/pull/262))
-- Bump `@codecov/codecov-action` from 5.5.0 to 5.5.1 ([#263](https://github.com/qBraid/pyqasm/pull/263))
-- Bump `@actions/github-script` from 7 to 8 ([#264](https://github.com/qBraid/pyqasm/pull/264))
+- Update `pillow` requirement from <11.4.0 to <12.1.0 ([#271](https://github.com/qBraid/pyqasm/pull/271))
+- Bump `actions/download-artifact` from 5 to 6 ([#272](https://github.com/qBraid/pyqasm/pull/272))
+- Bump `actions/upload-artifact` from 4 to 5 ([#273](https://github.com/qBraid/pyqasm/pull/273))
 
 ### Other
 
@@ -80,6 +49,7 @@ Types of changes:
 
 Archive of changelog entries from previous releases:
 
+- [v1.0.0](https://github.com/qBraid/pyqasm/releases/tag/v1.0.0)
 - [v0.5.0](https://github.com/qBraid/pyqasm/releases/tag/v0.5.0)
 - [v0.4.0](https://github.com/qBraid/pyqasm/releases/tag/v0.4.0)
 - [v0.3.2](https://github.com/qBraid/pyqasm/releases/tag/v0.3.2)

--- a/src/pyqasm/modules/qasm2.py
+++ b/src/pyqasm/modules/qasm2.py
@@ -45,6 +45,7 @@ class Qasm2Module(QasmModule):
             qasm3_ast.BranchingStatement,
             qasm3_ast.QubitDeclaration,
             qasm3_ast.ClassicalDeclaration,
+            qasm3_ast.DelayInstruction,
             qasm3_ast.Include,
             qasm3_ast.QuantumGateDefinition,
             qasm3_ast.QuantumGate,

--- a/tests/qasm2/test_operations.py
+++ b/tests/qasm2/test_operations.py
@@ -43,6 +43,8 @@ def test_whitelisted_ops():
     h q;
     cx q[0], q[1];
     custom_gate q[0], q[1];
+
+    delay[10.0ns] q[0]; 
     """
 
     expected_qasm = """
@@ -60,6 +62,7 @@ def test_whitelisted_ops():
     h q[1];
     cx q[0], q[1];
     cx q[0], q[1];
+    delay[10.0ns] q[0];
     """
 
     result = loads(qasm2_string)


### PR DESCRIPTION
## Summary of changes
* Added `qasm3_ast.DelayInstruction` to the list of recognized AST nodes in the `QASM2` module initializer, enabling parsing and handling of delay instructions.

### @AndreiCod | #274 
* For the `delay` instructions in `OPENQASM 2;`, following syntax can be used - 
```qasm
OPENQASM 2.0;
qreg q[2];
delay[10.0ns] q[0];
```
I would recommend switching to qasm3 as `delay` is not supported natively in the grammar of qasm2.

* **Note** : 
    * `opaque` is not supported in the `openqasm3` parser and since the AST of `pyqasm` is based off of it, the parsing of the `opaque` instructions fail. Moreover, `opaque delay` results in a parsing error as `delay` is a reserved keyword in the `openqasm3` parser.
    * One alternative to supporting `opaque` instructions is the [`external_gates` kwarg](https://github.com/qBraid/pyqasm/blob/ed59ae8fa56a6e93c3a3f60c666775a6925d26fd/src/pyqasm/visitor.py#L94) which we provide in the `unroll` method. 
    * You can define the gate skeleton , e.g. - 

```qasm
gate external_gate (param0, param1) qubit0, qubit1 { } // empty body 
``` 

and specify the name in the `external_gates` list. This will instruct the pyqasm unroller to skip the gate unrolling and just validate the parameters and arguments against the provided gate definition. Full example - 

```python
from pyqasm import loads

qasm_str = """
OPENQASM 2.0;
gate custom_ext_gate(p0) q0 { } 
qreg q[2];
custom_ext_gate(0) q[0];
"""

module = loads(qasm_str)
module.unroll(external_gates = ['custom_ext_gate'])
print(module)

"""OPENQASM 2.0;
qreg q[2];
custom_ext_gate(0) q[0];"""

```