### PR TITLE
ci: keep the pre-release version in the sdist build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Types of changes:
 ### Dependencies
 
 ### Other
+- Fixed the pre-release workflow publishing its source distribution under the released version instead of the pre-release one. `build_sdist.sh` ran `git reset --hard` and `git clean -xdf`, which discarded the `pyproject.toml` version that the preceding step had just stamped, so a run that built `1.1.0a0` wheels built a `1.1.0` sdist and PyPI rejected it as a duplicate. `pre_build.sh` already resets the tree, so the second reset is gone. It also no longer destroys uncommitted work when the script is run locally. ([#413](https://github.com/qBraid/pyqasm/pull/413))
 - Added a `SECURITY.md` with a private vulnerability disclosure path. There was no documented way to report one, leaving a public issue or a guessed email address as the only options. Reports now go through this repository's GitHub security advisory form. ([#383](https://github.com/qBraid/pyqasm/pull/383))
 
 ## Past Release Notes

--- a/bin/build_sdist.sh
+++ b/bin/build_sdist.sh
@@ -23,10 +23,6 @@ set -x
 # current working directory
 TARGET_PATH="${1:-$(pwd)}"
 
-# Reset the uncommitted changes which may have been made
-git reset --hard HEAD
-git clean -xdf
-
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
 
 # Create a temporary dir, XXXXX will be replaced by a random string


### PR DESCRIPTION
The pre-release workflow published its wheels as `1.1.0a0` and its source
distribution as `1.1.0`. PyPI rejected the sdist, because `1.1.0` is the released
version and that filename is taken:

```
400 File already exists ('pyqasm-1.1.0.tar.gz', with blake2_256 hash 'ee5726da…')
```

Failing run: https://github.com/qBraid/pyqasm/actions/runs/32816030134/job/97705288550

The `Source distribution` job has two steps that fight each other. `Update
pre-release version` runs `pre_build.sh`, which writes the stamped version into
`pyproject.toml`:

```
Deploying pre-release version '1.1.0-a.0'
Setting version to 1.1.0-a.0
```

`Build source distribution` then runs `build_sdist.sh`, whose first commands were
`git reset --hard HEAD` and `git clean -xdf`. `pyproject.toml` carries a static
`version`, so the reset restored `1.1.0` and the sdist was built under it:

```
creating pyqasm-1.1.0
```

The wheels escape this because cibuildwheel runs `pre_build.sh` as
`CIBW_BEFORE_BUILD`, inside each wheel build, with nothing resetting the tree
afterwards.

`pre_build.sh` already begins with the same reset, so this removes the second one.
`release.yml` is unaffected: its sdist job builds straight from a fresh checkout.
The script also no longer destroys uncommitted work when a developer runs it
locally.

## Where the reset came from

6719abd (#142, 2025-02-20) added it to `pre_build.sh` and `build_sdist.sh`
together, as a blanket "every build script starts from a clean tree" rule. Back
then the version came from `setuptools_scm`, which derives it from git state and
appends a dirty marker when the tree has uncommitted changes. `pre_build.sh`
dirties the tree by design, since `toml set` edits a tracked file. That was the
version discrepancy the PR title names, and the same commit added the other two
halves of the fix: `version_scheme = "no-guess-dev"` and the `RELEASE_BUILD`
assertion in `test_sdist.sh` that `importlib.metadata.version` equals
`pyqasm.__version__`.

5de7acd (#145) removed `setuptools_scm` the next day and added
`bin/write_version_file.py`, which reads the version out of `pyproject.toml`.
The version no longer depends on git cleanliness, and `pyproject.toml` became the
one input the pre-release step must set. The reset outlived its reason and now
only undoes that step.

## Verified

Stamping `pyproject.toml` to `1.1.0a0` and running the patched script locally
produces `dist/pyqasm-1.1.0a0.tar.gz`. The same setup produced
`pyqasm-1.1.0.tar.gz` before the change.
