### PR TITLE
Add physical qubit support for plain QASM 3 programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Types of changes:
 ### Removed
 
 ### Fixed
-- Added support for physical qubit identifiers (`$0`, `$1`, …) in plain QASM 3 programs, including gates, barriers, measurements, and duplicate-qubit detection. ([#PR_NUMBER](https://github.com/qBraid/pyqasm/pull/PR_NUMBER))
+- Added support for physical qubit identifiers (`$0`, `$1`, …) in plain QASM 3 programs, including gates, barriers, measurements, and duplicate-qubit detection. ([#291](https://github.com/qBraid/pyqasm/pull/291))
 - Updated CI to use `macos-15-intel` image due to deprecation of `macos-13` image. ([#283](https://github.com/qBraid/pyqasm/pull/283))
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Types of changes:
 ### Removed
 
 ### Fixed
+- Added support for physical qubit identifiers (`$0`, `$1`, …) in plain QASM 3 programs, including gates, barriers, measurements, and duplicate-qubit detection. ([#PR_NUMBER](https://github.com/qBraid/pyqasm/pull/PR_NUMBER))
 - Updated CI to use `macos-15-intel` image due to deprecation of `macos-13` image. ([#283](https://github.com/qBraid/pyqasm/pull/283))
 
 ### Dependencies

--- a/src/pyqasm/analyzer.py
+++ b/src/pyqasm/analyzer.py
@@ -251,21 +251,26 @@ class Qasm3Analyzer:
         raise_qasm3_error("Could not determine the OpenQASM version.", err_type=QasmParsingError)
 
     @staticmethod
-    def extract_duplicate_qubit(qubit_list: list[IndexedIdentifier]):
+    def extract_duplicate_qubit(qubit_list: list[IndexedIdentifier | Identifier]):
         """
         Extracts the duplicate qubit from a list of qubits.
 
         Args:
-            qubit_list (list[IndexedIdentifier]): The list of qubits.
+            qubit_list (list[IndexedIdentifier | Identifier]): The list of qubits.
 
         Returns:
             tuple(string, int): The duplicate qubit name and id.
         """
         qubit_set = set()
         for qubit in qubit_list:
-            assert isinstance(qubit, IndexedIdentifier)
-            qubit_name = qubit.name.name
-            qubit_id = qubit.indices[0][0].value  # type: ignore
+            if isinstance(qubit, Identifier):
+                # Physical qubit: name is "$n", identity is the name itself.
+                qubit_name = qubit.name
+                qubit_id = int(qubit.name[1:])
+            else:
+                assert isinstance(qubit, IndexedIdentifier)
+                qubit_name = qubit.name.name
+                qubit_id = qubit.indices[0][0].value  # type: ignore
             if (qubit_name, qubit_id) in qubit_set:
                 return (qubit_name, qubit_id)
             qubit_set.add((qubit_name, qubit_id))

--- a/src/pyqasm/transformer.py
+++ b/src/pyqasm/transformer.py
@@ -173,7 +173,7 @@ class Qasm3Transformer:
 
         Args:
             gate_op (QuantumGate): The gate operation to transform.
-            qubit_map (dict[str, IndexedIdentifier | Identifier]): The qubit map to use for transformation.
+            qubit_map: Maps qubits to their transformed identifiers.
 
         Returns:
             None

--- a/src/pyqasm/transformer.py
+++ b/src/pyqasm/transformer.py
@@ -166,13 +166,14 @@ class Qasm3Transformer:
 
     @staticmethod
     def transform_gate_qubits(
-        gate_op: QuantumGate | QuantumPhase, qubit_map: dict[str, IndexedIdentifier]
+        gate_op: QuantumGate | QuantumPhase,
+        qubit_map: dict[str, IndexedIdentifier | Identifier],
     ) -> None:
         """Transform the qubits of a gate operation with a qubit map.
 
         Args:
             gate_op (QuantumGate): The gate operation to transform.
-            qubit_map (dict[str, IndexedIdentifier]): The qubit map to use for transformation.
+            qubit_map (dict[str, IndexedIdentifier | Identifier]): The qubit map to use for transformation.
 
         Returns:
             None

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -283,7 +283,7 @@ class QasmVisitor:
             operation (Any): The operation to get qubits for.
             qubits (bool): Whether the bits are quantum bits or classical bits. Defaults to True.
         Returns:
-            list[Union[qasm3_ast.IndexedIdentifier, qasm3_ast.Identifier]] : The bits for the operation.
+            The quantum or classical bits for the operation.
         """
         openqasm_bits: list[Union[qasm3_ast.IndexedIdentifier, qasm3_ast.Identifier]] = []
         bit_list = []

--- a/tests/qasm3/resources/gates.py
+++ b/tests/qasm3/resources/gates.py
@@ -480,3 +480,70 @@ CUSTOM_GATE_INCORRECT_TESTS = {
         "gate custom_gate(a, b) p, q {",
     ),
 }
+
+
+# ── Physical-qubit tests ────────────────────────────────────────────────────
+
+PHYSICAL_QUBIT_VALID_TESTS = {
+    "basic_gates": (
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        x $0;
+        h $1;
+        cx $0, $1;
+        """,
+        2,
+        0,
+    ),
+    "custom_gate": (
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        gate prx(_gate_p_0, _gate_p_1) _gate_q_0 {
+            rz(0) _gate_q_0;
+            rx(pi/2) _gate_q_0;
+            rz(0) _gate_q_0;
+        }
+        bit[2] meas;
+        prx(pi/2, 0) $0;
+        prx(pi/2, 0) $0;
+        prx(pi/2, 0) $0;
+        barrier $0, $1;
+        meas[0] = measure $0;
+        meas[1] = measure $1;
+        """,
+        2,
+        2,
+    ),
+    "barrier_only": (
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        barrier $0, $1, $2;
+        """,
+        3,
+        0,
+    ),
+    "measure_physical": (
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        bit[1] c;
+        h $0;
+        c[0] = measure $0;
+        """,
+        1,
+        1,
+    ),
+    "non_contiguous_indices": (
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        x $0;
+        x $3;
+        """,
+        4,
+        0,
+    ),
+}


### PR DESCRIPTION
**Bug Fix**

Adds support for physical qubit identifiers (`$0`, `$1`, …) in plain (non-OpenPulse) QASM 3 programs. Previously, physical qubits were only handled inside OpenPulse contexts; using them in a regular QASM 3 program would either silently mishandle them or raise unexpected errors.

## Changes

- **Visitor**: Detect physical qubit references (`$n`) in `_get_op_bits` and register them via the new `_register_physical_qubit` helper, updating qubit depth tracking and `num_qubits` automatically.
- **Barrier**: Allow physical qubit indices on barriers in plain QASM programs instead of rejecting them as invalid pulse qubits.
- **Measurement**: Route physical qubits in measurement statements through `_register_physical_qubit` when OpenPulse grammar is not active.
- **Analyzer**: Update `extract_duplicate_qubit` to handle both `Identifier` (physical) and `IndexedIdentifier` (virtual) qubit types.
- **Transformer**: Widen `transform_gate_qubits` qubit map type to accept `Identifier | IndexedIdentifier`.
- **Depth tracking**: Extract a `_get_qubit_name_and_id` helper to unify index extraction for physical and virtual qubits across depth updates and branch-qubit tracking.
- **Tests**: Add comprehensive test suite for physical qubits covering basic gates, custom gates, barriers, measurements, non-contiguous indices, unrolling, and duplicate detection.
