### PR TITLE
Add c3x and rc3x gates, fix broken c4x, extend ctrl chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Types of changes:
 
 ### Fixed
 - Fixed the `c4x` (4-controlled X) gate, which previously raised `TypeError: c4x_gate() takes 4 positional arguments but 5 were given` because it was declared with four parameters for a five-qubit gate. It is now implemented via qiskit's structured `rc3x`/`c3sx`/`cphaseshift` decomposition. ([#320](https://github.com/qBraid/pyqasm/pull/320))
+- Added `inv @` (inverse modifier) support for the multi-controlled-X family: `inv @ c3x` / `inv @ c4x` resolve to the (self-inverse) gate, and `inv @ rc3x` / `inv @ rcccx` resolve to the correct relative-phase dagger. These previously raised `Unsupported / undeclared QASM operation`. ([#320](https://github.com/qBraid/pyqasm/pull/320))
+- Fixed the `ctrl @` modifier not resolving gate aliases: `ctrl @ toffoli` / `ctrl @ ccnot` (aliases of `ccx`) and `ctrl @ cnot` / `ctrl @ CX` (aliases of `cx`) now escalate controls identically to their canonical gate instead of raising `Unsupported controlled QASM operation`. ([#320](https://github.com/qBraid/pyqasm/pull/320))
 - Fixed classical register declarations not being visible inside `box` scope, causing "Missing clbit register declaration" errors for measurement statements inside box blocks. ([#306](https://github.com/qBraid/pyqasm/pull/306))
 - Fixed the backend-dependent `dt` duration unit being incorrectly relabeled as `ns` when unrolling `delay` and `box` statements without a `device_cycle_time`. Since `dt` cannot be converted to SI units without a sample rate, it is now preserved as `dt`. ([#317](https://github.com/qBraid/pyqasm/pull/317))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Types of changes:
 ## Unreleased
 
 ### Added
+- Added support for the `c3x` (3-controlled X) and `rc3x`/`rcccx` (relative-phase 3-controlled X) gates, decomposed into basis gates following qiskit's `C3XGate`/`RC3XGate` definitions. Also extended the `ctrl @` modifier chain so that 3- and 4-control stacks on `x` (e.g. `ctrl @ ctrl @ ctrl @ x`, `ctrl(4) @ x`) resolve to `c3x`/`c4x`. ([#320](https://github.com/qBraid/pyqasm/pull/320))
 
 ### Improved / Modified
 
@@ -23,6 +24,7 @@ Types of changes:
 ### Removed
 
 ### Fixed
+- Fixed the `c4x` (4-controlled X) gate, which previously raised `TypeError: c4x_gate() takes 4 positional arguments but 5 were given` because it was declared with four parameters for a five-qubit gate. It is now implemented via qiskit's structured `rc3x`/`c3sx`/`cphaseshift` decomposition. ([#320](https://github.com/qBraid/pyqasm/pull/320))
 - Fixed classical register declarations not being visible inside `box` scope, causing "Missing clbit register declaration" errors for measurement statements inside box blocks. ([#306](https://github.com/qBraid/pyqasm/pull/306))
 - Fixed the backend-dependent `dt` duration unit being incorrectly relabeled as `ns` when unrolling `delay` and `box` statements without a `device_cycle_time`. Since `dt` cannot be converted to SI units without a sample rate, it is now preserved as `dt`. ([#317](https://github.com/qBraid/pyqasm/pull/317))
 

--- a/docs/gate_decompositions.md
+++ b/docs/gate_decompositions.md
@@ -617,3 +617,92 @@ q_3: ┤ H ├─■────────┤ H ├┤ H ├─■────
 «q_3:─■────────┤ H ├┤ H ├─■─────────┤ H ├┤ H ├─■────────┤ H ├
 «              └───┘└───┘           └───┘└───┘          └───┘ 
 ```
+## [C3X Gate](../src/pyqasm/maps/gates.py#L766)
+
+The C3X (3-Controlled-X) gate is implemented using the following qiskit decomposition
+(translated from `qiskit.circuit.library.C3XGate.definition`, built from `h`, `p` and `cx`):
+
+```python
+In [1]: from qiskit.circuit.library import C3XGate
+In [2]: from qiskit import QuantumCircuit
+In [3]: qc = QuantumCircuit(4); qc.append(C3XGate(), range(4))
+In [4]: qc.draw()
+Out[4]:
+
+q_0: ──■──
+       │
+q_1: ──■──
+       │
+q_2: ──■──
+     ┌─┴─┐
+q_3: ┤ X ├
+     └───┘
+
+In [5]: qc.decompose().draw()
+Out[5]:
+                                                              ...
+     ┌────────┐                                               ...
+q_0: ┤ P(π/8) ├──■───────────────■─────────────...
+     ├────────┤┌─┴─┐┌─────────┐┌─┴─┐                          ...
+q_1: ┤ P(π/8) ├┤ X ├┤ P(-π/8) ├┤ X ├──■───────────────────...
+     ├────────┤└───┘└─────────┘└───┘┌─┴─┐┌─────────┐┌─┴─┐    ...
+q_2: ┤ P(π/8) ├─────────────────────┤ X ├┤ P(-π/8) ├┤ X ├──...
+     ├───┬────┤┌────────┐            └───┘└─────────┘└───┘    ...
+q_3: ┤ H ├────┤ P(π/8) ├ ...  (h · p(±π/8) · cx ladder) ...  ┤ H ├
+     └───┘    └────────┘                                      └───┘
+```
+
+The verified decomposition reproduces the exact `C3XGate` unitary (no global phase).
+
+## [RC3X Gate](../src/pyqasm/maps/gates.py#L809)
+
+The RC3X (relative-phase 3-Controlled-X, a.k.a. `rcccx`) gate is a phase-relaxed variant of
+`c3x` that uses fewer gates. It is implemented using the following qiskit decomposition
+(translated from `qiskit.circuit.library.RC3XGate.definition`, built from `h`, `t`, `tdg`, `cx`):
+
+```python
+In [1]: from qiskit.circuit.library import RC3XGate
+In [2]: from qiskit import QuantumCircuit
+In [3]: qc = QuantumCircuit(4); qc.append(RC3XGate(), range(4))
+In [4]: qc.decompose().draw()
+Out[4]:
+
+q_0: ──────────────────────────────■─────────────────────■────────────────────────
+                                    │                     │
+q_1: ───────────────────────────────────────■────────────────────■─────────────────
+                                    │        │           │         │
+q_2: ────────────■──────────────────┼────────┼───────────┼─────────┼───────■─────────
+     ┌───┐┌───┐┌─┴─┐┌─────┐┌───┐┌─┴─┐┌───┐┌─┴─┐┌─────┐┌─┴─┐┌───┐┌─┴─┐┌─────┐┌─┴─┐┌───┐
+q_3: ┤ H ├┤ T ├┤ X ├┤ Tdg ├┤ H ├┤ X ├┤ T ├┤ X ├┤ Tdg ├┤ X ├┤ T ├┤ X ├┤ Tdg ├┤ X ├┤ H ├
+     └───┘└───┘└───┘└─────┘└───┘└───┘└───┘└───┘└─────┘└───┘└───┘└───┘└─────┘└───┘└───┘
+```
+
+The verified decomposition reproduces the exact `RC3XGate` unitary (no global phase).
+
+## [C4X Gate](../src/pyqasm/maps/gates.py#L867)
+
+The C4X (4-Controlled-X) gate is implemented using qiskit's structured decomposition
+(translated from `qiskit.circuit.library.C4XGate.definition`) in terms of `h`,
+`cphaseshift` (`cp`), the relative-phase `rc3x` and its inverse, and `c3sx`:
+
+```python
+In [1]: from qiskit.circuit.library import C4XGate
+In [2]: from qiskit import QuantumCircuit
+In [3]: qc = QuantumCircuit(5); qc.append(C4XGate(), range(5))
+In [4]: qc.decompose().draw()
+Out[4]:
+                   ┌────────┐               ┌───────────┐
+q_0: ──────────────┤0       ├───────────────┤0          ├──■───
+                   │        │               │           │  │
+q_1: ──────────────┤1       ├───────────────┤1          ├──■───
+                   │  rcccx │               │  rcccx_dg │  │
+q_2: ──────────────┤2       ├───────────────┤2          ├──■───
+                   │        │               │           │  │
+q_3: ──────■───────┤3       ├──────■────────┤3          ├──┼───
+     ┌───┐ │P(π/2) └────────┘┌───┐ │P(-π/2) └───────────┘┌─┴──┐
+q_4: ┤ H ├─■─────────┤ H ├───┤ H ├─■───────────┤ H ├─────┤ Sx ├
+     └───┘           └───┘   └───┘             └───┘     └────┘
+```
+
+The decomposition reproduces the `C4XGate` unitary up to a global phase, inherited from
+pyqasm's `c3sx` implementation; this is physically irrelevant for the standalone gate.

--- a/src/pyqasm/maps/gates.py
+++ b/src/pyqasm/maps/gates.py
@@ -1254,6 +1254,10 @@ def map_qasm_ctrl_op_to_callable(op_name: str, ctrl_count: int):
             return TWO_QUBIT_OP_MAP[ctrl_op_name], 2
         if ctrl_op_name in THREE_QUBIT_OP_MAP:
             return THREE_QUBIT_OP_MAP[ctrl_op_name], 3
+        if ctrl_op_name in FOUR_QUBIT_OP_MAP:
+            return FOUR_QUBIT_OP_MAP[ctrl_op_name], 4
+        if ctrl_op_name in FIVE_QUBIT_OP_MAP:
+            return FIVE_QUBIT_OP_MAP[ctrl_op_name], 5
 
     # TODO: decompose controls if not built in
     raise ValidationError(

--- a/src/pyqasm/maps/gates.py
+++ b/src/pyqasm/maps/gates.py
@@ -1166,6 +1166,17 @@ U_INV_ROTATION_MAP = {
     "u2": u2_inv_gate,
 }
 
+# Inverses for the multi-controlled-X family. ``c3x`` / ``c4x`` are
+# self-inverse (the inverse of a multi-controlled X is the same gate), while
+# ``rc3x`` / ``rcccx`` are relative-phase Toffolis whose inverse is the
+# dedicated :func:`_rc3x_dg_gate` decomposition.
+MULTI_CONTROLLED_X_INV_MAP = {
+    "c3x": (c3x_gate, 4),
+    "c4x": (c4x_gate, 5),
+    "rc3x": (_rc3x_dg_gate, 4),
+    "rcccx": (_rc3x_dg_gate, 4),
+}
+
 
 def map_qasm_inv_op_to_callable(op_name: str):
     """
@@ -1178,15 +1189,18 @@ def map_qasm_inv_op_to_callable(op_name: str):
         tuple: A tuple containing the callable, the number of qubits the operation acts on,
         and what is to be done with the basic gate which we are trying to invert.
     """
-    if op_name in SELF_INVERTING_ONE_QUBIT_OP_SET:
-        return ONE_QUBIT_OP_MAP[op_name], 1, InversionOp.NO_OP
-    if op_name in ST_GATE_INV_MAP:
-        inv_gate_name = ST_GATE_INV_MAP[op_name]
+    if op_name in SELF_INVERTING_ONE_QUBIT_OP_SET or op_name in ST_GATE_INV_MAP:
+        # Self-inverting gates map to themselves; S/T map to their dagger and
+        # vice versa. Either way the result is a single-qubit gate applied as-is.
+        inv_gate_name = ST_GATE_INV_MAP.get(op_name, op_name)
         return ONE_QUBIT_OP_MAP[inv_gate_name], 1, InversionOp.NO_OP
     if op_name in TWO_QUBIT_OP_MAP:
         return TWO_QUBIT_OP_MAP[op_name], 2, InversionOp.NO_OP
     if op_name in THREE_QUBIT_OP_MAP:
         return THREE_QUBIT_OP_MAP[op_name], 3, InversionOp.NO_OP
+    if op_name in MULTI_CONTROLLED_X_INV_MAP:
+        inv_func, num_qubits = MULTI_CONTROLLED_X_INV_MAP[op_name]
+        return inv_func, num_qubits, InversionOp.NO_OP
     if op_name in U_INV_ROTATION_MAP:
         # Special handling for U gate as it is composed of multiple
         # basic gates and we need to invert each of them
@@ -1230,6 +1244,16 @@ CTRL_GATE_MAP = {
     "c3x": "c4x",
 }
 
+# Gate aliases share a callable with their canonical gate, but only the
+# canonical spelling appears in CTRL_GATE_MAP. Normalising them before
+# escalating controls lets e.g. ``ctrl @ toffoli`` behave like ``ctrl @ ccx``.
+CTRL_OP_ALIAS_MAP = {
+    "cnot": "cx",
+    "CX": "cx",
+    "toffoli": "ccx",
+    "ccnot": "ccx",
+}
+
 
 def map_qasm_ctrl_op_to_callable(op_name: str, ctrl_count: int):
     """
@@ -1243,7 +1267,7 @@ def map_qasm_ctrl_op_to_callable(op_name: str, ctrl_count: int):
         tuple: A tuple containing the callable and the number of qubits the operation acts on.
     """
 
-    ctrl_op_name, c = op_name, ctrl_count
+    ctrl_op_name, c = CTRL_OP_ALIAS_MAP.get(op_name, op_name), ctrl_count
     while c > 0 and ctrl_op_name in CTRL_GATE_MAP:
         ctrl_op_name = CTRL_GATE_MAP[ctrl_op_name]
         c -= 1

--- a/src/pyqasm/maps/gates.py
+++ b/src/pyqasm/maps/gates.py
@@ -763,23 +763,127 @@ def c3sx_gate(
     return result
 
 
-def c4x_gate(
+def c3x_gate(
     qubit0: IndexedIdentifier,
     qubit1: IndexedIdentifier,
     qubit2: IndexedIdentifier,
     qubit3: IndexedIdentifier,
 ) -> list[QuantumGate]:
-    """
-    Implements the c4x gate
-    """
-    return [
-        QuantumGate(
-            modifiers=[],
-            name=Identifier(name="c4x"),
-            arguments=[],
-            qubits=[qubit0, qubit1, qubit2, qubit3],
-        )
-    ]
+    """Implements the c3x (3-controlled X) gate as a decomposition of h/p/cx."""
+    pi = CONSTANTS_MAP["pi"]
+    result: list[QuantumGate] = []
+    result.extend(one_qubit_gate_op("h", qubit3))
+    result.extend(one_qubit_rotation_op("p", pi / 8, qubit0))
+    result.extend(one_qubit_rotation_op("p", pi / 8, qubit1))
+    result.extend(one_qubit_rotation_op("p", pi / 8, qubit2))
+    result.extend(one_qubit_rotation_op("p", pi / 8, qubit3))
+    result.extend(two_qubit_gate_op("cx", qubit0, qubit1))
+    result.extend(one_qubit_rotation_op("p", -pi / 8, qubit1))
+    result.extend(two_qubit_gate_op("cx", qubit0, qubit1))
+    result.extend(two_qubit_gate_op("cx", qubit1, qubit2))
+    result.extend(one_qubit_rotation_op("p", -pi / 8, qubit2))
+    result.extend(two_qubit_gate_op("cx", qubit0, qubit2))
+    result.extend(one_qubit_rotation_op("p", pi / 8, qubit2))
+    result.extend(two_qubit_gate_op("cx", qubit1, qubit2))
+    result.extend(one_qubit_rotation_op("p", -pi / 8, qubit2))
+    result.extend(two_qubit_gate_op("cx", qubit0, qubit2))
+    result.extend(two_qubit_gate_op("cx", qubit2, qubit3))
+    result.extend(one_qubit_rotation_op("p", -pi / 8, qubit3))
+    result.extend(two_qubit_gate_op("cx", qubit1, qubit3))
+    result.extend(one_qubit_rotation_op("p", pi / 8, qubit3))
+    result.extend(two_qubit_gate_op("cx", qubit2, qubit3))
+    result.extend(one_qubit_rotation_op("p", -pi / 8, qubit3))
+    result.extend(two_qubit_gate_op("cx", qubit0, qubit3))
+    result.extend(one_qubit_rotation_op("p", pi / 8, qubit3))
+    result.extend(two_qubit_gate_op("cx", qubit2, qubit3))
+    result.extend(one_qubit_rotation_op("p", -pi / 8, qubit3))
+    result.extend(two_qubit_gate_op("cx", qubit1, qubit3))
+    result.extend(one_qubit_rotation_op("p", pi / 8, qubit3))
+    result.extend(two_qubit_gate_op("cx", qubit2, qubit3))
+    result.extend(one_qubit_rotation_op("p", -pi / 8, qubit3))
+    result.extend(two_qubit_gate_op("cx", qubit0, qubit3))
+    result.extend(one_qubit_gate_op("h", qubit3))
+    return result
+
+
+def rc3x_gate(
+    qubit0: IndexedIdentifier,
+    qubit1: IndexedIdentifier,
+    qubit2: IndexedIdentifier,
+    qubit3: IndexedIdentifier,
+) -> list[QuantumGate]:
+    """Implements the rc3x (relative-phase 3-controlled X) gate."""
+    result: list[QuantumGate] = []
+    result.extend(one_qubit_gate_op("h", qubit3))
+    result.extend(one_qubit_gate_op("t", qubit3))
+    result.extend(two_qubit_gate_op("cx", qubit2, qubit3))
+    result.extend(one_qubit_gate_op("tdg", qubit3))
+    result.extend(one_qubit_gate_op("h", qubit3))
+    result.extend(two_qubit_gate_op("cx", qubit0, qubit3))
+    result.extend(one_qubit_gate_op("t", qubit3))
+    result.extend(two_qubit_gate_op("cx", qubit1, qubit3))
+    result.extend(one_qubit_gate_op("tdg", qubit3))
+    result.extend(two_qubit_gate_op("cx", qubit0, qubit3))
+    result.extend(one_qubit_gate_op("t", qubit3))
+    result.extend(two_qubit_gate_op("cx", qubit1, qubit3))
+    result.extend(one_qubit_gate_op("tdg", qubit3))
+    result.extend(one_qubit_gate_op("h", qubit3))
+    result.extend(one_qubit_gate_op("t", qubit3))
+    result.extend(two_qubit_gate_op("cx", qubit2, qubit3))
+    result.extend(one_qubit_gate_op("tdg", qubit3))
+    result.extend(one_qubit_gate_op("h", qubit3))
+    return result
+
+
+def _rc3x_dg_gate(
+    qubit0: IndexedIdentifier,
+    qubit1: IndexedIdentifier,
+    qubit2: IndexedIdentifier,
+    qubit3: IndexedIdentifier,
+) -> list[QuantumGate]:
+    """Inverse of :func:`rc3x_gate`, used in the c4x decomposition."""
+    result: list[QuantumGate] = []
+    result.extend(one_qubit_gate_op("h", qubit3))
+    result.extend(one_qubit_gate_op("t", qubit3))
+    result.extend(two_qubit_gate_op("cx", qubit2, qubit3))
+    result.extend(one_qubit_gate_op("tdg", qubit3))
+    result.extend(one_qubit_gate_op("h", qubit3))
+    result.extend(one_qubit_gate_op("t", qubit3))
+    result.extend(two_qubit_gate_op("cx", qubit1, qubit3))
+    result.extend(one_qubit_gate_op("tdg", qubit3))
+    result.extend(two_qubit_gate_op("cx", qubit0, qubit3))
+    result.extend(one_qubit_gate_op("t", qubit3))
+    result.extend(two_qubit_gate_op("cx", qubit1, qubit3))
+    result.extend(one_qubit_gate_op("tdg", qubit3))
+    result.extend(two_qubit_gate_op("cx", qubit0, qubit3))
+    result.extend(one_qubit_gate_op("h", qubit3))
+    result.extend(one_qubit_gate_op("t", qubit3))
+    result.extend(two_qubit_gate_op("cx", qubit2, qubit3))
+    result.extend(one_qubit_gate_op("tdg", qubit3))
+    result.extend(one_qubit_gate_op("h", qubit3))
+    return result
+
+
+def c4x_gate(
+    qubit0: IndexedIdentifier,
+    qubit1: IndexedIdentifier,
+    qubit2: IndexedIdentifier,
+    qubit3: IndexedIdentifier,
+    qubit4: IndexedIdentifier,
+) -> list[QuantumGate]:
+    """Implements the c4x (4-controlled X) gate via rc3x, c3sx and cphaseshift."""
+    pi = CONSTANTS_MAP["pi"]
+    result: list[QuantumGate] = []
+    result.extend(one_qubit_gate_op("h", qubit4))
+    result.extend(cphaseshift_gate(pi / 2, qubit3, qubit4))
+    result.extend(one_qubit_gate_op("h", qubit4))
+    result.extend(rc3x_gate(qubit0, qubit1, qubit2, qubit3))
+    result.extend(one_qubit_gate_op("h", qubit4))
+    result.extend(cphaseshift_gate(-pi / 2, qubit3, qubit4))
+    result.extend(one_qubit_gate_op("h", qubit4))
+    result.extend(_rc3x_dg_gate(qubit0, qubit1, qubit2, qubit3))
+    result.extend(c3sx_gate(qubit0, qubit1, qubit2, qubit4))
+    return result
 
 
 def prx_gate(theta, phi, qubit_id) -> list[QuantumGate]:
@@ -918,7 +1022,13 @@ THREE_QUBIT_OP_MAP = {
     "rccx": rccx_gate,
 }
 
-FOUR_QUBIT_OP_MAP = {"c3sx": c3sx_gate, "c3sqrtx": c3sx_gate}
+FOUR_QUBIT_OP_MAP = {
+    "c3sx": c3sx_gate,
+    "c3sqrtx": c3sx_gate,
+    "c3x": c3x_gate,
+    "rc3x": rc3x_gate,
+    "rcccx": rc3x_gate,
+}
 
 FIVE_QUBIT_OP_MAP = {
     "c4x": c4x_gate,
@@ -1116,6 +1226,8 @@ CTRL_GATE_MAP = {
     "u": "cu",
     "swap": "cswap",
     "cx": "ccx",
+    "ccx": "c3x",
+    "c3x": "c4x",
 }
 
 

--- a/tests/qasm3/resources/gates.py
+++ b/tests/qasm3/resources/gates.py
@@ -24,6 +24,7 @@ import os
 import pytest
 
 from pyqasm.maps.gates import (
+    FIVE_QUBIT_OP_MAP,
     FOUR_QUBIT_OP_MAP,
     ONE_QUBIT_OP_MAP,
     ONE_QUBIT_ROTATION_MAP,
@@ -42,6 +43,7 @@ VALID_GATE_NAMES = set(
     | ONE_QUBIT_ROTATION_MAP.keys()
     | THREE_QUBIT_OP_MAP.keys()
     | FOUR_QUBIT_OP_MAP.keys()
+    | FIVE_QUBIT_OP_MAP.keys()
 )
 
 
@@ -182,6 +184,30 @@ for gate in FOUR_QUBIT_OP_MAP:
     locals()[name] = _generate_four_qubit_fixture(gate)
 
 
+def _generate_five_qubit_fixture(gate_name: str):
+    @pytest.fixture()
+    def test_fixture():
+        if gate_name not in VALID_GATE_NAMES:
+            raise ValueError(f"Unknown qasm3 gate {gate_name}")
+        qasm3_string = f"""
+        OPENQASM 3;
+        include "stdgates.inc";
+
+        qubit[5] q;
+        {gate_name} q[0], q[1], q[2], q[3], q[4];
+        {gate_name} q;
+        """
+        return qasm3_string
+
+    return test_fixture
+
+
+# Generate five-qubit gate fixtures
+for gate in FIVE_QUBIT_OP_MAP:
+    name = _fixture_name(gate)
+    locals()[name] = _generate_five_qubit_fixture(gate)
+
+
 def _generate_custom_op_fixture(op_name: str):
     print(os.getcwd())
 
@@ -243,6 +269,8 @@ for gate in already_tested_triple_op:
     triple_op_tests.remove(_fixture_name(gate))
 
 four_op_tests = [_fixture_name(s) for s in FOUR_QUBIT_OP_MAP]
+
+five_op_tests = [_fixture_name(s) for s in FIVE_QUBIT_OP_MAP]
 
 custom_op_tests = [_fixture_name(s) for s in CUSTOM_OPS]
 

--- a/tests/qasm3/test_gates.py
+++ b/tests/qasm3/test_gates.py
@@ -17,6 +17,7 @@ Module containing unit tests for unrolling quantum gates.
 
 """
 
+import openqasm3.ast as qasm3_ast
 import pytest
 
 from pyqasm.entrypoint import dumps, loads
@@ -27,6 +28,7 @@ from tests.qasm3.resources.gates import (
     SINGLE_QUBIT_GATE_INCORRECT_TESTS,
     custom_op_tests,
     double_op_tests,
+    five_op_tests,
     four_op_tests,
     rotation_tests,
     single_op_tests,
@@ -35,6 +37,7 @@ from tests.qasm3.resources.gates import (
 from tests.utils import (
     check_custom_qasm_gate_op,
     check_custom_qasm_gate_op_with_external_gates,
+    check_five_qubit_gate_op,
     check_four_qubit_gate_op,
     check_single_qubit_gate_op,
     check_single_qubit_rotation_op,
@@ -111,6 +114,20 @@ def test_four_qubit_qasm3_gates(circuit_name, request):
     assert result.num_qubits == 4
     assert result.num_clbits == 0
     check_four_qubit_gate_op(result.unrolled_ast, 2, qubit_list, gate_name)
+
+
+@pytest.mark.parametrize("circuit_name", five_op_tests)
+def test_five_qubit_qasm3_gates(circuit_name, request):
+    qubit_list = [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]]
+    gate_name = circuit_name.removeprefix("Fixture_")
+
+    qasm3_string = request.getfixturevalue(circuit_name)
+    result = loads(qasm3_string)
+    # we do not want to validate every gate inside it
+    result.unroll(external_gates=[gate_name])
+    assert result.num_qubits == 5
+    assert result.num_clbits == 0
+    check_five_qubit_gate_op(result.unrolled_ast, 2, qubit_list, gate_name)
 
 
 def test_gate_body_param_expression():
@@ -418,6 +435,65 @@ def test_ctrl_gate_modifier():
     assert result.num_qubits == 4
     check_two_qubit_gate_op(result.unrolled_ast, 1, [[0, 1]], "cz")
     check_three_qubit_gate_op(result.unrolled_ast, 2, [[0, 1, 2], [1, 2, 3]], "ccx")
+
+
+@pytest.mark.parametrize(
+    "gate_name, num_qubits",
+    [("c3x", 4), ("rc3x", 4), ("rcccx", 4), ("c4x", 5)],
+)
+def test_multi_controlled_x_decomposition(gate_name, num_qubits):
+    """c3x / rc3x / c4x fully decompose into supported basis gates."""
+    qubits = ", ".join(f"q[{i}]" for i in range(num_qubits))
+    qasm3_string = f"""
+    OPENQASM 3;
+    include "stdgates.inc";
+    qubit[{num_qubits}] q;
+    {gate_name} {qubits};
+    """
+    result = loads(qasm3_string)
+    result.unroll()
+    assert result.num_qubits == num_qubits
+
+    # The high-level gate is decomposed away, leaving only basis gates.
+    allowed = {"h", "p", "cx", "t", "tdg", "rx", "rz", "x", "z", "cp", "ccx"}
+    seen = set()
+    for stmt in result.unrolled_ast.statements:
+        if isinstance(stmt, qasm3_ast.QuantumGate):
+            seen.add(stmt.name.name)
+    assert gate_name not in seen
+    assert seen.issubset(allowed), f"unexpected gates produced: {seen - allowed}"
+
+
+@pytest.mark.parametrize(
+    "named, chained, num_qubits",
+    [
+        # 3-controlled X: c3x == ctrl@ctrl@ctrl@x == ctrl@ccx
+        ("c3x q[0], q[1], q[2], q[3];", "ctrl @ ctrl @ ctrl @ x q[0], q[1], q[2], q[3];", 4),
+        ("c3x q[0], q[1], q[2], q[3];", "ctrl @ ccx q[0], q[1], q[2], q[3];", 4),
+        # 4-controlled X: c4x == ctrl(4)@x == ctrl@c3x
+        (
+            "c4x q[0], q[1], q[2], q[3], q[4];",
+            "ctrl(4) @ x q[0], q[1], q[2], q[3], q[4];",
+            5,
+        ),
+        (
+            "c4x q[0], q[1], q[2], q[3], q[4];",
+            "ctrl @ c3x q[0], q[1], q[2], q[3], q[4];",
+            5,
+        ),
+    ],
+)
+def test_ctrl_chain_beyond_two_controls(named, chained, num_qubits):
+    """The ctrl modifier chain resolves beyond two controls via c3x / c4x."""
+    header = f'OPENQASM 3;\ninclude "stdgates.inc";\nqubit[{num_qubits}] q;\n'
+
+    named_result = loads(header + named)
+    named_result.unroll()
+
+    chained_result = loads(header + chained)
+    chained_result.unroll()
+
+    assert dumps(named_result) == dumps(chained_result)
 
 
 def test_negctrl_gate_modifier():

--- a/tests/qasm3/test_gates.py
+++ b/tests/qasm3/test_gates.py
@@ -17,6 +17,7 @@ Module containing unit tests for unrolling quantum gates.
 
 """
 
+import numpy as np
 import openqasm3.ast as qasm3_ast
 import pytest
 
@@ -35,6 +36,7 @@ from tests.qasm3.resources.gates import (
     triple_op_tests,
 )
 from tests.utils import (
+    assert_unitary_equal,
     check_custom_qasm_gate_op,
     check_custom_qasm_gate_op_with_external_gates,
     check_five_qubit_gate_op,
@@ -44,6 +46,8 @@ from tests.utils import (
     check_three_qubit_gate_op,
     check_two_qubit_gate_op,
     check_unrolled_qasm,
+    mcx_unitary,
+    unitary_from_unrolled_ast,
 )
 
 
@@ -494,6 +498,157 @@ def test_ctrl_chain_beyond_two_controls(named, chained, num_qubits):
     chained_result.unroll()
 
     assert dumps(named_result) == dumps(chained_result)
+
+
+@pytest.mark.parametrize(
+    "alias, canonical, num_qubits",
+    [
+        # Gate aliases must escalate controls identically to their canonical gate.
+        ("ctrl @ cnot q[0], q[1], q[2];", "ctrl @ cx q[0], q[1], q[2];", 3),
+        ("ctrl @ CX q[0], q[1], q[2];", "ctrl @ cx q[0], q[1], q[2];", 3),
+        ("ctrl @ toffoli q[0], q[1], q[2], q[3];", "ctrl @ ccx q[0], q[1], q[2], q[3];", 4),
+        ("ctrl @ ccnot q[0], q[1], q[2], q[3];", "ctrl @ ccx q[0], q[1], q[2], q[3];", 4),
+        (
+            "ctrl @ ctrl @ toffoli q[0], q[1], q[2], q[3], q[4];",
+            "c4x q[0], q[1], q[2], q[3], q[4];",
+            5,
+        ),
+    ],
+)
+def test_ctrl_chain_resolves_gate_aliases(alias, canonical, num_qubits):
+    """Controlling an aliased gate (cnot/CX/toffoli/ccnot) matches the canonical gate."""
+    header = f'OPENQASM 3;\ninclude "stdgates.inc";\nqubit[{num_qubits}] q;\n'
+
+    alias_result = loads(header + alias)
+    alias_result.unroll()
+
+    canonical_result = loads(header + canonical)
+    canonical_result.unroll()
+
+    assert dumps(alias_result) == dumps(canonical_result)
+
+
+def _unrolled_unitary(body, num_qubits):
+    """Unroll a single-statement program and return its realised operator."""
+    header = f'OPENQASM 3;\ninclude "stdgates.inc";\nqubit[{num_qubits}] q;\n'
+    module = loads(header + body)
+    module.unroll()
+    return unitary_from_unrolled_ast(module.unrolled_ast, num_qubits)
+
+
+@pytest.mark.parametrize(
+    "body, num_qubits",
+    [
+        # Every spelling of the 3- and 4-controlled X must realise the same MCX
+        # operator. This is the real correctness check: a wrong angle or a
+        # swapped control/target survives a structural test but not this one.
+        ("c3x q[0], q[1], q[2], q[3];", 4),
+        ("ctrl @ ccx q[0], q[1], q[2], q[3];", 4),
+        ("ctrl @ ctrl @ ctrl @ x q[0], q[1], q[2], q[3];", 4),
+        ("ctrl @ ctrl @ cx q[0], q[1], q[2], q[3];", 4),
+        ("c4x q[0], q[1], q[2], q[3], q[4];", 5),
+        ("ctrl(4) @ x q[0], q[1], q[2], q[3], q[4];", 5),
+        ("ctrl @ c3x q[0], q[1], q[2], q[3], q[4];", 5),
+    ],
+)
+def test_multi_controlled_x_realises_mcx(body, num_qubits):
+    """c3x / c4x and their ctrl-chain equivalents implement the exact MCX unitary."""
+    assert_unitary_equal(_unrolled_unitary(body, num_qubits), mcx_unitary(num_qubits))
+
+
+@pytest.mark.parametrize(
+    "body, num_qubits, target",
+    [
+        # The target is the *last* listed qubit, not the highest index. Permuting
+        # the operands must move the target accordingly.
+        ("c3x q[3], q[0], q[1], q[2];", 4, 2),
+        ("c3x q[1], q[3], q[0], q[2];", 4, 2),
+        ("c4x q[4], q[3], q[2], q[1], q[0];", 5, 0),
+    ],
+)
+def test_multi_controlled_x_operand_order(body, num_qubits, target):
+    """Operand ordering selects the correct target qubit for the controlled-X."""
+    assert_unitary_equal(
+        _unrolled_unitary(body, num_qubits), mcx_unitary(num_qubits, target=target)
+    )
+
+
+def test_rc3x_is_relative_phase_toffoli():
+    """rc3x / rcccx is a relative-phase 3-controlled X: |U| matches the Toffoli."""
+    rc3x_u = _unrolled_unitary("rc3x q[0], q[1], q[2], q[3];", 4)
+    rcccx_u = _unrolled_unitary("rcccx q[0], q[1], q[2], q[3];", 4)
+    toffoli3 = mcx_unitary(4)
+
+    # rcccx is an alias for rc3x.
+    assert np.allclose(rc3x_u, rcccx_u, atol=1e-7)
+    # It must be unitary and share the Toffoli's permutation structure...
+    assert np.allclose(rc3x_u @ rc3x_u.conj().T, np.eye(16), atol=1e-7)
+    assert np.allclose(np.abs(rc3x_u), toffoli3, atol=1e-7)
+    # ...but it is NOT the true Toffoli: it carries relative phases (that is the
+    # whole point of the cheaper relative-phase decomposition).
+    assert not np.allclose(rc3x_u, toffoli3, atol=1e-7)
+
+
+@pytest.mark.parametrize(
+    "body, num_qubits, reference",
+    [
+        # inv @ <self-inverse gate> must round-trip back to the gate itself.
+        ("inv @ c3x q[0], q[1], q[2], q[3];", 4, lambda: mcx_unitary(4)),
+        ("inv @ c4x q[0], q[1], q[2], q[3], q[4];", 5, lambda: mcx_unitary(5)),
+    ],
+)
+def test_inverse_modifier_on_multi_controlled_x(body, num_qubits, reference):
+    """inv @ c3x / c4x is supported and equals the (self-inverse) gate."""
+    assert_unitary_equal(_unrolled_unitary(body, num_qubits), reference())
+
+
+@pytest.mark.parametrize("gate", ["rc3x", "rcccx"])
+def test_inverse_modifier_on_rc3x_round_trips(gate):
+    """rc3x is not self-inverse, but inv @ rc3x is its true dagger (round-trips to I)."""
+    body = f"{gate} q[0], q[1], q[2], q[3];\ninv @ {gate} q[0], q[1], q[2], q[3];"
+    assert_unitary_equal(_unrolled_unitary(body, 4), np.eye(16))
+
+
+def test_negctrl_chain_on_multi_controlled_x():
+    """A negctrl mixed into the control chain flips on the |0> state of that control."""
+    body = "negctrl @ ctrl @ ctrl @ x q[0], q[1], q[2], q[3];"
+    actual = _unrolled_unitary(body, 4)
+
+    expected = np.zeros((16, 16), dtype=complex)
+    for basis in range(16):
+        q0, q1, q2 = basis & 1, (basis >> 1) & 1, (basis >> 2) & 1
+        # control q0 is negative (active on 0), q1/q2 positive, target is q3
+        dest = basis ^ (1 << 3) if (q0 == 0 and q1 == 1 and q2 == 1) else basis
+        expected[dest, basis] = 1
+    assert_unitary_equal(actual, expected)
+
+
+@pytest.mark.parametrize(
+    "body, num_qubits",
+    [
+        # c4x has no controlled form (c5x is not defined), so a further control
+        # cannot be resolved and must raise rather than silently mis-decompose.
+        ("ctrl @ c4x q[0], q[1], q[2], q[3], q[4], q[5];", 6),
+        ("ctrl(5) @ x q[0], q[1], q[2], q[3], q[4], q[5];", 6),
+    ],
+)
+def test_too_many_controls_raises(body, num_qubits):
+    """Control chains requiring an undefined gate raise a clear ValidationError."""
+    header = f'OPENQASM 3;\ninclude "stdgates.inc";\nqubit[{num_qubits}] q;\n'
+    with pytest.raises(ValidationError, match="controlled QASM operation"):
+        loads(header + body).unroll()
+
+
+def test_inverse_of_unsupported_four_qubit_gate_raises():
+    """c3sx has no inverse decomposition; inv @ c3sx must fail loudly, not silently."""
+    qasm3_string = """
+    OPENQASM 3;
+    include "stdgates.inc";
+    qubit[4] q;
+    inv @ c3sx q[0], q[1], q[2], q[3];
+    """
+    with pytest.raises(ValidationError, match="Unsupported / undeclared QASM operation"):
+        loads(qasm3_string).unroll()
 
 
 def test_negctrl_gate_modifier():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -290,6 +290,20 @@ def check_four_qubit_gate_op(unrolled_ast, num_gates, qubit_list, gate_name):
     assert gate_count == num_gates
 
 
+def check_five_qubit_gate_op(unrolled_ast, num_gates, qubit_list, gate_name):
+    qubit_id, gate_count = 0, 0
+
+    for stmt in unrolled_ast.statements:
+        if isinstance(stmt, qasm3_ast.QuantumGate) and stmt.name.name == gate_name.lower():
+            assert len(stmt.qubits) == 5
+            for i in range(5):
+                assert stmt.qubits[i].indices[0][0].value == qubit_list[qubit_id][i]
+            qubit_id += 1
+            gate_count += 1
+
+    assert gate_count == num_gates
+
+
 def check_u3_gate_op(unrolled_ast, num_gates, qubit_list, param_list):
     op_count = 0
     q_id = 0

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,11 +17,161 @@ Module containing utility functions for unit tests.
 
 """
 
+import numpy as np
 import openqasm3.ast as qasm3_ast
 
 from pyqasm.maps.expressions import CONSTANTS_MAP
 
 CONTROLLED_ROTATION_TEST_ANGLE = 0.5
+
+
+# ---------------------------------------------------------------------------
+# Lightweight unitary simulator for verifying gate decompositions.
+#
+# Decomposing a high-level gate into a sequence of basis gates is only correct
+# if the resulting circuit implements the same unitary (up to global phase).
+# Structural ("which gates were produced") checks cannot catch a wrong angle,
+# a swapped control/target, or a sign error -- only a numerical comparison of
+# the realised operator can. The helpers below build the operator of an
+# unrolled circuit from scratch (no qiskit dependency) so the decompositions
+# added for c3x / rc3x / c4x can be pinned against their known matrices.
+# ---------------------------------------------------------------------------
+
+_I2 = np.eye(2, dtype=complex)
+_H = np.array([[1, 1], [1, -1]], dtype=complex) / np.sqrt(2)
+_X = np.array([[0, 1], [1, 0]], dtype=complex)
+_Y = np.array([[0, -1j], [1j, 0]], dtype=complex)
+_Z = np.diag([1, -1]).astype(complex)
+
+
+def _phase(theta):
+    return np.array([[1, 0], [0, np.exp(1j * theta)]], dtype=complex)
+
+
+def _rz(theta):
+    return np.array([[np.exp(-1j * theta / 2), 0], [0, np.exp(1j * theta / 2)]], dtype=complex)
+
+
+def _rx(theta):
+    cos, sin = np.cos(theta / 2), np.sin(theta / 2)
+    return np.array([[cos, -1j * sin], [-1j * sin, cos]], dtype=complex)
+
+
+def _ry(theta):
+    cos, sin = np.cos(theta / 2), np.sin(theta / 2)
+    return np.array([[cos, -sin], [sin, cos]], dtype=complex)
+
+
+_FIXED_ONE_QUBIT = {
+    "id": _I2,
+    "h": _H,
+    "x": _X,
+    "y": _Y,
+    "z": _Z,
+    "s": _phase(np.pi / 2),
+    "sdg": _phase(-np.pi / 2),
+    "t": _phase(np.pi / 4),
+    "tdg": _phase(-np.pi / 4),
+}
+_PARAM_ONE_QUBIT = {"p": _phase, "phaseshift": _phase, "rz": _rz, "rx": _rx, "ry": _ry}
+_PARAM_TWO_QUBIT = {"cp": _phase, "cphaseshift": _phase, "crz": _rz, "crx": _rx, "cry": _ry}
+_FIXED_TWO_QUBIT_TARGET = {"cx": _X, "cy": _Y, "cz": _Z}
+
+
+def _eval_angle(arg):
+    """Evaluate a (possibly negated/constant) numeric gate argument."""
+    value = getattr(arg, "value", None)
+    if value is not None:
+        return float(value)
+    if isinstance(arg, qasm3_ast.UnaryExpression) and arg.op.name == "-":
+        return -_eval_angle(arg.expression)
+    raise ValueError(f"Cannot evaluate gate argument: {arg!r}")
+
+
+def _embed_single(matrix, target, num_qubits):
+    """Embed a 1-qubit matrix acting on ``target`` (little-endian) into the full space."""
+    operator = np.array([[1]], dtype=complex)
+    for qubit in range(num_qubits):
+        operator = np.kron(matrix if qubit == target else _I2, operator)
+    return operator
+
+
+def _embed_controlled(matrix, control, target, num_qubits):
+    """Embed a controlled-``matrix`` (single control, single target)."""
+    proj0 = np.array([[1, 0], [0, 0]], dtype=complex)
+    proj1 = np.array([[0, 0], [0, 1]], dtype=complex)
+    op0 = np.array([[1]], dtype=complex)
+    op1 = np.array([[1]], dtype=complex)
+    for qubit in range(num_qubits):
+        if qubit == control:
+            op0, op1 = np.kron(proj0, op0), np.kron(proj1, op1)
+        elif qubit == target:
+            op0, op1 = np.kron(_I2, op0), np.kron(matrix, op1)
+        else:
+            op0, op1 = np.kron(_I2, op0), np.kron(_I2, op1)
+    return op0 + op1
+
+
+def unitary_from_unrolled_ast(unrolled_ast, num_qubits):
+    """Build the full operator of an unrolled circuit over basis/controlled gates.
+
+    Qubit ``i`` corresponds to ``q[i]`` and is treated as the ``i``-th (little
+    endian) tensor factor. Supports the basis gates the decompositions in this
+    repository emit plus their controlled variants.
+    """
+    unitary = np.eye(2**num_qubits, dtype=complex)
+    for stmt in unrolled_ast.statements:
+        if isinstance(stmt, qasm3_ast.QuantumPhase):
+            unitary = np.exp(1j * _eval_angle(stmt.argument)) * unitary
+            continue
+        if not isinstance(stmt, qasm3_ast.QuantumGate):
+            continue
+        name = stmt.name.name
+        qubits = [int(q.indices[0][0].value) for q in stmt.qubits]
+        args = [_eval_angle(a) for a in stmt.arguments]
+        if name in _FIXED_ONE_QUBIT:
+            gate = _embed_single(_FIXED_ONE_QUBIT[name], qubits[0], num_qubits)
+        elif name in _PARAM_ONE_QUBIT:
+            gate = _embed_single(_PARAM_ONE_QUBIT[name](args[0]), qubits[0], num_qubits)
+        elif name in _FIXED_TWO_QUBIT_TARGET:
+            gate = _embed_controlled(
+                _FIXED_TWO_QUBIT_TARGET[name], qubits[0], qubits[1], num_qubits
+            )
+        elif name in _PARAM_TWO_QUBIT:
+            gate = _embed_controlled(
+                _PARAM_TWO_QUBIT[name](args[0]), qubits[0], qubits[1], num_qubits
+            )
+        else:
+            raise ValueError(f"Unitary simulator does not support basis gate {name!r}")
+        unitary = gate @ unitary
+    return unitary
+
+
+def mcx_unitary(num_qubits, target=None):
+    """Reference multi-controlled-X: controls = all qubits except ``target``."""
+    if target is None:
+        target = num_qubits - 1
+    dim = 2**num_qubits
+    target_bit = 1 << target
+    control_mask = (dim - 1) ^ target_bit
+    unitary = np.zeros((dim, dim), dtype=complex)
+    for basis in range(dim):
+        dest = basis ^ target_bit if (basis & control_mask) == control_mask else basis
+        unitary[dest, basis] = 1
+    return unitary
+
+
+def assert_unitary_equal(actual, expected, atol=1e-7):
+    """Assert two operators are equal up to an irrelevant global phase."""
+    assert actual.shape == expected.shape
+    idx = np.unravel_index(np.argmax(np.abs(expected)), expected.shape)
+    ref = expected[idx]
+    if abs(ref) < 1e-9:
+        assert np.allclose(actual, expected, atol=atol)
+        return
+    phase = actual[idx] / ref
+    assert abs(abs(phase) - 1) < atol, "operators differ by more than a global phase"
+    assert np.allclose(actual, phase * expected, atol=atol), "operators are not equal up to phase"
 
 
 def check_unrolled_qasm(unrolled_qasm, expected_qasm):


### PR DESCRIPTION
## What

Adds the multi-controlled-X gates missing/broken in pyqasm, surfaced while transpiling qiskit's `qelib1.inc` extension gates (qBraid issue: `test_preprocess_qasm_1` is skipped because `c3x` is unsupported):

- **`c3x`** (3-controlled X) — was missing entirely. Added to `FOUR_QUBIT_OP_MAP`, decomposed into `h`/`p`/`cx` (translated from qiskit's `C3XGate.definition`).
- **`rc3x`** (relative-phase 3-controlled X, a.k.a. `rcccx`) — was missing. Added, decomposed into `h`/`t`/`tdg`/`cx`.
- **`c4x`** (4-controlled X) — was **broken**: `c4x_gate()` was declared with 4 parameters for a 5-qubit gate, so `c4x` raised `TypeError: c4x_gate() takes 4 positional arguments but 5 were given`. Reimplemented via `rc3x`/`c3sx`/`cphaseshift` (qiskit's structured decomposition).
- **`CTRL_GATE_MAP`** extended with `ccx -> c3x` and `c3x -> c4x` so the controlled-modifier chain resolves beyond 2 controls (`ctrl @ ctrl @ ctrl @ x` previously raised "Unsupported controlled QASM operation: x with 3 controls").
- **`map_qasm_ctrl_op_to_callable`** fixed: it resolved names through `CTRL_GATE_MAP` but only looked the result up in the one/two/three-qubit maps, so `c3x`/`c4x` resolved and then fell through to "Unsupported controlled QASM operation". The final lookup now also covers `FOUR_QUBIT_OP_MAP`/`FIVE_QUBIT_OP_MAP`, which is what actually makes the extended ctrl chain work.

## Why

`map_qasm_ctrl_op_to_callable` resolves controls by walking `CTRL_GATE_MAP` one step per control; the chain for X stopped at `ccx`, so 3+ controls were unsupported. And the named `c3x`/`c4x` gates from qiskit's qelib extensions weren't usable (`c3x` undefined, `c4x` crashing).

## Verification

Decompositions were checked against qiskit unitaries (`Operator`), not committed as a test dependency:

- `c3x` and `rc3x` reproduce the **exact** `C3XGate`/`RC3XGate` unitaries.
- `c4x` matches `C4XGate` **up to a global phase**, which is inherited from pyqasm's pre-existing `c3sx` implementation (same phase factor) and is physically irrelevant for the standalone gate.
- `ctrl @ ctrl @ ctrl @ x`, `ctrl @ ccx`, `ctrl(4) @ x`, and `ctrl @ c3x` all unroll to output identical to the corresponding named `c3x`/`c4x` gate.

Decompositions were generated directly from `qiskit.circuit.library.{C3XGate,RC3XGate,C4XGate}.definition`.
