### PR TITLE
ci: build Linux wheels on manylinux_2_28 instead of manylinux2014

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,27 +36,27 @@ jobs:
             python: 314
             platform_id: win_amd64
 
-          # Linux 64 bit manylinux2014
+          # Linux 64 bit manylinux_2_28
           - os: ubuntu-latest
             python: 310
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-latest
             python: 311
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-latest
             python: 312
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-latest
             python: 313
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-latest
             python: 314
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
 
           # MacOS x86_64
           - os: macos-15-intel

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -30,27 +30,27 @@ jobs:
             python: 314
             platform_id: win_amd64
 
-          # Linux 64 bit manylinux2014
+          # Linux 64 bit manylinux_2_28
           - os: ubuntu-latest
             python: 310
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-latest
             python: 311
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-latest
             python: 312
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-latest
             python: 313
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-latest
             python: 314
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
 
           # MacOS x86_64
           - os: macos-15-intel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,27 +32,27 @@ jobs:
             python: 314
             platform_id: win_amd64
 
-          # Linux 64 bit manylinux2014
+          # Linux 64 bit manylinux_2_28
           - os: ubuntu-latest
             python: 310
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-latest
             python: 311
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-latest
             python: 312
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-latest
             python: 313
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-latest
             python: 314
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
 
           # MacOS x86_64
           - os: macos-15-intel

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -30,27 +30,27 @@ jobs:
             python: 314
             platform_id: win_amd64
 
-          # Linux 64 bit manylinux2014
+          # Linux 64 bit manylinux_2_28
           - os: ubuntu-latest
             python: 310
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-latest
             python: 311
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-latest
             python: 312
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-latest
             python: 313
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
           - os: ubuntu-latest
             python: 314
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux_2_28
 
           # MacOS x86_64
           - os: macos-15-intel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Types of changes:
 - Fixed the backend-dependent `dt` duration unit being incorrectly relabeled as `ns` when unrolling `delay` and `box` statements without a `device_cycle_time`. Since `dt` cannot be converted to SI units without a sample rate, it is now preserved as `dt`. ([#317](https://github.com/qBraid/pyqasm/pull/317))
 
 ### Dependencies
+- Migrated the Linux wheel *build container* from `manylinux2014` to `manylinux_2_28`. NumPy stopped publishing `manylinux2014` (glibc 2.17) wheels for CPython 3.12+, so `pip` fell back to building NumPy from source inside the build container, whose GCC is older than NumPy requires — failing every Linux wheel job for cp312/cp313/cp314. The published wheels are unaffected: auditwheel tags them from the extension's actual symbol requirements, so they remain `manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64` and still install on glibc 2.17 systems.
 - Bumped `actions/configure-pages` from 5 to 6. ([#307](https://github.com/qBraid/pyqasm/pull/307))
 - Bumped `codecov/codecov-action` from 5.5.2 to 6.0.0. ([#308](https://github.com/qBraid/pyqasm/pull/308))
 - Bumped `actions/deploy-pages` from 4 to 5. ([#309](https://github.com/qBraid/pyqasm/pull/309))


### PR DESCRIPTION
## Summary of changes

Every Linux wheel job for **cp312 / cp313 / cp314** is currently failing on `main` and on every open PR (e.g. #324, #325). This fixes them.

### Why they fail

NumPy no longer publishes `manylinux2014` (glibc 2.17) wheels for those interpreters — it ships `manylinux_2_27` / `manylinux_2_28` only. NumPy is a **build** dependency here (it's in `build-system.requires`, and the Cython extension compiles against its headers), so `pip` inside the `manylinux2014` build container finds no compatible wheel, falls back to a source build, and dies because that image's GCC is older than NumPy's meson build requires:

```
Downloading numpy-2.5.1.tar.gz (20.8 MB)
...
../meson.build:25:4: ERROR: Problem encountered: NumPy requires GCC >= ...
error: metadata-generation-failed
```

cp310/cp311 still pass only because `pip` resolves them to an older NumPy that *does* have a manylinux2014 wheel — so this was always going to spread as those interpreters age out.

> [!NOTE]
> The `Error response from daemon: No such image: quay.io/pypa/manylinux2014_x86_64:...` line in the failing logs is a red herring — cibuildwheel emits it before pulling, and it appears on successful builds too. The image is pullable; the NumPy source build is the real failure.

### The fix

Switch the Linux **build container** from `manylinux2014` to `manylinux_2_28`, which is the platform NumPy itself now targets.

Applied to **all four** workflows that build wheels — `main`, `release`, `pre-release`, `test-release` — so the release pipeline doesn't hit the same wall when publishing.

### No impact on users

Only the build container changes; the published artifact does not. auditwheel tags the repaired wheel from the extension's **actual symbol requirements**, not from the image it was built in, and pyqasm's Cython extension only needs old glibc symbols. The wheel CI produces on this branch is still tagged:

```
pyqasm-1.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
```

so it installs on glibc 2.17 systems exactly as before. No minimum-glibc bump.

### Verification

Reproduced the failure and confirmed the fix directly inside the images:

| Image | Python | What pip resolves NumPy to |
|---|---|---|
| `manylinux2014` | cp312 | `numpy-2.5.1.tar.gz` (source build → GCC error) |
| `manylinux_2_28` | cp312 | `numpy-2.5.1-cp312-...-manylinux_2_28_x86_64.whl` |
| `manylinux_2_28` | cp314 | `numpy-2.5.1-cp314-...-manylinux_2_28_x86_64.whl` |

Also ran `cibuildwheel` locally end-to-end for `cp312-manylinux_x86_64` against this branch: wheel built and the in-container test suite passed (671 passed, 3 skipped).

CI on this PR is green — all five Linux wheel jobs that fail on `main` now pass.
