### PR TITLE
Fix classical register visibility inside box scope

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -104,10 +104,6 @@ recursive=no
 # source root.
 source-roots=
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Types of changes:
 ### Removed
 
 ### Fixed
+- Fixed classical register declarations not being visible inside `box` scope, causing "Missing clbit register declaration" errors for measurement statements inside box blocks. ([#306](https://github.com/qBraid/pyqasm/pull/306))
 
 ### Dependencies
 

--- a/src/pyqasm/scope.py
+++ b/src/pyqasm/scope.py
@@ -193,11 +193,7 @@ class ScopeManager:
         curr_scope = self.get_curr_scope()
         if self.in_global_scope():
             return global_scope.get(var_name, None)
-        if (
-            self.in_function_scope()
-            or self.in_gate_scope()
-            or self.in_pulse_scope()
-        ):
+        if self.in_function_scope() or self.in_gate_scope() or self.in_pulse_scope():
             if var_name in curr_scope:
                 return curr_scope[var_name]
             if var_name in global_scope and (

--- a/src/pyqasm/scope.py
+++ b/src/pyqasm/scope.py
@@ -149,19 +149,19 @@ class ScopeManager:
         curr_scope = self.get_curr_scope()
         if self.in_global_scope():
             return var_name in global_scope
-        if (
-            self.in_function_scope()
-            or self.in_gate_scope()
-            or self.in_box_scope()
-            or self.in_pulse_scope()
-        ):
+        if self.in_function_scope() or self.in_gate_scope() or self.in_pulse_scope():
             if var_name in curr_scope:
                 return True
             if var_name in global_scope:
                 return global_scope[var_name].is_constant or global_scope[var_name].is_qubit
-        if self.in_block_scope():
+        if self.in_block_scope() or self.in_box_scope():
+            in_box = self.in_box_scope()
             for scope, context in zip(reversed(self._scope), reversed(self._context)):
-                if context != Context.BLOCK:
+                if context == Context.BOX:
+                    in_box = True
+                if context not in (Context.BLOCK, Context.BOX):
+                    if in_box and var_name in scope:
+                        return scope[var_name].is_constant or scope[var_name].is_qubit
                     return var_name in scope
                 if var_name in scope:
                     return True
@@ -205,7 +205,7 @@ class ScopeManager:
         if self.in_block_scope() or self.in_box_scope():
             var_found = None
             for scope, context in zip(reversed(self._scope), reversed(self._context)):
-                if context != Context.BLOCK:
+                if context not in (Context.BLOCK, Context.BOX):
                     var_found = scope.get(var_name, None)
                     break
                 if var_name in scope:

--- a/src/pyqasm/scope.py
+++ b/src/pyqasm/scope.py
@@ -196,7 +196,6 @@ class ScopeManager:
         if (
             self.in_function_scope()
             or self.in_gate_scope()
-            or self.in_box_scope()
             or self.in_pulse_scope()
         ):
             if var_name in curr_scope:
@@ -207,7 +206,7 @@ class ScopeManager:
                 # we also need to return the variable if it is a constant or qubit
                 # in the global scope, as it can be used in the function or gate
                 return global_scope[var_name]
-        if self.in_block_scope():
+        if self.in_block_scope() or self.in_box_scope():
             var_found = None
             for scope, context in zip(reversed(self._scope), reversed(self._context)):
                 if context != Context.BLOCK:

--- a/tests/qasm3/test_box.py
+++ b/tests/qasm3/test_box.py
@@ -256,3 +256,29 @@ def test_box_measurement_with_classical_register():
     """
     result = loads(qasm_str)
     result.validate()
+
+
+def test_box_measurement_with_enclosing_block_scope():
+    """Measurement inside a box nested within a non-global scope (e.g. an
+    if-block) should still have access to classical registers declared in
+    the enclosing global scope.
+
+    Complements test_box_measurement_with_classical_register by ensuring the
+    scope walker traverses intermediate BLOCK contexts to reach the global
+    scope where the classical register is declared.
+    """
+    qasm_str = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[4] q;
+    bit[3] c;
+
+    if (true) {
+        box {
+            h q[0];
+            c[1] = measure q[1];
+        }
+    }
+    """
+    result = loads(qasm_str)
+    result.validate()

--- a/tests/qasm3/test_box.py
+++ b/tests/qasm3/test_box.py
@@ -232,3 +232,27 @@ def test_box_statement_error(qasm_code, error_message, error_span, caplog):
             loads(qasm_code).unroll()
     assert error_message in str(err.value)
     assert error_span in caplog.text
+
+
+def test_box_measurement_with_classical_register():
+    """Measurement inside a box should have access to classical registers
+    declared in the enclosing (global) scope.
+
+    Regression: box scope was treated like function/gate scope, restricting
+    access to only constants and qubits from global scope. Classical registers
+    were invisible, causing 'Missing clbit register declaration' errors.
+    See: https://github.com/qBraid/pyqasm/issues/302
+    """
+    qasm_str = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[4] q;
+    bit[3] c;
+
+    box [100ns] {
+        h q[0];
+        c[1] = measure q[1];
+    }
+    """
+    result = loads(qasm_str)
+    result.validate()

--- a/tests/qasm3/test_box.py
+++ b/tests/qasm3/test_box.py
@@ -282,3 +282,52 @@ def test_box_measurement_with_enclosing_block_scope():
     """
     result = loads(qasm_str)
     result.validate()
+
+
+def test_box_measurement_with_multiple_classical_registers():
+    """Measurement inside a box should have access to multiple classical
+    registers declared in the enclosing (global) scope."""
+    qasm_str = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[4] q;
+    bit[3] c0;
+    bit[2] c1;
+
+    box {
+        c0[0] = measure q[0];
+        c0[2] = measure q[2];
+        c1[1] = measure q[3];
+    }
+    """
+    result = loads(qasm_str)
+    result.validate()
+
+
+def test_multiple_box_statements():
+    """Multiple box statements in the same program should each have access
+    to classical registers from the enclosing scope."""
+    qasm_str = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[4] q;
+    bit[4] c;
+
+    box [50ns] {
+        h q[0];
+        c[0] = measure q[0];
+    }
+
+    box [100ns] {
+        cx q[1], q[2];
+        c[1] = measure q[1];
+        c[2] = measure q[2];
+    }
+
+    box {
+        h q[3];
+        c[3] = measure q[3];
+    }
+    """
+    result = loads(qasm_str)
+    result.validate()

--- a/tests/qasm3/test_box.py
+++ b/tests/qasm3/test_box.py
@@ -284,6 +284,26 @@ def test_box_measurement_with_enclosing_block_scope():
     result.validate()
 
 
+def test_box_measurement_with_block_scoped_register():
+    """Measurement inside a box nested within a block scope should have access
+    to a classical register declared in the immediate parent block scope."""
+    qasm_str = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[4] q;
+
+    if (true) {
+        bit[3] c;
+        box {
+            h q[0];
+            c[1] = measure q[1];
+        }
+    }
+    """
+    result = loads(qasm_str)
+    result.validate()
+
+
 def test_box_measurement_with_multiple_classical_registers():
     """Measurement inside a box should have access to multiple classical
     registers declared in the enclosing (global) scope."""


### PR DESCRIPTION
## Summary

- Fix `box` blocks being treated as isolated scopes (like `gate`/`function`), preventing access to classical registers from the enclosing scope
- `c[1] = measure q[1];` inside a `box` block now correctly resolves the classical register `c` declared at global scope

## Details

In `scope.py`, `get_from_visible_scope()` grouped `in_box_scope()` with `in_function_scope()` / `in_gate_scope()` / `in_pulse_scope()`, which only allows access to constants and qubits from global scope. Classical registers were invisible, causing "Missing clbit register declaration" errors.

Per the OpenQASM 3.0 spec, `box` is a timing directive that executes in the enclosing scope — not an isolated scope like a gate or function definition. This PR moves `in_box_scope()` to the block scope group, which has full parent scope visibility.

Closes #302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Classical register declarations are now visible inside box scopes; measurements in box blocks can reference registers declared in enclosing or global scopes without validation errors.
* **Documentation**
  * Changelog updated to document the above fix.
* **Tests**
  * Added tests covering measurements to classical registers from within box scopes (nested blocks, multiple registers, multiple boxes).
* **Chores**
  * Removed a pylint suggestion-mode setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->