### PR TITLE
ci: fix pre-release versioning issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Types of changes:
 ### Dependencies
 
 ### Other
+- Fixed the pre-release build stamping a version that `pyqasm.__version__` and the package metadata spelled differently. `pre_build.sh` wrote `1.1.0-a.0` into `pyproject.toml`, setuptools normalized that to `1.1.0a0` for the metadata, and `_version.py` kept the raw string, so `pip show pyqasm` and `pyqasm.__version__` disagreed and `test_sdist.sh` failed its version check. The stamped version is now normalized to PEP 440 before it is written. ([#414](https://github.com/qBraid/pyqasm/pull/414))
 - Fixed the pre-release workflow publishing its source distribution under the released version instead of the pre-release one. `build_sdist.sh` ran `git reset --hard` and `git clean -xdf`, which discarded the `pyproject.toml` version that the preceding step had just stamped, so a run that built `1.1.0a0` wheels built a `1.1.0` sdist and PyPI rejected it as a duplicate. `pre_build.sh` already resets the tree, so the second reset is gone. It also no longer destroys uncommitted work when the script is run locally. ([#413](https://github.com/qBraid/pyqasm/pull/413))
 - Added a `SECURITY.md` with a private vulnerability disclosure path. There was no documented way to report one, leaving a public issue or a guessed email address as the only options. Reports now go through this repository's GitHub security advisory form. ([#383](https://github.com/qBraid/pyqasm/pull/383))
 

--- a/bin/cibw/pre_build.sh
+++ b/bin/cibw/pre_build.sh
@@ -66,7 +66,10 @@ if [[ ${PRE_RELEASE_BUILD:-false} == "true" ]]; then
 
     # Get the path to .toml file
     PYPROJECT_TOML_PATH="${project}/pyproject.toml"
-    DEV_VERSION="${PRE_RELEASE_VERSION}"
+
+    # Normalize to PEP 440, so that pyproject.toml, _version.py and the package
+    # metadata all spell the version the same way, eg 1.1.0-a.0 -> 1.1.0a0
+    DEV_VERSION=$(python -c "from packaging.version import Version; print(Version('${PRE_RELEASE_VERSION}'))")
 
     # Update the version in the .toml file
     echo "Setting version to ${DEV_VERSION}"


### PR DESCRIPTION
The pre-release run failed its source distribution test:

```
+ IMPORTLIB_VERSION=1.1.0a0
+ VERSION_ATTRIBUTE=1.1.0-a.0
+ [[ 1.1.0a0 != 1.1.0-a.0 ]]
Versions do not match
```

Failing run: https://github.com/qBraid/pyqasm/actions/runs/32819763552/job/97715243458

One version, two spellings. `pre_build.sh` stamped qbraid-core's `1.1.0-a.0` into
`pyproject.toml`. setuptools normalized that to `1.1.0a0` for the package
metadata, while `write_version_file.py` copied the raw string into `_version.py`.
So `importlib.metadata.version` and `pyqasm.__version__` disagreed, and the
`RELEASE_BUILD` check in `test_sdist.sh` compares them as plain strings.

The check was right to fail. On every pre-release, `pip show pyqasm` reported
`1.1.0a0` while `pyqasm.__version__` reported `1.1.0-a.0`. #413 is what exposed
it: before that, the reset in `build_sdist.sh` discarded the stamp, so both sides
read the plain release version and the check never saw a pre-release.

This normalizes the stamped version to PEP 440 before writing it, so
`pyproject.toml`, `_version.py` and the package metadata all agree.
`packaging` is available at that point, because `pre_build.sh` installs
`qbraid-core` in the same block and `qbraid-core` requires it.

## Verified locally

Ran the full sequence in a throwaway clone with its own venv:

```
pre_build.sh (PRE_RELEASE_BUILD=true)
  Deploying pre-release version '1.1.0-a.0'
  Setting version to 1.1.0a0
  pyproject.toml:  version = "1.1.0a0"
  _version.py:     __version__ = version = '1.1.0a0'

build_sdist.sh
  dist/pyqasm-1.1.0a0.tar.gz

test_sdist.sh (RELEASE_BUILD=true)
  Importlib version: 1.1.0a0
  Version attribute: 1.1.0a0
  802 passed, 3 skipped
```

## Not addressed here

- `__version_tuple__` is still approximate: `parse_version_tuple("1.1.0a0")`
  yields `(1, 1, '0a0')`. That is better than the `(1, 1, '0-a', '0')` it produced
  before, but it is not a real PEP 440 parse.
- The version collision is separate. `[project] version` is still `1.1.0`, so the
  stamper keeps returning `1.1.0a0`, and those wheels are already on PyPI. The
  publish step will keep failing with `400 File already exists` until the base
  version moves to the next unreleased one, spelled with an `-alpha` suffix so
  that repeat pre-releases bump to a1, a2 and so on.
