### PR TITLE
Remove deprecated macOS 13 from CI and update to macOS 15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,16 +52,16 @@ jobs:
             manylinux_image: manylinux2014
 
           # MacOS x86_64
-          - os: macos-13
+          - os: macos-15
             python: 310
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-15
             python: 311
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-15
             python: 312
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-15
             python: 313
             platform_id: macosx_x86_64
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,16 +52,16 @@ jobs:
             manylinux_image: manylinux2014
 
           # MacOS x86_64
-          - os: macos-15
+          - os: macos-15-intel
             python: 310
             platform_id: macosx_x86_64
-          - os: macos-15
+          - os: macos-15-intel
             python: 311
             platform_id: macosx_x86_64
-          - os: macos-15
+          - os: macos-15-intel
             python: 312
             platform_id: macosx_x86_64
-          - os: macos-15
+          - os: macos-15-intel
             python: 313
             platform_id: macosx_x86_64
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -46,16 +46,16 @@ jobs:
             manylinux_image: manylinux2014
 
           # MacOS x86_64
-          - os: macos-15
+          - os: macos-15-intel
             python: 310
             platform_id: macosx_x86_64
-          - os: macos-15
+          - os: macos-15-intel
             python: 311
             platform_id: macosx_x86_64
-          - os: macos-15
+          - os: macos-15-intel
             python: 312
             platform_id: macosx_x86_64
-          - os: macos-15
+          - os: macos-15-intel
             python: 313
             platform_id: macosx_x86_64
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -46,16 +46,16 @@ jobs:
             manylinux_image: manylinux2014
 
           # MacOS x86_64
-          - os: macos-13
+          - os: macos-15
             python: 310
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-15
             python: 311
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-15
             python: 312
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-15
             python: 313
             platform_id: macosx_x86_64
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,16 +48,16 @@ jobs:
             manylinux_image: manylinux2014
 
           # MacOS x86_64
-          - os: macos-15
+          - os: macos-15-intel
             python: 310
             platform_id: macosx_x86_64
-          - os: macos-15
+          - os: macos-15-intel
             python: 311
             platform_id: macosx_x86_64
-          - os: macos-15
+          - os: macos-15-intel
             python: 312
             platform_id: macosx_x86_64
-          - os: macos-15
+          - os: macos-15-intel
             python: 313
             platform_id: macosx_x86_64
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,16 +48,16 @@ jobs:
             manylinux_image: manylinux2014
 
           # MacOS x86_64
-          - os: macos-13
+          - os: macos-15
             python: 310
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-15
             python: 311
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-15
             python: 312
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-15
             python: 313
             platform_id: macosx_x86_64
 

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -46,16 +46,16 @@ jobs:
             manylinux_image: manylinux2014
 
           # MacOS x86_64
-          - os: macos-15
+          - os: macos-15-intel
             python: 310
             platform_id: macosx_x86_64
-          - os: macos-15
+          - os: macos-15-intel
             python: 311
             platform_id: macosx_x86_64
-          - os: macos-15
+          - os: macos-15-intel
             python: 312
             platform_id: macosx_x86_64
-          - os: macos-15
+          - os: macos-15-intel
             python: 313
             platform_id: macosx_x86_64
 

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -46,16 +46,16 @@ jobs:
             manylinux_image: manylinux2014
 
           # MacOS x86_64
-          - os: macos-13
+          - os: macos-15
             python: 310
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-15
             python: 311
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-15
             python: 312
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-15
             python: 313
             platform_id: macosx_x86_64
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Types of changes:
 ### Removed
 
 ### Fixed
-
+- Updated CI to use `macos-15-intel` image due to deprecation of `macos-13` image. ([#283](https://github.com/qBraid/pyqasm/pull/283))
 
 ### Dependencies
 - Update `pillow` requirement from <11.4.0 to <12.1.0 ([#271](https://github.com/qBraid/pyqasm/pull/271))


### PR DESCRIPTION
## Summary of changes
This pull request updates the GitHub Actions workflows to use macOS 15 instead of macOS 13 for all x86_64 Python build and test jobs. This ensures that our CI pipelines are running on the latest available macOS environment, which can help with compatibility and future-proofing.

Platform update in CI workflows:

* Updated the `os` field from `macos-13` to `macos-15-intel` for all Python x86_64 jobs in the following workflow files:
  - `.github/workflows/main.yml`
  - `.github/workflows/pre-release.yml`
  - `.github/workflows/release.yml`
  - `.github/workflows/test-release.yml`
  
Reference - https://github.com/actions/runner-images/issues/13046