### PR TITLE
Annotate raise_qasm3_error as NoReturn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,14 @@ Types of changes:
 ### Added
 
 ### Improved / Modified
+- `raise_qasm3_error` is now annotated `NoReturn`. Every path through it raises, but the `None` return type made each caller look like it could fall through, so eight `# type: ignore[return]` comments and `inconsistent-return-statements` suppressions existed only to silence that. They are gone, and `mypy` and `pylint` now check those functions instead of skipping them.
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+- Fixed a `switch` whose target matches no case and which declares no `default` crashing with `TypeError: 'NoneType' object is not iterable`. The spec does not require a `default`, so such a switch is valid and now contributes no statements. `_visit_switch_statement` fell off its last branch and returned `None`, which a `# type: ignore[return]` had been hiding.
 - Fixed `pyqasm validate` wrapping its diagnostics at the console width, which split a file path longer than the width across lines mid-token and left it neither copyable nor clickable. The error console now uses `soft_wrap`, keeping one diagnostic per line.
 - Fixed an indirect cycle between gate definitions exhausting the Python stack: `gate a q { b q; }` with `gate b q { a q; }` raised a bare `RecursionError` naming nothing, while the direct case was already reported cleanly. The guard compared the body's gate name against one name, so it saw only a cycle of length one. It now tests membership of the whole expansion chain, and names the path: `Recursive definitions not allowed for gate 'a' (a -> b -> a)`. A gate reached twice down separate paths is a diamond, not a cycle, and still expands. ([#369](https://github.com/qBraid/pyqasm/issues/369))
 - Fixed a nested external custom gate counting the depth of the decomposition it skipped, the shape the [#352](https://github.com/qBraid/pyqasm/issues/352) fix did not reach: `unroll(external_gates=["outer"])` on a gate whose body calls another custom gate emitted one statement but reported `depth() == 13`. The suppression flag was assigned and cleared without save-restore, so the inner gate clobbered the outer gate's state in both directions. It is now saved and restored, and the depth is recorded once, from the outermost external gate. ([#367](https://github.com/qBraid/pyqasm/issues/367))

--- a/src/pyqasm/analyzer.py
+++ b/src/pyqasm/analyzer.py
@@ -223,8 +223,8 @@ class Qasm3Analyzer:
             )
         return bit_list
 
-    @staticmethod  # pylint: disable-next=inconsistent-return-statements
-    def extract_qasm_version(qasm: str) -> float:  # type: ignore[return]
+    @staticmethod
+    def extract_qasm_version(qasm: str) -> float:
         """
         Extracts the OpenQASM version from a given OpenQASM string.
 

--- a/src/pyqasm/exceptions.py
+++ b/src/pyqasm/exceptions.py
@@ -19,7 +19,7 @@ Module defining base PyQASM exceptions.
 
 import os
 import sys
-from typing import Optional, Type
+from typing import NoReturn, Optional, Type
 
 from openqasm3.ast import QASMNode, Span
 from openqasm3.parser import QASM3ParsingError
@@ -89,7 +89,7 @@ def raise_qasm3_error(
     error_node: Optional[QASMNode] = None,
     span: Optional[Span] = None,
     raised_from: Optional[Exception] = None,
-) -> None:
+) -> NoReturn:
     """Raises a QASM3 conversion error with optional chaining from another exception.
 
     Args:

--- a/src/pyqasm/expressions.py
+++ b/src/pyqasm/expressions.py
@@ -195,7 +195,7 @@ class Qasm3ExprEvaluator:
 
     @classmethod
     # pylint: disable-next=too-many-return-statements,too-many-branches,too-many-statements,too-many-locals,too-many-arguments
