### PR TITLE
fix: detect gate definition cycles of any length, not just self-calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Types of changes:
 ### Removed
 
 ### Fixed
+- Fixed an indirect cycle between gate definitions exhausting the Python stack: `gate a q { b q; }` with `gate b q { a q; }` raised a bare `RecursionError` naming nothing, while the direct case was already reported cleanly. The guard compared the body's gate name against one name, so it saw only a cycle of length one. It now tests membership of the whole expansion chain, and names the path: `Recursive definitions not allowed for gate 'a' (a -> b -> a)`. A gate reached twice down separate paths is a diamond, not a cycle, and still expands. ([#369](https://github.com/qBraid/pyqasm/issues/369))
 - Fixed a nested external custom gate counting the depth of the decomposition it skipped, the shape the [#352](https://github.com/qBraid/pyqasm/issues/352) fix did not reach: `unroll(external_gates=["outer"])` on a gate whose body calls another custom gate emitted one statement but reported `depth() == 13`. The suppression flag was assigned and cleared without save-restore, so the inner gate clobbered the outer gate's state in both directions. It is now saved and restored, and the depth is recorded once, from the outermost external gate. ([#367](https://github.com/qBraid/pyqasm/issues/367))
 
 ### Dependencies

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -124,6 +124,9 @@ class QasmVisitor:
         self._function_qreg_transform_map: deque = deque([])  # for nested functions
         self._global_creg_size_map: dict[str, int] = {}
         self._custom_gates: dict[str, qasm3_ast.QuantumGateDefinition] = {}
+        # gates currently being expanded, outermost first; a name reappearing on it is a
+        # cycle of any length between gate definitions (issue #369)
+        self._gate_expansion_chain: list[str] = []
         self._external_gates: list[str] = [] if external_gates is None else external_gates
         self._subroutine_defns: dict[
             str, qasm3_ast.SubroutineDefinition | qasm3_ast.ExternDeclaration
@@ -1284,6 +1287,24 @@ class QasmVisitor:
             error_node=statement,
         )
 
+    def _raise_recursive_gate_error(self, gate_op: qasm3_ast.QuantumGate) -> None:
+        """Report a cyclic gate definition, naming the cycle it closes (issue #369).
+
+        Args:
+            gate_op (QuantumGate): The call in the gate body that closes the cycle.
+
+        Raises:
+            ValidationError: Always.
+        """
+        gate_name = gate_op.name.name
+        cycle = self._gate_expansion_chain[self._gate_expansion_chain.index(gate_name) :]
+        raise_qasm3_error(
+            f"Recursive definitions not allowed for gate '{gate_name}' "
+            f"({' -> '.join(cycle + [gate_name])})",
+            error_node=gate_op,
+            span=gate_op.span,
+        )
+
     def _visit_custom_gate_operation(
         self,
         operation: qasm3_ast.QuantumGate,
@@ -1345,6 +1366,7 @@ class QasmVisitor:
         self._recording_ext_gate_depth = prev_recording or is_external
 
         result = []
+        self._gate_expansion_chain.append(gate_name)
         try:
             for gate_op in gate_definition_ops:
                 if isinstance(gate_op, (qasm3_ast.QuantumGate, qasm3_ast.QuantumPhase)):
@@ -1353,13 +1375,9 @@ class QasmVisitor:
                     # in case the gate is reapplied
                     if (
                         isinstance(gate_op, qasm3_ast.QuantumGate)
-                        and gate_op.name.name == gate_name
+                        and gate_op.name.name in self._gate_expansion_chain
                     ):
-                        raise_qasm3_error(
-                            f"Recursive definitions not allowed for gate '{gate_name}'",
-                            error_node=gate_op,
-                            span=gate_op.span,
-                        )
+                        self._raise_recursive_gate_error(gate_op)
                     Qasm3Transformer.transform_gate_params(gate_op_copy, param_map)
                     Qasm3Transformer.transform_gate_qubits(gate_op_copy, qubit_map)
                     # need to trickle the inverse down to the child gates
@@ -1377,6 +1395,7 @@ class QasmVisitor:
                         span=gate_op.span,
                     )
         finally:
+            self._gate_expansion_chain.pop()
             self._recording_ext_gate_depth = prev_recording
 
         # Update the depth once for the whole gate, from the outermost external gate only:

--- a/tests/qasm3/resources/gates.py
+++ b/tests/qasm3/resources/gates.py
@@ -484,6 +484,57 @@ CUSTOM_GATE_INCORRECT_TESTS = {
         12,
         "custom_gate(a, b) p, q;",
     ),
+    # A cycle of length two between gate definitions used to exhaust the Python stack
+    # with a bare RecursionError, because the guard compared a single name (issue #369)
+    "indirect_recursive_definition": (
+        """
+        OPENQASM 3;
+        include "stdgates.inc";
+
+        gate gate_a(a) p{
+            gate_b(a) p;
+        }
+
+        gate gate_b(a) p{
+            gate_a(a) p;
+        }
+
+        qubit[1] q1;
+        gate_a(0.5) q1;
+        """,
+        r"Recursive definitions not allowed for gate 'gate_a' \(gate_a -> gate_b -> gate_a\)",
+        10,
+        12,
+        "gate_a(a) p;",
+    ),
+    "three_gate_recursive_definition": (
+        """
+        OPENQASM 3;
+        include "stdgates.inc";
+
+        gate gate_a(a) p{
+            gate_b(a) p;
+        }
+
+        gate gate_b(a) p{
+            gate_c(a) p;
+        }
+
+        gate gate_c(a) p{
+            gate_a(a) p;
+        }
+
+        qubit[1] q1;
+        gate_a(0.5) q1;
+        """,
+        (
+            r"Recursive definitions not allowed for gate 'gate_a' "
+            r"\(gate_a -> gate_b -> gate_c -> gate_a\)"
+        ),
+        14,
+        12,
+        "gate_a(a) p;",
+    ),
     "duplicate_definition": (
         """
         OPENQASM 3;

--- a/tests/qasm3/test_gates.py
+++ b/tests/qasm3/test_gates.py
@@ -876,6 +876,63 @@ def test_incorrect_custom_ops(test_name, caplog):
     assert line in caplog.text
 
 
+def test_shared_gate_definition_is_not_recursion():
+    """A gate reached twice down separate paths is a diamond, not a cycle. Testing the
+    expansion chain rather than a set of every gate seen is what keeps this from being
+    reported as recursion (issue #369)."""
+    qasm3_string = """
+    OPENQASM 3;
+    include "stdgates.inc";
+
+    gate gate_d p{ x p; }
+    gate gate_b p{ gate_d p; }
+    gate gate_c p{ gate_d p; }
+    gate gate_a p{ gate_b p; gate_c p; }
+
+    qubit[1] q1;
+    gate_a q1;
+    """
+    module = loads(qasm3_string)
+    module.unroll()
+    check_single_qubit_gate_op(module.unrolled_ast, 2, [0, 0], "x")
+    assert module.depth() == 2
+
+
+def test_repeated_gate_call_in_one_body_is_not_recursion():
+    """The same gate called twice in a single body must expand twice, not raise:
+    the chain entry is popped when the first expansion returns (issue #369)."""
+    qasm3_string = """
+    OPENQASM 3;
+    include "stdgates.inc";
+
+    gate gate_b p{ x p; }
+    gate gate_a p{ gate_b p; gate_b p; }
+
+    qubit[1] q1;
+    gate_a q1;
+    """
+    module = loads(qasm3_string)
+    module.unroll()
+    check_single_qubit_gate_op(module.unrolled_ast, 2, [0, 0], "x")
+
+
+def test_indirect_recursion_does_not_exhaust_the_stack():
+    """The reported symptom was a bare RecursionError, so pin that the error is a
+    ValidationError and never a RecursionError (issue #369)."""
+    qasm3_string = """
+    OPENQASM 3;
+    include "stdgates.inc";
+
+    gate gate_a p{ gate_b p; }
+    gate gate_b p{ gate_a p; }
+
+    qubit[1] q1;
+    gate_a q1;
+    """
+    with pytest.raises(ValidationError, match="Recursive definitions not allowed"):
+        loads(qasm3_string).validate()
+
+
 @pytest.mark.parametrize("test_name", SINGLE_QUBIT_GATE_INCORRECT_TESTS.keys())
 def test_incorrect_single_qubit_gates(test_name, caplog):
     qasm_input, error_message, line_num, col_num, line = SINGLE_QUBIT_GATE_INCORRECT_TESTS[


### PR DESCRIPTION
Fixes #369.

## The bug

pyqasm reported a gate that calls itself cleanly, but a cycle between two definitions exhausted the Python stack:

```python
# direct — already correct
pyqasm.loads('gate a(t) q { a(t) q; } ...').validate()
# ValidationError: Recursive definitions not allowed for gate 'a'

# indirect — stack blowout
pyqasm.loads('gate a(t) q { b(t) q; } gate b(t) q { a(t) q; } ...').validate()
# RecursionError: maximum recursion depth exceeded
```

The `RecursionError` named nothing, so there was no indication of which gates were cycling.

## Cause

The guard in `_visit_custom_gate_operation` compared the body's gate name against **one** name — the gate currently being expanded:

```python
if isinstance(gate_op, qasm3_ast.QuantumGate) and gate_op.name.name == gate_name:
```

A cycle of length one matches. A cycle of length two or more passes the check and recurses through gate expansion until the interpreter's stack limit.

## The fix

Track the chain of gates currently being expanded (`_gate_expansion_chain`, pushed on entry and popped in a `finally`) and test **membership of that chain** instead of equality with a single name. One mechanism now covers both cases, so the direct-recursion check is replaced rather than duplicated.

The error names the path it closes, as the issue requested:

```
Recursive definitions not allowed for gate 'a' (a -> b -> a)
Recursive definitions not allowed for gate 'a' (a -> b -> c -> a)
Recursive definitions not allowed for gate 'a' (a -> a)          # direct, unchanged shape
```

The check stays at the same point in the body scan as the old one, so the reported span is still the call inside the definition that closes the cycle.

**Chain, not a seen-set.** Membership of the *chain* is what distinguishes a cycle from a diamond. With a set of every gate seen, `a` calling both `b` and `c`, where both call `d`, would be misreported as recursion. Popping on return keeps that legal.

## Behaviour that does not change

| Program | Before | After |
|---|---|---|
| `gate a q { a q; }` | `ValidationError` | same, plus `(a -> a)` |
| gate `b` never defined | `Unsupported / undeclared QASM operation: b` | unchanged |
| diamond `a → {b, c} → d` | expands | expands |
| same gate called twice in one body | expands twice | expands twice |

## Verification

- Full suite: **789 passed, 4 skipped**.
- `tox -e format-check`: pylint 10.00/10, isort, black, mypy and headers all clean.
- **Mutation-tested.** With the source fix reverted, all three new cycle tests fail with `RecursionError`; the two diamond/repeat guards pass on `main`, as they should.

## Tests added

- `CUSTOM_GATE_INCORRECT_TESTS` gains `indirect_recursive_definition` (a → b → a) and `three_gate_recursive_definition` (a → b → c → a). Both pin the full message including the path, and both inherit the existing line/column assertions.
- `test_shared_gate_definition_is_not_recursion` — the diamond must expand, not raise.
- `test_repeated_gate_call_in_one_body_is_not_recursion` — the chain entry must be popped when an expansion returns.
- `test_indirect_recursion_does_not_exhaust_the_stack` — pins that the failure is a `ValidationError` and never a `RecursionError`, which was the reported symptom.

## Note on the base branch

This is stacked on #375, because both PRs edit `_visit_custom_gate_operation` — reviewing them independently would hand you a conflict. **Merge #375 first**; this diff then reduces to its own four files. The commits are separate and each stands on its own.

## Follow-up not taken

The issue notes this is likely to be hit by anyone fixing #54 / #370 (`opaque` declarations), since giving Quantinuum's opaque primitives real bodies creates a mutual cycle with `hqslib1`'s `U` and `CX`. That case now reports the cycle by name instead of blowing the stack, which is the whole of what this issue asked for.