### PR TITLE
fix: nested external gate depth, and gate definition cycles of any length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Types of changes:
 ### Removed
 
 ### Fixed
+- Fixed an indirect cycle between gate definitions exhausting the Python stack: `gate a q { b q; }` with `gate b q { a q; }` raised a bare `RecursionError` naming nothing, while the direct case was already reported cleanly. The guard compared the body's gate name against one name, so it saw only a cycle of length one. It now tests membership of the whole expansion chain, and names the path: `Recursive definitions not allowed for gate 'a' (a -> b -> a)`. A gate reached twice down separate paths is a diamond, not a cycle, and still expands. ([#369](https://github.com/qBraid/pyqasm/issues/369))
 - Fixed a nested external custom gate counting the depth of the decomposition it skipped, the shape the [#352](https://github.com/qBraid/pyqasm/issues/352) fix did not reach: `unroll(external_gates=["outer"])` on a gate whose body calls another custom gate emitted one statement but reported `depth() == 13`. The suppression flag was assigned and cleared without save-restore, so the inner gate clobbered the outer gate's state in both directions. It is now saved and restored, and the depth is recorded once, from the outermost external gate. ([#367](https://github.com/qBraid/pyqasm/issues/367))
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Types of changes:
 ### Removed
 
 ### Fixed
+- Fixed a nested external custom gate counting the depth of the decomposition it skipped, the shape the [#352](https://github.com/qBraid/pyqasm/issues/352) fix did not reach: `unroll(external_gates=["outer"])` on a gate whose body calls another custom gate emitted one statement but reported `depth() == 13`. The suppression flag was assigned and cleared without save-restore, so the inner gate clobbered the outer gate's state in both directions. It is now saved and restored, and the depth is recorded once, from the outermost external gate. ([#367](https://github.com/qBraid/pyqasm/issues/367))
 
 ### Dependencies
 

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -1287,24 +1287,6 @@ class QasmVisitor:
             error_node=statement,
         )
 
-    def _raise_recursive_gate_error(self, gate_op: qasm3_ast.QuantumGate) -> None:
-        """Report a cyclic gate definition, naming the cycle it closes (issue #369).
-
-        Args:
-            gate_op (QuantumGate): The call in the gate body that closes the cycle.
-
-        Raises:
-            ValidationError: Always.
-        """
-        gate_name = gate_op.name.name
-        cycle = self._gate_expansion_chain[self._gate_expansion_chain.index(gate_name) :]
-        raise_qasm3_error(
-            f"Recursive definitions not allowed for gate '{gate_name}' "
-            f"({' -> '.join(cycle + [gate_name])})",
-            error_node=gate_op,
-            span=gate_op.span,
-        )
-
     def _visit_custom_gate_operation(
         self,
         operation: qasm3_ast.QuantumGate,
@@ -1377,7 +1359,17 @@ class QasmVisitor:
                         isinstance(gate_op, qasm3_ast.QuantumGate)
                         and gate_op.name.name in self._gate_expansion_chain
                     ):
-                        self._raise_recursive_gate_error(gate_op)
+                        # name the cycle the call closes, e.g. (a -> b -> a)
+                        called = gate_op.name.name
+                        cycle = self._gate_expansion_chain[
+                            self._gate_expansion_chain.index(called) :
+                        ] + [called]
+                        raise_qasm3_error(
+                            f"Recursive definitions not allowed for gate '{called}' "
+                            f"({' -> '.join(cycle)})",
+                            error_node=gate_op,
+                            span=gate_op.span,
+                        )
                     Qasm3Transformer.transform_gate_params(gate_op_copy, param_map)
                     Qasm3Transformer.transform_gate_qubits(gate_op_copy, qubit_map)
                     # need to trickle the inverse down to the child gates

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -1338,40 +1338,50 @@ class QasmVisitor:
         # Pause recording the depth of new gates because we are processing the
         # definition of a custom gate here - handle the depth separately afterwards.
         # A verbatim gate is emitted as written, so it counts once, like an external gate.
-        self._recording_ext_gate_depth = self._in_verbatim_box or gate_name in self._external_gates
+        # 'or', not '=': a nested gate must stay suppressed inside an enclosing external
+        # gate rather than re-enable recording for the body its parent skips (issue #367)
+        prev_recording = self._recording_ext_gate_depth
+        is_external = self._in_verbatim_box or gate_name in self._external_gates
+        self._recording_ext_gate_depth = prev_recording or is_external
 
         result = []
-        for gate_op in gate_definition_ops:
-            if isinstance(gate_op, (qasm3_ast.QuantumGate, qasm3_ast.QuantumPhase)):
-                gate_op_copy = copy.deepcopy(gate_op)
-                # necessary to avoid modifying the original gate definition
-                # in case the gate is reapplied
-                if isinstance(gate_op, qasm3_ast.QuantumGate) and gate_op.name.name == gate_name:
+        try:
+            for gate_op in gate_definition_ops:
+                if isinstance(gate_op, (qasm3_ast.QuantumGate, qasm3_ast.QuantumPhase)):
+                    gate_op_copy = copy.deepcopy(gate_op)
+                    # necessary to avoid modifying the original gate definition
+                    # in case the gate is reapplied
+                    if (
+                        isinstance(gate_op, qasm3_ast.QuantumGate)
+                        and gate_op.name.name == gate_name
+                    ):
+                        raise_qasm3_error(
+                            f"Recursive definitions not allowed for gate '{gate_name}'",
+                            error_node=gate_op,
+                            span=gate_op.span,
+                        )
+                    Qasm3Transformer.transform_gate_params(gate_op_copy, param_map)
+                    Qasm3Transformer.transform_gate_qubits(gate_op_copy, qubit_map)
+                    # need to trickle the inverse down to the child gates
+                    if inverse:
+                        # span doesn't matter as we don't analyze it
+                        gate_op_copy.modifiers.append(
+                            qasm3_ast.QuantumGateModifier(qasm3_ast.GateModifierName.inv, None)
+                        )
+                    result.extend(self._visit_generic_gate_operation(gate_op_copy, ctrls))
+                else:
+                    # TODO: add control flow support
                     raise_qasm3_error(
-                        f"Recursive definitions not allowed for gate '{gate_name}'",
+                        f"Unsupported statement in gate definition '{type(gate_op).__name__}'",
                         error_node=gate_op,
                         span=gate_op.span,
                     )
-                Qasm3Transformer.transform_gate_params(gate_op_copy, param_map)
-                Qasm3Transformer.transform_gate_qubits(gate_op_copy, qubit_map)
-                # need to trickle the inverse down to the child gates
-                if inverse:
-                    # span doesn't matter as we don't analyze it
-                    gate_op_copy.modifiers.append(
-                        qasm3_ast.QuantumGateModifier(qasm3_ast.GateModifierName.inv, None)
-                    )
-                result.extend(self._visit_generic_gate_operation(gate_op_copy, ctrls))
-            else:
-                # TODO: add control flow support
-                raise_qasm3_error(
-                    f"Unsupported statement in gate definition '{type(gate_op).__name__}'",
-                    error_node=gate_op,
-                    span=gate_op.span,
-                )
+        finally:
+            self._recording_ext_gate_depth = prev_recording
 
-        # Update the depth only once for the entire custom gate
-        if self._recording_ext_gate_depth:
-            self._recording_ext_gate_depth = False
+        # Update the depth once for the whole gate, from the outermost external gate only:
+        # an inner one is already covered by its parent's single count
+        if is_external and not prev_recording:
             if not self._in_branching_statement:  # if custom gate is not in branching statement
                 self._update_qubit_depth_for_gate([op_qubits], ctrls)
             else:

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -124,6 +124,9 @@ class QasmVisitor:
         self._function_qreg_transform_map: deque = deque([])  # for nested functions
         self._global_creg_size_map: dict[str, int] = {}
         self._custom_gates: dict[str, qasm3_ast.QuantumGateDefinition] = {}
+        # gates currently being expanded, outermost first; a name reappearing on it is a
+        # cycle of any length between gate definitions (issue #369)
+        self._gate_expansion_chain: list[str] = []
         self._external_gates: list[str] = [] if external_gates is None else external_gates
         self._subroutine_defns: dict[
             str, qasm3_ast.SubroutineDefinition | qasm3_ast.ExternDeclaration
@@ -1284,6 +1287,24 @@ class QasmVisitor:
             error_node=statement,
         )
 
+    def _raise_recursive_gate_error(self, gate_op: qasm3_ast.QuantumGate) -> None:
+        """Report a cyclic gate definition, naming the cycle it closes (issue #369).
+
+        Args:
+            gate_op (QuantumGate): The call in the gate body that closes the cycle.
+
+        Raises:
+            ValidationError: Always.
+        """
+        gate_name = gate_op.name.name
+        cycle = self._gate_expansion_chain[self._gate_expansion_chain.index(gate_name) :]
+        raise_qasm3_error(
+            f"Recursive definitions not allowed for gate '{gate_name}' "
+            f"({' -> '.join(cycle + [gate_name])})",
+            error_node=gate_op,
+            span=gate_op.span,
+        )
+
     def _visit_custom_gate_operation(
         self,
         operation: qasm3_ast.QuantumGate,
@@ -1345,6 +1366,7 @@ class QasmVisitor:
         self._recording_ext_gate_depth = prev_recording or is_external
 
         result = []
+        self._gate_expansion_chain.append(gate_name)
         try:
             for gate_op in gate_definition_ops:
                 if isinstance(gate_op, (qasm3_ast.QuantumGate, qasm3_ast.QuantumPhase)):
@@ -1353,13 +1375,9 @@ class QasmVisitor:
                     # in case the gate is reapplied
                     if (
                         isinstance(gate_op, qasm3_ast.QuantumGate)
-                        and gate_op.name.name == gate_name
+                        and gate_op.name.name in self._gate_expansion_chain
                     ):
-                        raise_qasm3_error(
-                            f"Recursive definitions not allowed for gate '{gate_name}'",
-                            error_node=gate_op,
-                            span=gate_op.span,
-                        )
+                        self._raise_recursive_gate_error(gate_op)
                     Qasm3Transformer.transform_gate_params(gate_op_copy, param_map)
                     Qasm3Transformer.transform_gate_qubits(gate_op_copy, qubit_map)
                     # need to trickle the inverse down to the child gates
@@ -1377,6 +1395,7 @@ class QasmVisitor:
                         span=gate_op.span,
                     )
         finally:
+            self._gate_expansion_chain.pop()
             self._recording_ext_gate_depth = prev_recording
 
         # Update the depth once for the whole gate, from the outermost external gate only:

--- a/tests/qasm3/resources/gates.py
+++ b/tests/qasm3/resources/gates.py
@@ -484,6 +484,57 @@ CUSTOM_GATE_INCORRECT_TESTS = {
         12,
         "custom_gate(a, b) p, q;",
     ),
+    # A cycle of length two between gate definitions used to exhaust the Python stack
+    # with a bare RecursionError, because the guard compared a single name (issue #369)
+    "indirect_recursive_definition": (
+        """
+        OPENQASM 3;
+        include "stdgates.inc";
+
+        gate gate_a(a) p{
+            gate_b(a) p;
+        }
+
+        gate gate_b(a) p{
+            gate_a(a) p;
+        }
+
+        qubit[1] q1;
+        gate_a(0.5) q1;
+        """,
+        r"Recursive definitions not allowed for gate 'gate_a' \(gate_a -> gate_b -> gate_a\)",
+        10,
+        12,
+        "gate_a(a) p;",
+    ),
+    "three_gate_recursive_definition": (
+        """
+        OPENQASM 3;
+        include "stdgates.inc";
+
+        gate gate_a(a) p{
+            gate_b(a) p;
+        }
+
+        gate gate_b(a) p{
+            gate_c(a) p;
+        }
+
+        gate gate_c(a) p{
+            gate_a(a) p;
+        }
+
+        qubit[1] q1;
+        gate_a(0.5) q1;
+        """,
+        (
+            r"Recursive definitions not allowed for gate 'gate_a' "
+            r"\(gate_a -> gate_b -> gate_c -> gate_a\)"
+        ),
+        14,
+        12,
+        "gate_a(a) p;",
+    ),
     "duplicate_definition": (
         """
         OPENQASM 3;

--- a/tests/qasm3/test_depth.py
+++ b/tests/qasm3/test_depth.py
@@ -711,6 +711,44 @@ def test_external_basic_gate_counts_own_depth():
     assert result.depth() == 1
 
 
+NESTED_EXTERNAL_GATE_DEPTH = """
+OPENQASM 3.0;
+include "stdgates.inc";
+gate inner a, b { crz(0.5) a, b; }
+gate outer a, b { inner a, b; h a; }
+qubit[2] q;
+outer q[0], q[1];
+"""
+
+
+@pytest.mark.parametrize("external_gates", [["outer"], ["inner", "outer"]])
+def test_nested_external_custom_gate_counts_own_depth(external_gates):
+    """An external custom gate whose body calls another custom gate emits one statement,
+    so it counts as depth 1. The two parametrizations failed differently before the fix:
+    13 and 2 respectively (issue #367)."""
+    result = loads(NESTED_EXTERNAL_GATE_DEPTH)
+    result.unroll(external_gates=external_gates)
+    assert len(result.unrolled_ast.statements) == 3  # OPENQASM, include, outer
+    assert result.depth() == 1
+
+
+def test_nested_custom_gate_depth_unchanged_without_external_gates():
+    """The nested shape still decomposes fully when nothing is external, so the flag
+    handling cannot silently suppress ordinary depth counting."""
+    result = loads(NESTED_EXTERNAL_GATE_DEPTH)
+    result.unroll()
+    assert result.depth() == 13
+
+
+def test_inner_external_gate_records_depth_inside_plain_custom_gate():
+    """Only the outermost external gate is skipped, so an inner one still records its own
+    depth when the enclosing gate is not external."""
+    result = loads(NESTED_EXTERNAL_GATE_DEPTH)
+    result.unroll(external_gates=["inner"])
+    # inner counts once on q[0], q[1], then `h a` adds one more on q[0]
+    assert result.depth() == 2
+
+
 def test_external_basic_gate_depth_with_neighbours():
     """External gate depth composes with surrounding gates like any single gate"""
     qasm3_string = """

--- a/tests/qasm3/test_gates.py
+++ b/tests/qasm3/test_gates.py
@@ -876,6 +876,63 @@ def test_incorrect_custom_ops(test_name, caplog):
     assert line in caplog.text
 
 
+def test_shared_gate_definition_is_not_recursion():
+    """A gate reached twice down separate paths is a diamond, not a cycle. Testing the
+    expansion chain rather than a set of every gate seen is what keeps this from being
+    reported as recursion (issue #369)."""
+    qasm3_string = """
+    OPENQASM 3;
+    include "stdgates.inc";
+
+    gate gate_d p{ x p; }
+    gate gate_b p{ gate_d p; }
+    gate gate_c p{ gate_d p; }
+    gate gate_a p{ gate_b p; gate_c p; }
+
+    qubit[1] q1;
+    gate_a q1;
+    """
+    module = loads(qasm3_string)
+    module.unroll()
+    check_single_qubit_gate_op(module.unrolled_ast, 2, [0, 0], "x")
+    assert module.depth() == 2
+
+
+def test_repeated_gate_call_in_one_body_is_not_recursion():
+    """The same gate called twice in a single body must expand twice, not raise:
+    the chain entry is popped when the first expansion returns (issue #369)."""
+    qasm3_string = """
+    OPENQASM 3;
+    include "stdgates.inc";
+
+    gate gate_b p{ x p; }
+    gate gate_a p{ gate_b p; gate_b p; }
+
+    qubit[1] q1;
+    gate_a q1;
+    """
+    module = loads(qasm3_string)
+    module.unroll()
+    check_single_qubit_gate_op(module.unrolled_ast, 2, [0, 0], "x")
+
+
+def test_indirect_recursion_does_not_exhaust_the_stack():
+    """The reported symptom was a bare RecursionError, so pin that the error is a
+    ValidationError and never a RecursionError (issue #369)."""
+    qasm3_string = """
+    OPENQASM 3;
+    include "stdgates.inc";
+
+    gate gate_a p{ gate_b p; }
+    gate gate_b p{ gate_a p; }
+
+    qubit[1] q1;
+    gate_a q1;
+    """
+    with pytest.raises(ValidationError, match="Recursive definitions not allowed"):
+        loads(qasm3_string).validate()
+
+
 @pytest.mark.parametrize("test_name", SINGLE_QUBIT_GATE_INCORRECT_TESTS.keys())
 def test_incorrect_single_qubit_gates(test_name, caplog):
     qasm_input, error_message, line_num, col_num, line = SINGLE_QUBIT_GATE_INCORRECT_TESTS[


### PR DESCRIPTION
Fixes #367 and #369.

> **Scope note:** #376 (issue #369, cyclic gate definitions) was merged into this branch, so this PR now carries both fixes plus a small follow-up that inlines #376's single-caller error helper. Both touch `_visit_custom_gate_operation`, which is why they travel together.

## The bug

An external custom gate whose body calls **another custom gate** reported the depth of the decomposition it never emitted. This is the shape the #352 fix did not reach — one level of nesting was already correct, which is why the existing tests passed.

```python
qasm = '''OPENQASM 3.0;
include "stdgates.inc";
gate inner a, b { crz(0.5) a, b; }
gate outer a, b { inner a, b; h a; }
qubit[2] q;
outer q[0], q[1];
'''
module = loads(qasm)
module.unroll(external_gates=["outer"])
module.depth()   # 13, from one emitted statement
```

| `external_gates` | statements | `depth()` before | after |
|---|---|---|---|
| `["outer"]` | 1 | **13** | 1 |
| `["inner", "outer"]` | 1 | **2** | 1 |
| single level, for contrast | 1 | 1 | 1 |
| `None` (nothing external) | 13 | 13 | 13 |

## Cause

`_visit_custom_gate_operation` assigned `_recording_ext_gate_depth` unconditionally and cleared it to `False` on exit, with no save-restore. The inner gate clobbered the outer gate's state in **both** directions:

- Descending into `inner` overwrote the flag with `False`, so the `crz` decomposition inside the body `outer` was skipping recorded its depth → 13.
- When `inner` returned it left the flag `False`, so `outer` never recorded its own single depth → the `["inner", "outer"]` row reported 2 instead of 1.

That is why save-restore alone is not sufficient: it fixes `["inner", "outer"]` and leaves `["outer"]` at 13.

## The fix

Two changes in `_visit_custom_gate_operation`:

1. Save the flag and restore it in a `finally` block, matching the pattern #359 introduced in `_visit_external_gate_operation`.
2. Compute `prev_recording or is_external` rather than assigning, so an inner gate stays suppressed inside an enclosing external gate, and record the depth under `is_external and not prev_recording` — from the outermost external gate only.

## Verification

- Full suite: **789 passed, 4 skipped**. No existing expectation changed.
- `tox -e format-check`: pylint 10.00/10, isort, black, mypy and headers all clean.
- **Mutation-tested.** With the source fix reverted, both new parametrizations fail, and they fail *differently* — `["outer"]` at 13, `["inner", "outer"]` at 2 — which is the point: they pin two distinct halves of the bug.

## Tests added

In `tests/qasm3/test_depth.py`, beside `test_external_basic_gate_counts_own_depth`:

- `test_nested_external_custom_gate_counts_own_depth`, parametrized over `["outer"]` and `["inner", "outer"]`, asserting one emitted statement and `depth() == 1`.
- `test_nested_custom_gate_depth_unchanged_without_external_gates` — the same program still decomposes to 13 when nothing is external, so the flag handling cannot silently suppress ordinary counting.
- `test_inner_external_gate_records_depth_inside_plain_custom_gate` — `external_gates=["inner"]` still records the inner gate's own depth when the enclosing gate is not external (2, not 1).

The last two pass on `main`; they are regression guards, not bug pins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recursive custom-gate validation to detect indirect cycles of any length and report the complete cycle path.
  - Corrected nested external-gate depth tracking, ensuring operation counts reflect the appropriate outermost and inner gates.
  - Preserved depth calculations when gates are fully decomposed or nested in different configurations.

- **Tests**
  - Added regression coverage for recursive gate definitions, repeated gate calls, and nested external-gate depth scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->