### PR TITLE
Support classical value bit slicing on int / uint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Types of changes:
 ## Unreleased
 
 ### Added
+- Added classical value bit slicing on `int[n]` / `uint[n]`, including array elements: `myInt[0]`, `myInt[0:2:31]`, `myInt[4:7] = "1010"`, `intArr[0][0] = 1`. These previously raised `Invalid initialization value` or `Cannot cast 'str' to 'IntType'`. Index 0 is the least-significant bit. A descending range requires an explicit negative step (`myInt[-1:-1:-16]`). ([#395](https://github.com/qBraid/pyqasm/issues/395))
 - Negative indices are now honored across arrays, `bit[n]`, `qubit[n]`, and `let` aliases, including ranges: `myArray[-1]`, `a[-1] = 10`, `h q[-1]`, `bit c = b[-1]`, `let last_three = two[-4:-1]`. An index still outside `[-size, size)` after normalization raises `ValidationError` and names the index as written. ([#391](https://github.com/qBraid/pyqasm/issues/391))
 
 ### Improved / Modified

--- a/src/pyqasm/analyzer.py
+++ b/src/pyqasm/analyzer.py
@@ -36,6 +36,7 @@ from openqasm3.ast import (
     QuantumMeasurementStatement,
     RangeDefinition,
     Span,
+    UintType,
     UnaryExpression,
 )
 
@@ -109,6 +110,53 @@ def slice_positions(start: int, end: int, step: int) -> range:
     return range(start, end + (1 if step > 0 else -1), step)
 
 
+def read_int_bits(value: int, positions: range) -> int:
+    """Extract the bits of an integer at ``positions`` into a bit vector.
+
+    Bit 0 of an ``int[n]`` / ``uint[n]`` value is its *least*-significant bit, per
+    `classical value bit slicing
+    <https://openqasm.com/versions/3.1/language/types.html#classical-value-bit-slicing>`_.
+    The first selected position becomes the least-significant bit of the result, so
+    ``myInt[0:2:31]`` on ``int[32] myInt = 15`` yields ``3``.
+
+    Args:
+        value: The source integer. Negative values are read in two's complement.
+        positions: The bit positions to read, in traversal order.
+
+    Returns:
+        int: The extracted bit vector, ``len(positions)`` bits wide.
+    """
+    result = 0
+    for shift, pos in enumerate(positions):
+        result |= ((value >> pos) & 1) << shift
+    return result
+
+
+def write_int_bits(value: int, positions: range, bits: int, width: int, signed: bool) -> int:
+    """Return ``value`` with the bits at ``positions`` replaced by ``bits``.
+
+    The inverse of :func:`read_int_bits`: bit ``j`` of ``bits`` lands at
+    ``positions[j]``. The result is re-interpreted in ``width`` bits, so writing
+    the top bit of a signed integer yields a negative value.
+
+    Args:
+        value: The current integer value.
+        positions: The bit positions to overwrite, in traversal order.
+        bits: The replacement bit vector, ``len(positions)`` bits wide.
+        width: The declared width of the integer, in bits.
+        signed: ``True`` for ``int[n]``, ``False`` for ``uint[n]``.
+
+    Returns:
+        int: The updated value.
+    """
+    result = value & ((1 << width) - 1)
+    for shift, pos in enumerate(positions):
+        result = (result & ~(1 << pos)) | (((bits >> shift) & 1) << pos)
+    if signed and result >> (width - 1):
+        result -= 1 << width
+    return result
+
+
 class Qasm3Analyzer:
     """Class with utility functions for analyzing QASM3 elements"""
 
@@ -120,6 +168,7 @@ class Qasm3Analyzer:
         index_node: Any,
         dim_num: Optional[int] = None,
         qubit: bool = False,
+        type_name: Optional[str] = None,
     ) -> int:
         """Normalize an index against a register or dimension of size ``size``.
 
@@ -136,6 +185,9 @@ class Qasm3Analyzer:
             dim_num: Optional zero-based dimension number for multi-dim arrays; if
                 given, the error message mentions it.
             qubit: ``True`` for a qubit register (used for message phrasing).
+            type_name: Optional scalar type name ("int", "uint") for a bit-slice of a
+                classical value; if given, the error message names the declared width
+                instead of a register dimension.
 
         Returns:
             int: The normalized non-negative index.
@@ -149,7 +201,12 @@ class Qasm3Analyzer:
             return idx
         register_kind = "qubit" if qubit else "clbit"
         span = getattr(index_node, "span", None)
-        if dim_num is not None:
+        if type_name is not None:
+            message = (
+                f"Index {source_index} out of range for '{type_name}[{size}]' "
+                f"variable '{var_name}'"
+            )
+        elif dim_num is not None:
             message = (
                 f"Index {source_index} out of bounds for dimension {dim_num} "
                 f"of variable '{var_name}'. Expected index in range "
@@ -170,7 +227,82 @@ class Qasm3Analyzer:
         raise ValidationError(message)
 
     @staticmethod
-    def analyze_classical_indices(  # pylint: disable=too-many-locals
+    def _validate_step(start_id: int, end_id: int, step: int, index_node: Any) -> None:
+        """Reject a range whose step cannot reach its end bound."""
+        if step == 0:
+            raise_qasm3_error(
+                message="Index step cannot be zero",
+                err_type=ValidationError,
+                error_node=index_node,
+                span=index_node.span,
+            )
+        if (step < 0 and start_id < end_id) or (step > 0 and start_id > end_id):
+            direction = "less than" if step < 0 else "greater than"
+            raise_qasm3_error(
+                message=f"Index {start_id} is {direction} {end_id} but step"
+                f" is {'negative' if step < 0 else 'positive'}",
+                err_type=ValidationError,
+                error_node=index_node,
+                span=index_node.span,
+            )
+
+    @staticmethod
+    def resolve_index(  # pylint: disable=too-many-arguments
+        index: Any,
+        size: int,
+        var_name: str,
+        expr_evaluator: Qasm3ExprEvaluator,
+        dim_num: Optional[int] = None,
+        type_name: Optional[str] = None,
+    ) -> tuple[int, int, int]:
+        """Resolve one subscript against a dimension of ``size`` elements.
+
+        Handles both a scalar subscript and a ``RangeDefinition``, normalizing
+        negative bounds and rejecting a step that cannot reach its end bound.
+
+        Args:
+            index: The subscript AST node.
+            size: The number of elements the subscript selects from.
+            var_name: The variable name (used in error messages).
+            expr_evaluator: The evaluator used to reduce index expressions.
+            dim_num: Optional zero-based dimension number, for array error messages.
+            type_name: Optional scalar type name, for bit-slice error messages.
+
+        Returns:
+            tuple[int, int, int]: The inclusive ``(start, end, step)`` triple.
+
+        Raises:
+            ValidationError: If the subscript type, bounds, or step are invalid.
+        """
+        if not isinstance(index, (Identifier, Expression, RangeDefinition, IntegerLiteral)):
+            raise_qasm3_error(
+                message=f"Unsupported index type '{type(index)}' for "
+                f"classical variable '{var_name}'",
+                err_type=ValidationError,
+                error_node=index,
+                span=index.span,
+            )
+
+        def _bound(expr: Any) -> int:
+            raw = expr_evaluator.evaluate_expression(expr, reqd_type=IntType)[0]
+            return Qasm3Analyzer.normalize_index(
+                raw, size, var_name, index, dim_num=dim_num, type_name=type_name
+            )
+
+        if isinstance(index, RangeDefinition):
+            start_id = 0 if index.start is None else _bound(index.start)
+            end_id = size - 1 if index.end is None else _bound(index.end)
+            step = 1
+            if index.step is not None:
+                step = expr_evaluator.evaluate_expression(index.step, reqd_type=IntType)[0]
+            Qasm3Analyzer._validate_step(start_id, end_id, step, index)
+            return start_id, end_id, step
+
+        index_value = _bound(index)
+        return index_value, index_value, 1
+
+    @staticmethod
+    def analyze_classical_indices(
         indices: list[Any], var: Variable, expr_evaluator: Qasm3ExprEvaluator
     ) -> list:
         """Validate the indices for a classical variable.
@@ -208,67 +340,69 @@ class Qasm3Analyzer:
                 span=indices[0].span,
             )
 
-        def _validate_step(start_id, end_id, step, index_node):
-            if (step < 0 and start_id < end_id) or (step > 0 and start_id > end_id):
-                direction = "less than" if step < 0 else "greater than"
-                raise_qasm3_error(
-                    message=f"Index {start_id} is {direction} {end_id} but step"
-                    f" is {'negative' if step < 0 else 'positive'}",
-                    err_type=ValidationError,
-                    error_node=index_node,
-                    span=index_node.span,
-                )
-
+        assert var_dimensions is not None
         for i, index in enumerate(indices):
-            if not isinstance(index, (Identifier, Expression, RangeDefinition, IntegerLiteral)):
-                raise_qasm3_error(
-                    message=f"Unsupported index type '{type(index)}' for "
-                    f"classical variable '{var.name}'",
-                    err_type=ValidationError,
-                    error_node=index,
-                    span=index.span,
+            indices_list.append(
+                Qasm3Analyzer.resolve_index(
+                    index, var_dimensions[i], var.name, expr_evaluator, dim_num=i
                 )
-
-            if isinstance(index, RangeDefinition):
-                assert var_dimensions is not None
-                dim_size = var_dimensions[i]
-
-                if index.start is not None:
-                    raw_start = expr_evaluator.evaluate_expression(index.start, reqd_type=IntType)[
-                        0
-                    ]
-                    start_id = Qasm3Analyzer.normalize_index(
-                        raw_start, dim_size, var.name, index, dim_num=i
-                    )
-                else:
-                    start_id = 0
-
-                if index.end is not None:
-                    raw_end = expr_evaluator.evaluate_expression(index.end, reqd_type=IntType)[0]
-                    end_id = Qasm3Analyzer.normalize_index(
-                        raw_end, dim_size, var.name, index, dim_num=i
-                    )
-                else:
-                    end_id = dim_size - 1
-
-                step = 1
-                if index.step is not None:
-                    step = expr_evaluator.evaluate_expression(index.step, reqd_type=IntType)[0]
-
-                _validate_step(start_id, end_id, step, index)
-
-                indices_list.append((start_id, end_id, step))
-
-            if isinstance(index, (Identifier, IntegerLiteral, Expression)):
-                raw_value = expr_evaluator.evaluate_expression(index, reqd_type=IntType)[0]
-                curr_dimension = var_dimensions[i]  # type: ignore[index]
-                index_value = Qasm3Analyzer.normalize_index(
-                    raw_value, curr_dimension, var.name, index, dim_num=i
-                )
-
-                indices_list.append((index_value, index_value, 1))
+            )
 
         return indices_list
+
+    @staticmethod
+    def is_int_bit_slice(var: Variable, indices: Any) -> bool:
+        """Check whether ``indices`` bit-slice an ``int[n]`` / ``uint[n]`` value.
+
+        A bit slice carries exactly one subscript more than the variable has
+        dimensions: the leading subscripts select an array element (none for a
+        scalar) and the trailing one selects bits of that element.
+
+        Args:
+            var: The variable being indexed.
+            indices: The subscripts, as returned by ``analyze_index_expression``.
+                A ``DiscreteSet`` is never a bit slice.
+
+        Returns:
+            bool: True if the subscripts address the bits of an integer value.
+        """
+        return (
+            isinstance(var.base_type, (IntType, UintType))
+            and isinstance(indices, list)
+            and len(indices) == len(var.dims or []) + 1
+        )
+
+    @staticmethod
+    def analyze_int_bit_slice(
+        indices: list[Any], var: Variable, expr_evaluator: Qasm3ExprEvaluator
+    ) -> tuple[list[tuple[int, int, int]], range]:
+        """Split a bit-slice subscript chain into element indices and bit positions.
+
+        Args:
+            indices: The subscripts, the last of which selects bits.
+            var: The ``int[n]`` / ``uint[n]`` variable, possibly an array of them.
+            expr_evaluator: The evaluator used to reduce index expressions.
+
+        Returns:
+            tuple: The validated element indices (empty for a scalar) and the
+            selected bit positions, counted from the least-significant bit.
+
+        Raises:
+            ValidationError: If any subscript is out of range or malformed.
+        """
+        element_indices = (
+            Qasm3Analyzer.analyze_classical_indices(indices[:-1], var, expr_evaluator)
+            if len(indices) > 1
+            else []
+        )
+        start, end, step = Qasm3Analyzer.resolve_index(
+            indices[-1],
+            var.base_size,
+            var.name,
+            expr_evaluator,
+            type_name=type(var.base_type).__name__.removesuffix("Type").lower(),
+        )
+        return element_indices, slice_positions(start, end, step)
 
     @staticmethod
     def analyze_index_expression(

--- a/src/pyqasm/expressions.py
+++ b/src/pyqasm/expressions.py
@@ -45,7 +45,7 @@ from openqasm3.ast import (
     UnaryExpression,
 )
 
-from pyqasm.analyzer import Qasm3Analyzer, bits_to_int, slice_positions
+from pyqasm.analyzer import Qasm3Analyzer, bits_to_int, read_int_bits, slice_positions
 from pyqasm.elements import BitValue, Variable
 from pyqasm.exceptions import ValidationError, raise_qasm3_error
 from pyqasm.maps.expressions import (
@@ -183,6 +183,19 @@ class Qasm3ExprEvaluator:
         var = cls.visitor_obj._scope_manager.get_from_visible_scope(var_name)
         if isinstance(expression, Identifier):
             return var.value
+
+        if Qasm3Analyzer.is_int_bit_slice(var, indices):
+            element_indices, positions = Qasm3Analyzer.analyze_int_bit_slice(indices, var, cls)
+            source = (
+                Qasm3Analyzer.find_array_element(var.value, element_indices)
+                if element_indices
+                else var.value
+            )
+            if source is None:
+                # Defer to ``_check_var_initialized`` for the uninitialized message.
+                return None
+            selected = read_int_bits(int(source), positions)
+            return selected if len(positions) == 1 else BitValue(selected, len(positions))
 
         validated_indices = Qasm3Analyzer.analyze_classical_indices(indices, var, cls)
 

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -32,7 +32,7 @@ import numpy as np
 import openqasm3.ast as qasm3_ast
 from openqasm3.printer import dumps
 
-from pyqasm.analyzer import Qasm3Analyzer, bits_to_int, slice_positions
+from pyqasm.analyzer import Qasm3Analyzer, bits_to_int, slice_positions, write_int_bits
 from pyqasm.elements import (
     INTERNAL_QUBIT_REGISTER,
     PHYSICAL_QUBIT_PREFIX,
@@ -128,6 +128,89 @@ def _write_bit_slice(
         target_shift = width - 1 - pos
         result = (result & ~(1 << target_shift)) | (bit_from_new << target_shift)
     return BitValue(result, width)
+
+
+def _bit_vector_operand(value: Any, slice_width: int, var_name: str, node: Any) -> int:
+    """Coerce the right-hand side of a bit-slice assignment to a bit vector.
+
+    Args:
+        value: The evaluated right-hand side: a bitstring, a ``BitValue``, or an
+            integer for a single-bit target.
+        slice_width: The number of bits the target slice selects.
+        var_name: The assignment target name (used in error messages).
+        node: The AST node used for span attribution on error.
+
+    Returns:
+        int: The right-hand side as a ``slice_width``-bit vector.
+
+    Raises:
+        ValidationError: If the value is not a bit vector, or its width differs
+            from ``slice_width``.
+    """
+    width = slice_width
+    if isinstance(value, str):
+        width, value = len(value), int(value, 2) if value else 0
+    elif isinstance(value, BitValue):
+        width = value.width
+    elif isinstance(value, (bool, int, np.integer)):
+        # A bare integer carries no width; require it to fit the target slice.
+        if not 0 <= int(value) < (1 << slice_width):
+            raise_qasm3_error(
+                f"Value {value} out of range for a {slice_width}-bit slice of '{var_name}'",
+                err_type=ValidationError,
+                error_node=node,
+                span=node.span,
+            )
+    else:
+        raise_qasm3_error(
+            f"Cannot assign value of type '{type(value).__name__}' to a bit slice "
+            f"of '{var_name}'",
+            err_type=ValidationError,
+            error_node=node,
+            span=node.span,
+        )
+    if width != slice_width:
+        raise_qasm3_error(
+            f"Cannot assign a {width}-bit value to a {slice_width}-bit slice of '{var_name}'",
+            err_type=ValidationError,
+            error_node=node,
+            span=node.span,
+        )
+    return int(value)
+
+
+def _write_int_bit_slice(var: Variable, indices: list[Any], value: Any, node: Any) -> None:
+    """Write ``value`` into the bit representation of an ``int`` / ``uint`` variable.
+
+    Args:
+        var: The ``int[n]`` / ``uint[n]`` variable, or an array of them.
+        indices: The subscripts, the last of which selects the bits to overwrite.
+        value: The evaluated right-hand side.
+        node: The AST node used for span attribution on error.
+
+    Raises:
+        ValidationError: If a subscript is out of range, or the right-hand side
+            does not match the width of the selected slice.
+    """
+    element_indices, positions = Qasm3Analyzer.analyze_int_bit_slice(
+        indices, var, Qasm3ExprEvaluator  # type: ignore[arg-type]
+    )
+    current = (
+        Qasm3Analyzer.find_array_element(var.value, element_indices)  # type: ignore[arg-type]
+        if element_indices
+        else var.value
+    )
+    updated = write_int_bits(
+        int(current or 0),
+        positions,
+        _bit_vector_operand(value, len(positions), var.name, node),
+        var.base_size,
+        signed=isinstance(var.base_type, qasm3_ast.IntType),
+    )
+    if element_indices:
+        Qasm3Transformer.update_array_element(var.value, element_indices, updated)  # type: ignore
+    else:
+        var.value = updated
 
 
 # pylint: disable-next=too-many-instance-attributes
@@ -2187,6 +2270,17 @@ class QasmVisitor:
                 error_node=statement,
                 span=statement.span,
             )
+        l_indices: list[Any] = []
+        if isinstance(lvalue, qasm3_ast.IndexedIdentifier):
+            # stupid indices structure in openqasm :/
+            if len(lvalue.indices[0]) > 1:  # type: ignore[arg-type]
+                l_indices = lvalue.indices[0]  # type: ignore[assignment]
+            else:
+                l_indices = [idx[0] for idx in lvalue.indices]  # type: ignore[index]
+        # A bit-slice target holds a bit vector, not a value of the variable's own
+        # type, so it must bypass the scalar cast/range check below.
+        int_bit_target = Qasm3Analyzer.is_int_bit_slice(lvar, l_indices)  # type: ignore[arg-type]
+
         binary_op: str | None | qasm3_ast.BinaryOperator = None
         if statement.op != qasm3_ast.AssignmentOperator["="]:
             # eg. j += 1 -> broken down to j = j + 1
@@ -2247,7 +2341,9 @@ class QasmVisitor:
                 lvar.base_size = len(angle_val_bit_string)  # type: ignore[union-attr]
         # cast + validation
         rvalue_eval = None
-        if not isinstance(rvalue_raw, np.ndarray):
+        if int_bit_target:
+            rvalue_eval = rvalue_raw
+        elif not isinstance(rvalue_raw, np.ndarray):
             # rhs is a scalar
             if rvalue_raw is not None and not self._in_extern_function:
                 rvalue_eval = Qasm3Validator.validate_variable_assignment_value(
@@ -2275,12 +2371,9 @@ class QasmVisitor:
             )
 
         # lvalue will be the variable which will HOLD this value
-        if isinstance(lvalue, qasm3_ast.IndexedIdentifier):
-            # stupid indices structure in openqasm :/
-            if len(lvalue.indices[0]) > 1:  # type: ignore[arg-type]
-                l_indices = lvalue.indices[0]
-            else:
-                l_indices = [idx[0] for idx in lvalue.indices]  # type: ignore[assignment, index]
+        if int_bit_target:
+            _write_int_bit_slice(lvar, l_indices, rvalue_eval, statement)  # type: ignore[arg-type]
+        elif isinstance(lvalue, qasm3_ast.IndexedIdentifier):
             try:
                 validated_l_indices = Qasm3Analyzer.analyze_classical_indices(
                     l_indices, lvar, Qasm3ExprEvaluator  # type: ignore[arg-type]

--- a/tests/qasm3/resources/variables.py
+++ b/tests/qasm3/resources/variables.py
@@ -297,12 +297,14 @@ ASSIGNMENT_TESTS = {
         8,
         "float[32] x = 1.2345678912345679e+44;",
     ),
+    # ``int`` / ``uint`` scalars are excluded here: they are bit-sliceable per the
+    # OpenQASM classical value bit slicing rules, so ``x[0]`` is a valid lvalue.
     "indexing_non_array": (
         """
         OPENQASM 3.0;
         include "stdgates.inc";
 
-        int x = 3;
+        float x = 3.0;
         x[0] = 4;
         """,
         "Invalid index for variable 'x'",

--- a/tests/qasm3/test_expressions.py
+++ b/tests/qasm3/test_expressions.py
@@ -18,6 +18,7 @@ Module containing unit tests for expressions.
 """
 
 import pytest
+from openqasm3.ast import QuantumGate
 
 from pyqasm.analyzer import bits_to_int, int_to_bits
 from pyqasm.elements import BitValue
@@ -266,3 +267,208 @@ def test_bit_register_op_result_stays_bit_type():
     text = dumps(module)
     assert "c = a | b" in text
     assert "d = c & a" in text
+
+
+def test_bit_register_descending_slice():
+    """``b[3:-1:0]`` selects every position down to 0, not just down to 1.
+
+    Regression guard: an inclusive range must extend its stop bound in the
+    direction of travel, so a negative step keeps the final position.
+    """
+    module = loads("""
+        OPENQASM 3.0;
+        qubit q;
+        bit[4] b = "1100";
+        bit[4] r = b[3:-1:0];
+        int[8] v = r;
+        rx(v) q;
+        """)
+    module.unroll()
+    # "1100" read back-to-front is "0011" == 3.
+    assert _rotation_args(module) == [3]
+
+
+# ---------------------------------------------------------------------------
+# Issue #395 — classical value bit slicing on ``int`` / ``uint``
+# ---------------------------------------------------------------------------
+
+
+def _rotation_args(module):
+    """Return the evaluated ``rx`` arguments of an unrolled module, in order.
+
+    Bit-slice results are not otherwise observable from the public API, so the
+    tests below funnel each value into an ``rx`` angle and read it back.
+    """
+    return [
+        stmt.arguments[0].value
+        for stmt in module.unrolled_ast.statements
+        if isinstance(stmt, QuantumGate) and stmt.name.name == "rx"
+    ]
+
+
+def test_int_bit_slice_spec_example():
+    """The spec's ``int[32] myInt = 15`` example evaluates to its documented values.
+
+    Reference: https://openqasm.com/versions/3.1/language/types.html#classical-value-bit-slicing
+    """
+    module = loads("""
+        OPENQASM 3.0;
+        qubit q;
+        int[32] myInt = 15;
+        bit[1] lastBit = myInt[0];
+        bit[1] signBit = myInt[31];
+        bit[1] alsoSignBit = myInt[-1];
+        bit[16] evenBits = myInt[0:2:31];
+        bit[16] upperBits = myInt[-16:-1];
+        int[8] a = lastBit;
+        int[8] b = signBit;
+        int[8] c = alsoSignBit;
+        int[32] d = evenBits;
+        int[32] e = upperBits;
+        myInt[4:7] = "1010";
+        rx(a) q;
+        rx(b) q;
+        rx(c) q;
+        rx(d) q;
+        rx(e) q;
+        rx(myInt) q;
+        """)
+    module.unroll()
+    assert _rotation_args(module) == [1, 0, 0, 3, 0, 0xAF]
+
+
+@pytest.mark.parametrize("int_type", ["int", "uint"])
+def test_int_bit_slice_single_bit_read(int_type):
+    """``i[k]`` yields the bit at position ``k``, counted from the LSB."""
+    module = loads(f"""
+        OPENQASM 3.0;
+        qubit q;
+        {int_type}[8] i = 15;
+        int[8] low = i[0];
+        int[8] high = i[4];
+        rx(low) q;
+        rx(high) q;
+        """)
+    module.unroll()
+    assert _rotation_args(module) == [1, 0]
+
+
+@pytest.mark.parametrize("int_type", ["int", "uint"])
+def test_int_bit_slice_assignment(int_type):
+    """``i[a:b] = <bit[k]>`` writes the bit vector into the integer, LSB first."""
+    module = loads(f"""
+        OPENQASM 3.0;
+        qubit q;
+        {int_type}[32] i = 15;
+        i[4:7] = "1010";
+        rx(i) q;
+        """)
+    module.unroll()
+    # 0b1010 written LSB-first into positions 4..7 sets bits 5 and 7: 15 + 32 + 128.
+    assert _rotation_args(module) == [0xAF]
+
+
+def test_int_bit_slice_assignment_wraps_to_signed():
+    """Writing the top bit of a signed ``int[n]`` re-reads as a negative value."""
+    module = loads("""
+        OPENQASM 3.0;
+        qubit q;
+        int[4] x = 0;
+        uint[4] y = 0;
+        x[3] = 1;
+        y[3] = 1;
+        rx(x) q;
+        rx(y) q;
+        """)
+    module.unroll()
+    assert _rotation_args(module) == [-8, 8]
+
+
+def test_int_bit_slice_array_element():
+    """``arr[i][k]`` and ``arr[i][a:b]`` address the bits of one array element."""
+    module = loads("""
+        OPENQASM 3.0;
+        qubit q;
+        array[int[32], 5] intArr = {0, 1, 2, 3, 4};
+        intArr[0][0] = 1;
+        bit[5] b = intArr[4][0:4];
+        int[8] v = b;
+        int[8] w = intArr[0];
+        rx(v) q;
+        rx(w) q;
+        """)
+    module.unroll()
+    assert _rotation_args(module) == [4, 1]
+
+
+def test_int_bit_slice_multi_dimensional_array_element():
+    """A trailing bit subscript is separated from the element subscripts, not flattened.
+
+    Regression guard for ``Invalid index for variable``: ``a[0][0][3]`` carries one
+    subscript more than the array has dimensions, and the extra one selects bits.
+    """
+    module = loads("""
+        OPENQASM 3.0;
+        qubit q;
+        array[int[8], 2, 3] a = {{1, 2, 3}, {4, 5, 6}};
+        a[0][0][3] = 1;
+        bit[3] s = a[1][1][0:2];
+        int[8] w = a[0][0];
+        int[8] u = s;
+        rx(w) q;
+        rx(u) q;
+        """)
+    module.unroll()
+    # a[0][0] == 1, setting bit 3 adds 8; a[1][1] == 5, whose low three bits are 0b101.
+    assert _rotation_args(module) == [9, 5]
+
+
+def test_int_bit_slice_reversed_range_requires_explicit_step(caplog):
+    """A descending range needs an explicit negative step.
+
+    The spec's ``myInt[-1:-16]`` is an empty index set under the normative range
+    definition (``a:b`` implies step 1, and no ``a + m`` reaches a smaller ``b``),
+    yet its example assigns it to a ``bit[16]``. pyqasm follows the normative rule
+    and rejects the ambiguous form; ``myInt[-1:-1:-16]`` gives the reversed slice.
+    """
+    with pytest.raises(ValidationError, match="Invalid initialization value"):
+        with caplog.at_level("ERROR"):
+            loads("""
+                OPENQASM 3.0;
+                int[32] myInt = 15;
+                bit[16] upperReversed = myInt[-1:-16];
+                """).validate()
+    assert "Error at line" in caplog.text
+
+    module = loads("""
+        OPENQASM 3.0;
+        qubit q;
+        int[8] myInt = 15;
+        bit[8] reversed_bits = myInt[-1:-1:-8];
+        int[16] v = reversed_bits;
+        rx(v) q;
+        """)
+    module.unroll()
+    # 0b00001111 read from bit 7 down to bit 0 is 0b11110000 == 240.
+    assert _rotation_args(module) == [240]
+
+
+def test_int_bit_slice_index_out_of_range_names_width(caplog):
+    """An index outside ``[0, n)`` after normalisation reports the declared width."""
+    with pytest.raises(ValidationError, match=r"Index 32 out of range for 'int\[32\]' variable"):
+        with caplog.at_level("ERROR"):
+            loads("OPENQASM 3.0; int[32] m = 15; m[32] = 1;").validate()
+    assert "Error at line" in caplog.text
+
+    with pytest.raises(ValidationError) as excinfo:
+        loads("OPENQASM 3.0; uint[8] m = 15; bit b = m[-9];").validate()
+    assert "Index -9 out of range for 'uint[8]' variable 'm'" in str(excinfo.value.__cause__)
+
+
+def test_int_bit_slice_assignment_width_mismatch():
+    """The right-hand side of a slice assignment must match the slice width."""
+    with pytest.raises(ValidationError, match="Cannot assign a 2-bit value to a 4-bit slice"):
+        loads('OPENQASM 3.0; int[32] m = 15; m[0:3] = "10";').validate()
+
+    with pytest.raises(ValidationError, match="Value 4 out of range for a 1-bit slice"):
+        loads("OPENQASM 3.0; int[32] m = 15; m[0] = 4;").validate()


### PR DESCRIPTION
Closes #395

## Problem

Indexing an `int[n]` / `uint[n]` at the bit level was unsupported. Reads failed with `Invalid initialization value for variable ...`, slice assignment failed with the misleading `Cannot cast 'str' to 'IntType'`, and `intArr[0][0]` failed with `Invalid index for variable`.

## Approach

- `Qasm3Analyzer.resolve_index` is extracted from `analyze_classical_indices`, so one subscript can be resolved against a bit width instead of an array dimension. `normalize_index` gains an optional `type_name`, so an out-of-range bit index reports the declared width: `Index 32 out of range for 'int[32]' variable 'myInt'`.
- `read_int_bits` / `write_int_bits` work in LSB-first integer space, since `myInt[0]` is the least-significant bit — the opposite of the `bit[n]` convention, where bit 0 is the most-significant bit of the stored value. Conversion happens at the boundary, and a slice read returns a width-carrying `BitValue`.
- A chained subscript is split into element indices plus one trailing bit subscript rather than flattened, so `intArr[0][0]` and `a[0][0][3]` resolve.
- `_visit_classical_assignment` detects a bit-slice lvalue up front and bypasses the scalar cast that produced the `str`-to-`IntType` error.
- Writing the top bit of a signed `int[n]` re-reads as negative (`int[4] x = 0; x[3] = 1;` gives `-8`). `uint[n]` stays unsigned.

## Reversed slice: `myInt[-1:-16]` is rejected

The spec is self-inconsistent here. Its normative range rule says `a:b` implies step 1 and the set is `{a, a+c, ...}` with `a+mc <= b`, so `31:16` is empty — and "a register cannot be indexed by an empty index set". Yet the same section's example assigns `myInt[-1:-16]` to a `bit[16]`.

pyqasm follows the normative rule and rejects the ambiguous form, which also keeps descending ranges consistent with every other slice in the codebase. `myInt[-1:-1:-16]` is well-defined by the same formula and gives the reversed slice. Both are covered by a test.

## Tested

`tests/qasm3/test_expressions.py`: the spec example end to end (`1, 0, 0, 3, 0xAF`), single-bit read, stepped slice read, slice assignment, signed wrap on a top-bit write, 1-D and 2-D array-element bit access, `uint` variants, both reversed-slice forms, out-of-range index naming the width, and RHS width mismatch. Also a regression guard for a descending `bit[n]` slice, which dropped its final position before this change.

`840 passed, 3 skipped`. `pylint` 10.00/10; `isort`, `black`, and `mypy` clean apart from the pre-existing `tabulate` stub error.

The `indexing_non_array` fixture moves from `int` to `float`: `int x; x[0] = 4;` is now a valid lvalue with an out-of-range value, so it no longer exercises that path.

## Out of scope

- The spec also allows bit slicing on `angle[n]`; not implemented here.
- `myInt[{0,2}]` (a `DiscreteSet` subscript) still raises `TypeError: 'DiscreteSet' object is not subscriptable`, unchanged from `main`.
- Pre-existing in #404: `qasm_variable_type_cast` keeps the RHS width when a `BitValue` initializes a `bit[n]`, so `bit[8] w = <16-bit slice>` is accepted silently. Left for a reviewer call on where that belongs.

Stacked on #404 (`feature-385-391-bit-repr-negative-indices`); rebases onto `main` once #404 merges.