-    def evaluate_expression(  # type: ignore[return]
+    def evaluate_expression(
         cls,
         expression,
         const_expr: bool = False,

--- a/src/pyqasm/maps/expressions.py
+++ b/src/pyqasm/maps/expressions.py
@@ -87,7 +87,7 @@ def qasm3_expression_op_map(op_name: str, *args) -> float | int | bool:
         raise ValidationError(f"Unsupported / undeclared QASM operator: {op_name}") from exc
 
 
-# pylint: disable=inconsistent-return-statements,too-many-return-statements
+# pylint: disable=too-many-return-statements
 def qasm_variable_type_cast(openqasm_type, var_name, base_size, rhs_value):
     """Cast the variable type to the type to match, if possible.
 
@@ -133,6 +133,9 @@ def qasm_variable_type_cast(openqasm_type, var_name, base_size, rhs_value):
         if isinstance(rhs_value, float):
             return complex(rhs_value)
         return rhs_value
+    raise ValidationError(
+        f"Unsupported cast to type '{openqasm_type.__name__}' for variable '{var_name}'"
+    )
 
 
 # IEEE 754 Standard for floats

--- a/src/pyqasm/maps/gates.py
+++ b/src/pyqasm/maps/gates.py
@@ -1166,8 +1166,7 @@ def map_qasm_op_num_params(op_name: str) -> int:
     return 0
 
 
-# pylint: disable-next=inconsistent-return-statements
-def map_qasm_op_to_callable(op_node: QuantumGate) -> tuple[Callable, int]:  # type: ignore[return]
+def map_qasm_op_to_callable(op_node: QuantumGate) -> tuple[Callable, int]:
     """
     Map a QASM operation to a callable.
 

--- a/src/pyqasm/validator.py
+++ b/src/pyqasm/validator.py
@@ -290,7 +290,7 @@ class Qasm3Validator:
             )
 
     @staticmethod
-    def validate_return_statement(  # pylint: disable=inconsistent-return-statements
+    def validate_return_statement(
         subroutine_def: SubroutineDefinition,
         return_statement: ReturnStatement,
         return_value: Any,
@@ -317,27 +317,30 @@ class Qasm3Validator:
                     error_node=return_statement,
                     span=return_statement.span,
                 )
-        else:
-            if return_value is None:
-                raise_qasm3_error(
-                    f"Return type mismatch for subroutine '{subroutine_def.name.name}'."
-                    f" Expected {type(subroutine_def.return_type)} but got void",
-                    error_node=return_statement,
-                    span=return_statement.span,
-                )
-            base_size = 1
-            if hasattr(subroutine_def.return_type, "size"):
-                base_size = subroutine_def.return_type.size.value
+            # A void subroutine carries no value back to its caller.
+            return None
 
-            return Qasm3Validator.validate_variable_assignment_value(
-                Variable(
-                    subroutine_def.name.name + "_return",
-                    subroutine_def.return_type,
-                    base_size,
-                    None,
-                    None,
-                    span=return_statement.span,
-                ),
-                return_value,
-                op_node=return_statement,
+        if return_value is None:
+            raise_qasm3_error(
+                f"Return type mismatch for subroutine '{subroutine_def.name.name}'."
+                f" Expected {type(subroutine_def.return_type)} but got void",
+                error_node=return_statement,
+                span=return_statement.span,
             )
+
+        base_size = 1
+        if hasattr(subroutine_def.return_type, "size"):
+            base_size = subroutine_def.return_type.size.value
+
+        return Qasm3Validator.validate_variable_assignment_value(
+            Variable(
+                subroutine_def.name.name + "_return",
+                subroutine_def.return_type,
+                base_size,
+                None,
+                None,
+                span=return_statement.span,
+            ),
+            return_value,
+            op_node=return_statement,
+        )

--- a/src/pyqasm/visitor.py
+++ b/src/pyqasm/visitor.py
@@ -2892,7 +2892,7 @@ class QasmVisitor:
 
         return []
 
-    def _visit_switch_statement(  # type: ignore[return]
+    def _visit_switch_statement(
         self, statement: qasm3_ast.SwitchStatement
     ) -> list[qasm3_ast.Statement]:
         """Visit a switch statement element.
@@ -2979,9 +2979,10 @@ class QasmVisitor:
                 case_stmts = case[1].statements
                 return _evaluate_case(case_stmts)
 
-        if not case_fulfilled and statement.default:
-            default_stmts = statement.default.statements
-            return _evaluate_case(default_stmts)
+        # Reaching here means no case matched: the loop returns as soon as one does.
+        if statement.default:
+            return _evaluate_case(statement.default.statements)
+        return []
 
     def _resolve_duration_unit(self, time_var: qasm3_ast.Expression) -> qasm3_ast.TimeUnit:
         """Determine the output unit for a duration literal.

--- a/tests/qasm3/test_switch.py
+++ b/tests/qasm3/test_switch.py
@@ -149,6 +149,39 @@ def test_switch_const_int():
     check_single_qubit_gate_op(result.unrolled_ast, 1, [0], "x")
 
 
+def test_switch_no_match_without_default():
+    """Test a switch whose target matches no case and which has no default block.
+
+    The spec does not require a default, so this is valid and must simply contribute
+    no statements. It previously raised ``TypeError: 'NoneType' object is not iterable``.
+    """
+
+    qasm3_switch_program = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+
+    int i = 5;
+    qubit q;
+
+    switch(i) {
+    case 1 {
+        x q;
+    }
+    case 2 {
+        z q;
+    }
+    }
+    h q;
+    """
+
+    result = loads(qasm3_switch_program)
+    result.unroll()
+
+    assert result.num_qubits == 1
+    # Only the gate after the switch survives; neither case body is emitted.
+    check_single_qubit_gate_op(result.unrolled_ast, 1, [0], "h")
+
+
 def test_switch_duplicate_cases():
     """Test that switch raises error if duplicate values are present in case."""
 


### PR DESCRIPTION
## Problem

`raise_qasm3_error` always raises — every path through it ends in a `raise`. But it was annotated `-> None`, so to `mypy` and `pylint` every caller looked like it could fall through and return nothing. Eight suppressions existed only to silence that:

- `# type: ignore[return]` on `evaluate_expression`, `_visit_switch_statement`, `extract_qasm_version`, `map_qasm_op_to_callable`
- `inconsistent-return-statements` disables in `validator.py`, `analyzer.py`, `maps/gates.py`, `maps/expressions.py`

Blanket suppressions do not distinguish a function that provably raises from one that genuinely falls through, so real gaps were sitting behind them.

## Change

`raise_qasm3_error` is annotated `NoReturn`, and all eight suppressions are removed. `mypy` and `pylint` then found the three functions the annotation does not cover.

**A valid `switch` crashed.** `_visit_switch_statement` fell off its last branch when no case matched and no `default` was declared, returning `None` into `result.extend(...)`:

```qasm
int i = 5;
switch (i) {
  case 1 { x q; }
  case 2 { z q; }
}
// TypeError: 'NoneType' object is not iterable
```

The spec does not require a `default`, so this is valid and must simply contribute no statements. The redundant `not case_fulfilled` guard is gone too — the loop returns as soon as a case matches, so reaching that line already means none did.

**`qasm_variable_type_cast` fell off its branch chain** rather than reporting an unsupported target type. It now raises a `ValidationError` naming the type and variable.

**`validate_return_statement` fell off its void branch implicitly.** It now returns `None` explicitly, which also lets the `else` arm flatten out one level of nesting.

## Tests

`test_switch_no_match_without_default` covers the crash. 803 passed, 3 skipped.

Verified against CI's exact linters (`pylint==4.0.7`, `astroid==4.0.4`): pylint exits 0 with no messages, isort and black exit 0, mypy reports only the pre-existing `tabulate` stub error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an error that could occur when a `switch` statement matched no case and had no default branch.
  - Improved diagnostic wrapping for narrow console displays.
  - Fixed validation of indirect gate-definition cycles.
  - Corrected depth counting for nested external custom gates.

- **Quality Improvements**
  - Strengthened validation and error handling for clearer, more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->