### PR TITLE
Refactor visit statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Types of changes:
 ### Added
 
 ### Improved / Modified
+- Moved the `visit_map` from the `visit_statement` function to a class level variable for improved efficiency. ([#279](https://github.com/qBraid/pyqasm/pull/279))
 
 ### Deprecated
 


### PR DESCRIPTION


## Summary of changes

**Refactoring for efficiency and maintainability:**

* Moved the `visit_map` from the local scope of the `visit_statement` function to a class-level variable, initializing it once in the constructor for improved efficiency and easier maintenance. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR20) [[2]](diffhunk://#diff-802ca57af29fc92ca8eb2f536fb5217c61c874c4c35bd39b7fd82512ee0e9a84L145-R145) [[3]](diffhunk://#diff-802ca57af29fc92ca8eb2f536fb5217c61c874c4c35bd39b7fd82512ee0e9a84L3083-R3115)
* Added the `_construct_visit_map` helper method to encapsulate and organize the construction of the visitor map, making the code cleaner and more modular.