### PR TITLE
Keep pyqasm validate diagnostics on one line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Types of changes:
 ### Removed
 
 ### Fixed
+- Fixed `pyqasm validate` wrapping its diagnostics at the console width, which split a file path longer than the width across lines mid-token and left it neither copyable nor clickable. The error console now uses `soft_wrap`, keeping one diagnostic per line.
 - Fixed an indirect cycle between gate definitions exhausting the Python stack: `gate a q { b q; }` with `gate b q { a q; }` raised a bare `RecursionError` naming nothing, while the direct case was already reported cleanly. The guard compared the body's gate name against one name, so it saw only a cycle of length one. It now tests membership of the whole expansion chain, and names the path: `Recursive definitions not allowed for gate 'a' (a -> b -> a)`. A gate reached twice down separate paths is a diamond, not a cycle, and still expands. ([#369](https://github.com/qBraid/pyqasm/issues/369))
 - Fixed a nested external custom gate counting the depth of the decomposition it skipped, the shape the [#352](https://github.com/qBraid/pyqasm/issues/352) fix did not reach: `unroll(external_gates=["outer"])` on a gate whose body calls another custom gate emitted one statement but reported `depth() == 13`. The suppression flag was assigned and cleared without save-restore, so the inner gate clobbered the outer gate's state in both directions. It is now saved and restored, and the depth is recorded once, from the outermost external gate. ([#367](https://github.com/qBraid/pyqasm/issues/367))
 

--- a/src/pyqasm/cli/validate.py
+++ b/src/pyqasm/cli/validate.py
@@ -55,7 +55,10 @@ def validate_qasm(src_paths: list[str], skip_files: Optional[list[str]] = None) 
 
     failed_files: list[tuple[str, Exception]] = []
 
-    console = Console()
+    # soft_wrap keeps each diagnostic on one line. Rich otherwise wraps at the
+    # console width and breaks mid-token, so a file path longer than the width is
+    # split across lines and stops being copyable or clickable in a terminal.
+    console = Console(soft_wrap=True)
 
     def validate_qasm_file(file_path: str) -> None:
         with open(file_path, "r", encoding="utf-8") as f:


### PR DESCRIPTION
## Problem

`pyqasm validate` builds its output with a default `rich.Console`, which wraps at the detected console width (80 when stdout is not a tty). A file path longer than that is broken **mid-token** across lines:

```
/private/tmp/.../3eba83a3-89e
0-4a99-a5cf-386bf6fb273b/scratchpad/...: error: ...
```

The reported path is then neither copyable nor clickable in a terminal.

The same wrapping breaks two CLI tests, which assert the absolute path appears in the output:

- `tests/cli/test_cli_commands.py::test_validate_qasm_with_invalid_file`
- `tests/cli/test_cli_commands.py::test_validate_command_with_invalid_file`

They pass in CI only because the runner checks out to a short path (`/home/runner/work/pyqasm/pyqasm`). They fail for any contributor whose clone sits at a longer path, which is why they showed up as "pre-existing failures" while reviewing #402, #403 and #404.

## Fix

The error console now uses `soft_wrap=True`, which disables wrapping and cropping while leaving markup intact — one diagnostic per line, path unbroken.

## Verification

`tests/cli` at a short path and at a path long enough to trigger the old wrap:

| | before | after |
|---|---|---|
| short path | 33 passed | 33 passed |
| long path | 2 failed, 31 passed | 33 passed |

Full suite at the long path: **802 passed, 3 skipped**. `pylint` 10.00/10, `black` and `isort` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `pyqasm validate` diagnostics so long file paths remain intact instead of splitting across terminal lines.
- **Documentation**
  - Added an unreleased changelog entry describing the validation output improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->