### PR TITLE
Add SECURITY.md with a private vulnerability disclosure path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Types of changes:
 ### Dependencies
 
 ### Other
+- Added a `SECURITY.md` with a private vulnerability disclosure path. There was no documented way to report one, leaving a public issue or a guessed email address as the only options. Reports now go through this repository's GitHub security advisory form. ([#383](https://github.com/qBraid/pyqasm/pull/383))
 
 ## Past Release Notes
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,12 @@
 
 ## Supported Versions
 
-qBraid actively supports security updates for the most recent minor release of
-`pyqasm`. Older minor versions receive fixes only where an issue is judged severe
-and a straightforward backport exists.
+qBraid actively supports security updates for the latest minor release line of `pyqasm`:
+the most recent `MAJOR.MINOR` version together with every patch release within it. For
+example, if the current release is `1.2.3`, then `1.2.x` is supported and `1.1.x` is not.
+
+Older minor lines receive fixes only where an issue is judged severe and a straightforward
+backport exists.
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,10 +25,10 @@ requests, or discussions.
 
 ### Vulnerabilities in dependencies
 
-`pyqasm` reaches third-party quantum SDKs through optional extras. If you are reporting an
-issue that originates in one of those upstream packages rather than in `pyqasm` itself,
-please report it upstream as well, and tell us here so we can assess whether users are
-exposed through a path this package creates and advise them accordingly.
+If an issue originates in an upstream dependency rather than in `pyqasm` itself, whether a
+direct dependency or one reached through an optional extra, please report it to that
+project as well and tell us here. We will assess whether users are exposed through a path
+this package creates, and advise them accordingly.
 
 ### What to expect
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Supported Versions
+
+qBraid actively supports security updates for the most recent minor release of
+`pyqasm`. Older minor versions receive fixes only where an issue is judged severe
+and a straightforward backport exists.
+
+## Reporting a Vulnerability
+
+The qBraid team takes the security of our software seriously, across every repository in
+this organization. We encourage responsible disclosure of any security vulnerability.
+
+### How to report
+
+Use GitHub's private security advisory form for this repository:
+
+[Report a security vulnerability](https://github.com/qBraid/pyqasm/security/advisories/new)
+
+Please **do not** report security vulnerabilities through public GitHub issues, pull
+requests, or discussions.
+
+### Vulnerabilities in dependencies
+
+`pyqasm` reaches third-party quantum SDKs through optional extras. If you are reporting an
+issue that originates in one of those upstream packages rather than in `pyqasm` itself,
+please report it upstream as well, and tell us here so we can assess whether users are
+exposed through a path this package creates and advise them accordingly.
+
+### What to expect
+
+- Acknowledgment of your report within two business days.
+- An assessment of severity and scope, and a request for any further detail we need.
+- Progress updates while we work on a fix.
+- Notification when the issue is resolved, including the release carrying the fix, and
+  credit in the advisory unless you prefer otherwise.
+
+### What to include
+
+- The type of issue and its impact.
+- The version of `pyqasm` affected, and the Python version and platform.
+- Full paths of the source files involved, if known.
+- Steps to reproduce, ideally a minimal example.
+- Any proof-of-concept or exploit code you are willing to share.


### PR DESCRIPTION
Adds a `SECURITY.md` to `pyqasm`, which currently has no documented way to report a
vulnerability privately. A researcher's only options today are a public issue, which
discloses the problem to everyone at once, or guessing at an email address.

`qBraid/qBraid` already carries one; this adapts it for `pyqasm` and points at this
repository's own private advisory form.

Two deliberate differences from the qBraid/qBraid version:

- **No hardcoded version table.** The existing policy pins "0.7.x" as supported, which
  has been stale since 0.8. This one states support for the most recent minor release,
  so it does not need editing on every release.
- **A section on upstream dependencies.** `pyqasm` reaches third-party packages through
  optional extras, and a reporter should know where to send an issue that originates
  upstream, and that we still want to hear about it so we can assess exposure through
  a path this package creates.

Related: qBraid/pyqasm#382.